### PR TITLE
feat!(pages): add new collection config creation approach using only types instead of functions

### DIFF
--- a/pages/CHANGELOG.md
+++ b/pages/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.6.0 (Unreleased)
+
+- feat!: add new collection config creation approach using `PageCollectionConfig` and `RedirectsCollectionConfig` types instead of `createPageCollectionConfig` and `createRedirectsCollectionConfig` functions.
+
+### Migration Guide
+
+**Old approach:**
+```ts
+import { createPageCollectionConfig, createRedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'
+
+const Pages: CollectionConfig = createPageCollectionConfig({
+  slug: 'pages',
+  page: { /* config */ },
+  fields: [/* fields */],
+})
+
+const Redirects = createRedirectsCollectionConfig({})
+```
+
+**New approach:**
+```ts
+import { PageCollectionConfig, RedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'
+
+const Pages: PageCollectionConfig = {
+  slug: 'pages',
+  page: { /* config */ },
+  fields: [/* fields */],
+}
+
+const Redirects: RedirectsCollectionConfig = {
+  slug: 'redirects',
+  redirects: {},
+  fields: [],
+}
+```
+
 ## 0.5.1
 
 - fix: ensure compatibility with sqlite db adapter (4a2efdc)

--- a/pages/README.md
+++ b/pages/README.md
@@ -6,59 +6,85 @@ The Payload Pages plugin simplifies website building by adding essential fields 
 
 ## Setup
 
-Add the plugin to your payload config as follows:
+First, add the plugin to your payload config as follows:
 
 ```ts
 plugins: [payloadPagesPlugin({})]
 ```
 
-Use the `createPagesCollectionConfig` function to create a collection config for the Pages collection. This adds all necessary fields and hooks to the collection. The `page` field must be specified as follows:
+Next, create a page collections using the `PageCollectionConfig` type. This type extends Payload's `CollectionConfig` type with a `page` field that contains configurations for the page collection. The `page` field must be specified as follows:
 
-- `parentCollection`: The slug of the collection that will be used as the parent of the current collection.
-- `parentField`: The name of the field on the parent collection that will be used to relate to the current collection.
+- `parent.collection`: The slug of the collection that will be used as the parent of the current collection.
+- `parent.name`: The name of the field on the parent collection that will be used to relate to the current collection.
 - `isRootCollection`: Whether the collection is the root collection (collection which contains the root page). If true, the parent field is optional. Defaults to `false`.
-- `sharedParentDocument` (optional, defaults to `false`): If true, the parent document will be shared between all documents in the collection.
-- `breadcrumbLabelField` (optional, defaults to `admin.useAsTitle`): The name of the field that will be used to label the document in the breadcrumb.
-- `slugFallbackField` (optional, defaults to `title`): The name of the field that will be used as the fallback for the slug.
+- `parent.sharedDocument` (optional, defaults to `false`): If true, the parent document will be shared between all documents in the collection.
+- `breadcrumbs.labelField` (optional, defaults to `admin.useAsTitle`): The name of the field that will be used to label the document in the breadcrumb.
+- `slug.fallbackField` (optional, defaults to `title`): The name of the field that will be used as the fallback for the slug.
 
-First, the root collection must be created. This is the collection that will contain the root page.
+Here is an example of the page collection config of the root collection:
 
 ```ts
-import { createPagesCollectionConfig } from '@jhb.software/payload-pages-plugin'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-const Pages: CollectionConfig = createPageCollectionConfig({
+const Pages: PageCollectionConfig = {
   slug: 'pages',
+  admin: {
+    useAsTitle: 'title',
+  },
   page: {
-    parentCollection: 'pages',
-    parentField: 'parent',
+    parent: {
+      collection: 'pages',
+      name: 'parent',
+    },
     isRootCollection: true,
   },
-  // configure the rest as normal
-})
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    // other fields
+  ],
+}
 ```
 
 Then additional collections can be created. Documents in these collections will be nested under documents in the root collection.
 
 ```ts
-import { createPagesCollectionConfig } from '@jhb.software/payload-pages-plugin'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-const Projects: CollectionConfig = createPageCollectionConfig({
-  slug: 'projects',
+const Posts: PageCollectionConfig = {
+  slug: 'posts',
   page: {
-    parentCollection: 'pages',
-    parentField: 'parent',
-    sharedParentDocument: true,
+    parent: {
+      collection: 'pages',
+      name: 'parent',
+      sharedDocument: true,
+    },
   },
-  // configure the rest as normal
-})
+  fields: [
+    // your fields
+  ],
+}
 ```
 
-Additionally create the redirect collection:
+The plugin also includes a `RedirectsCollectionConfig` type that can be used to create a redirects collection. This type extends Payload's `CollectionConfig` type with a `redirects` field that contains configurations for the redirects collection.
 
 ```ts
-import { createRedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'
+import { RedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-const redirectsCollection = createRedirectsCollectionConfig({})
+const Redirects: RedirectsCollectionConfig = {
+  slug: 'redirects',
+  admin: {
+    defaultColumns: ['sourcePath', 'destinationPath', 'permanent', 'createdAt'],
+    listSearchableFields: ['sourcePath', 'destinationPath'],
+  },
+  redirects: {},
+  fields: [
+    // the fields are added by the plugin automatically
+  ],
+}
 ```
 
 In order for the official payload SEO plugin to use the generated URL, you need to pass the `getPageUrl` function provided by this plugin to the `generateURL` field in the `seo` plugin config inside your payload config. 

--- a/pages/dev/src/collections/authors.ts
+++ b/pages/dev/src/collections/authors.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Authors: CollectionConfig = createPageCollectionConfig({
+export const Authors: PageCollectionConfig = {
   slug: 'authors',
   admin: {
     useAsTitle: 'name',
@@ -30,4 +29,4 @@ export const Authors: CollectionConfig = createPageCollectionConfig({
       localized: true,
     },
   ],
-})
+}

--- a/pages/dev/src/collections/blogposts.ts
+++ b/pages/dev/src/collections/blogposts.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Blogposts: CollectionConfig = createPageCollectionConfig({
+export const Blogposts: PageCollectionConfig = {
   slug: 'blogposts',
   admin: {
     useAsTitle: 'title',
@@ -36,4 +35,4 @@ export const Blogposts: CollectionConfig = createPageCollectionConfig({
       localized: true,
     },
   ],
-})
+}

--- a/pages/dev/src/collections/countries.ts
+++ b/pages/dev/src/collections/countries.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Countries: CollectionConfig = createPageCollectionConfig({
+export const Countries: PageCollectionConfig = {
   slug: 'countries',
   admin: {
     useAsTitle: 'title',
@@ -30,4 +29,4 @@ export const Countries: CollectionConfig = createPageCollectionConfig({
       localized: true,
     },
   ],
-})
+}

--- a/pages/dev/src/collections/country-travel-tips.ts
+++ b/pages/dev/src/collections/country-travel-tips.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const CountryTravelTips: CollectionConfig = createPageCollectionConfig({
+export const CountryTravelTips: PageCollectionConfig = {
   slug: 'country-travel-tips',
   admin: {
     useAsTitle: 'title',
@@ -38,4 +37,4 @@ export const CountryTravelTips: CollectionConfig = createPageCollectionConfig({
       localized: true,
     },
   ],
-})
+}

--- a/pages/dev/src/collections/pages.ts
+++ b/pages/dev/src/collections/pages.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Pages: CollectionConfig = createPageCollectionConfig({
+export const Pages: PageCollectionConfig = {
   slug: 'pages',
   admin: {
     useAsTitle: 'title',
@@ -32,4 +31,4 @@ export const Pages: CollectionConfig = createPageCollectionConfig({
       localized: true,
     },
   ],
-})
+}

--- a/pages/dev/src/collections/redirects.ts
+++ b/pages/dev/src/collections/redirects.ts
@@ -1,3 +1,13 @@
-import { createRedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'
+import { RedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Redirects = createRedirectsCollectionConfig({})
+export const Redirects: RedirectsCollectionConfig = {
+  slug: 'redirects',
+  admin: {
+    defaultColumns: ['sourcePath', 'destinationPath', 'permanent', 'createdAt'],
+    listSearchableFields: ['sourcePath', 'destinationPath'],
+  },
+  redirects: {},
+  fields: [
+    // the fields are added by the plugin automatically
+  ],
+}

--- a/pages/dev_unlocalized/src/collections/authors.ts
+++ b/pages/dev_unlocalized/src/collections/authors.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Authors: CollectionConfig = createPageCollectionConfig({
+export const Authors: PageCollectionConfig = {
   slug: 'authors',
   admin: {
     useAsTitle: 'name',
@@ -28,4 +27,4 @@ export const Authors: CollectionConfig = createPageCollectionConfig({
       required: true,
     },
   ],
-})
+}

--- a/pages/dev_unlocalized/src/collections/blogposts.ts
+++ b/pages/dev_unlocalized/src/collections/blogposts.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Blogposts: CollectionConfig = createPageCollectionConfig({
+export const Blogposts: PageCollectionConfig = {
   slug: 'blogposts',
   admin: {
     useAsTitle: 'title',
@@ -33,4 +32,4 @@ export const Blogposts: CollectionConfig = createPageCollectionConfig({
       required: true,
     },
   ],
-})
+}

--- a/pages/dev_unlocalized/src/collections/countries.ts
+++ b/pages/dev_unlocalized/src/collections/countries.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Countries: CollectionConfig = createPageCollectionConfig({
+export const Countries: PageCollectionConfig = {
   slug: 'countries',
   admin: {
     useAsTitle: 'title',
@@ -28,4 +27,4 @@ export const Countries: CollectionConfig = createPageCollectionConfig({
       required: true,
     },
   ],
-})
+}

--- a/pages/dev_unlocalized/src/collections/country-travel-tips.ts
+++ b/pages/dev_unlocalized/src/collections/country-travel-tips.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const CountryTravelTips: CollectionConfig = createPageCollectionConfig({
+export const CountryTravelTips: PageCollectionConfig = {
   slug: 'country-travel-tips',
   admin: {
     useAsTitle: 'title',
@@ -33,4 +32,4 @@ export const CountryTravelTips: CollectionConfig = createPageCollectionConfig({
       required: true,
     },
   ],
-})
+}

--- a/pages/dev_unlocalized/src/collections/pages.ts
+++ b/pages/dev_unlocalized/src/collections/pages.ts
@@ -1,7 +1,6 @@
-import { createPageCollectionConfig } from '@jhb.software/payload-pages-plugin'
-import { CollectionConfig } from 'payload'
+import { PageCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Pages: CollectionConfig = createPageCollectionConfig({
+export const Pages: PageCollectionConfig = {
   slug: 'pages',
   admin: {
     useAsTitle: 'title',
@@ -28,4 +27,4 @@ export const Pages: CollectionConfig = createPageCollectionConfig({
       required: true,
     },
   ],
-})
+}

--- a/pages/dev_unlocalized/src/collections/redirects.ts
+++ b/pages/dev_unlocalized/src/collections/redirects.ts
@@ -1,3 +1,13 @@
-import { createRedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'
+import { RedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'
 
-export const Redirects = createRedirectsCollectionConfig({})
+export const Redirects: RedirectsCollectionConfig = {
+  slug: 'redirects',
+  admin: {
+    defaultColumns: ['sourcePath', 'destinationPath', 'permanent', 'createdAt'],
+    listSearchableFields: ['sourcePath', 'destinationPath'],
+  },
+  redirects: {},
+  fields: [
+    // the fields are added by the plugin automatically
+  ],
+}

--- a/pages/src/collections/RedirectsCollectionConfig.ts
+++ b/pages/src/collections/RedirectsCollectionConfig.ts
@@ -1,5 +1,10 @@
 import { CollectionConfig } from 'payload'
 import { validateRedirect } from '../hooks/validateRedirect.js'
+import { PagesPluginConfig } from 'src/types/PagesPluginConfig.js'
+import {
+  IncomingRedirectsCollectionConfig,
+  RedirectsCollectionConfig,
+} from 'src/types/RedirectsCollectionConfig.js'
 
 // TODO: Consider the potential benefits of storing the destination page in a relationship field.
 //       Note: The destination path should still be explicitly defined to ensure the redirect path remains consistent,
@@ -10,109 +15,101 @@ import { validateRedirect } from '../hooks/validateRedirect.js'
  * In contrast to the official redirects plugin, this collection supports validation rules and a reason field.
  */
 export const createRedirectsCollectionConfig = ({
-  labels,
-  versions,
-  access,
-  overrides = {
-    admin: {},
-  },
+  collectionConfig: incomingCollectionConfig,
+  pluginConfig,
 }: {
-  labels?: CollectionConfig['labels']
-  versions?: CollectionConfig['versions']
-  access?: CollectionConfig['access']
-  overrides?: {
-    admin?: CollectionConfig['admin']
+  collectionConfig: IncomingRedirectsCollectionConfig
+  pluginConfig: PagesPluginConfig
+}): CollectionConfig => {
+  const redirectsCollectionConfig: RedirectsCollectionConfig = {
+    ...incomingCollectionConfig,
   }
-}): CollectionConfig => ({
-  slug: 'redirects',
-  versions: versions ?? undefined, // fallback to undefined (e.g. when an empty object is passed) to use the default versions settings
-  admin: {
-    defaultColumns: ['sourcePath', 'destinationPath', 'permanent', 'createdAt'],
-    listSearchableFields: ['sourcePath', 'destinationPath'],
-    ...overrides.admin,
-  },
-  labels: labels ?? undefined, // fallback to undefined (e.g. when an empty object is passed) to use the default labels
-  access: access ?? {},
-  hooks: {
-    beforeValidate: [validateRedirect],
-  },
-  fields: [
-    {
-      name: 'sourcePath',
-      type: 'text',
-      required: true,
-      admin: {
-        placeholder: '/',
-      },
-      // @ts-ignore
-      validate: (value, { siblingData }) => {
-        const destinationPath = siblingData.destinationPath
 
-        if (!value) {
-          return 'A source path is required'
-        } else if (destinationPath === value) {
-          return 'The provided path must be different from the destination path'
-        } else if (value && !value.startsWith('/')) {
-          return 'A path must start with a forward slash (/)'
-        }
+  return {
+    ...incomingCollectionConfig,
+    hooks: {
+      ...incomingCollectionConfig.hooks,
+      beforeValidate: [...(incomingCollectionConfig.hooks?.beforeValidate || []), validateRedirect],
+    },
+    fields: [
+      {
+        name: 'sourcePath',
+        type: 'text',
+        required: true,
+        admin: {
+          placeholder: '/',
+        },
+        // @ts-ignore
+        validate: (value, { siblingData }) => {
+          const destinationPath = siblingData.destinationPath
 
-        return true
+          if (!value) {
+            return 'A source path is required'
+          } else if (destinationPath === value) {
+            return 'The provided path must be different from the destination path'
+          } else if (value && !value.startsWith('/')) {
+            return 'A path must start with a forward slash (/)'
+          }
+
+          return true
+        },
+        hooks: {
+          beforeDuplicate: [
+            // append "-copy" to the value to ensure that the validation succeeds when duplicating a redirect
+            ({ value }) => value + '-copy',
+          ],
+        },
       },
-      hooks: {
-        beforeDuplicate: [
-          // append "-copy" to the value to ensure that the validation succeeds when duplicating a redirect
-          ({ value }) => value + '-copy',
+      {
+        name: 'destinationPath',
+        type: 'text',
+        required: true,
+        admin: {
+          placeholder: '/',
+        },
+        // @ts-ignore
+        validate: (value: string, { siblingData }) => {
+          const sourcePath = siblingData.sourcePath
+
+          if (!value) {
+            return 'A destination path is required'
+          } else if (sourcePath === value) {
+            return 'The provided path must be different from the source path'
+          } else if (value && !value.startsWith('/')) {
+            return 'A path must start with a forward slash (/)'
+          }
+
+          return true
+        },
+        hooks: {
+          beforeDuplicate: [
+            // append "-copy" to the value to ensure that the validation succeeds when duplicating a redirect
+            ({ value }) => value + '-copy',
+          ],
+        },
+      },
+      {
+        name: 'type',
+        type: 'select',
+        required: true,
+        defaultValue: 'permanent',
+        options: [
+          {
+            label: 'Permanent',
+            value: 'permanent',
+          },
+          {
+            label: 'Temporary',
+            value: 'temporary',
+          },
         ],
       },
-    },
-    {
-      name: 'destinationPath',
-      type: 'text',
-      required: true,
-      admin: {
-        placeholder: '/',
+      {
+        name: 'reason',
+        type: 'textarea',
+        required: false,
       },
-      // @ts-ignore
-      validate: (value: string, { siblingData }) => {
-        const sourcePath = siblingData.sourcePath
-
-        if (!value) {
-          return 'A destination path is required'
-        } else if (sourcePath === value) {
-          return 'The provided path must be different from the source path'
-        } else if (value && !value.startsWith('/')) {
-          return 'A path must start with a forward slash (/)'
-        }
-
-        return true
-      },
-      hooks: {
-        beforeDuplicate: [
-          // append "-copy" to the value to ensure that the validation succeeds when duplicating a redirect
-          ({ value }) => value + '-copy',
-        ],
-      },
-    },
-    {
-      name: 'type',
-      type: 'select',
-      required: true,
-      defaultValue: 'permanent',
-      options: [
-        {
-          label: 'Permanent',
-          value: 'permanent',
-        },
-        {
-          label: 'Temporary',
-          value: 'temporary',
-        },
-      ],
-    },
-    {
-      name: 'reason',
-      type: 'textarea',
-      required: false,
-    },
-  ],
-})
+      ...incomingCollectionConfig.fields,
+    ],
+  }
+}

--- a/pages/src/index.ts
+++ b/pages/src/index.ts
@@ -1,15 +1,15 @@
-export { createPageCollectionConfig } from './collections/PageCollectionConfig.js'
-export { createRedirectsCollectionConfig } from './collections/RedirectsCollectionConfig.js'
 export { alternatePathsField } from './fields/alternatePathsField.js'
 export { slugField } from './fields/slugField.js'
 export { payloadPagesPlugin } from './plugin.js'
-export type {
-  IncomingPageCollectionConfig,
-  PageCollectionConfig,
-} from './types/PageCollectionConfig.js'
+export type { IncomingPageCollectionConfig as PageCollectionConfig } from './types/PageCollectionConfig.js'
+export type { IncomingRedirectsCollectionConfig as RedirectsCollectionConfig } from './types/RedirectsCollectionConfig.js'
 export type {
   PageCollectionConfigAttributes,
   IncomingPageCollectionConfigAttributes as PageCollectionIncomingConfigAttributes,
 } from './types/PageCollectionConfigAttributes.js'
+export type {
+  RedirectsCollectionConfigAttributes,
+  IncomingRedirectsCollectionConfigAttributes as RedirectsCollectionIncomingConfigAttributes,
+} from './types/RedirectsCollectionConfigAttributes.js'
 export type { PagesPluginConfig } from './types/PagesPluginConfig.js'
 export { getPageUrl } from './utils/getPageUrl.js'

--- a/pages/src/plugin.ts
+++ b/pages/src/plugin.ts
@@ -1,8 +1,11 @@
 import type { Config } from 'payload'
-
 import type { PagesPluginConfig } from './types/PagesPluginConfig.js'
 import { translations } from './translations/index.js'
 import { deepMergeSimple } from './utils/deepMergeSimple.js'
+import { createPageCollectionConfig } from './collections/PageCollectionConfig.js'
+import { IncomingPageCollectionConfig } from './types/PageCollectionConfig.js'
+import { createRedirectsCollectionConfig } from './collections/RedirectsCollectionConfig.js'
+import { IncomingRedirectsCollectionConfig } from './types/RedirectsCollectionConfig.js'
 
 /** Payload plugin which integrates fields for managing website pages. */
 export const payloadPagesPlugin =
@@ -31,6 +34,27 @@ export const payloadPagesPlugin =
         )
       }
     }
+
+    // Ensure collections array exists
+    config.collections = config.collections || []
+
+    // Find and transform collections
+    config.collections = config.collections.map((collection) => {
+      if ('page' in collection) {
+        // Create page collection using the page configuration
+        return createPageCollectionConfig({
+          collectionConfig: collection as IncomingPageCollectionConfig,
+          pluginConfig: pluginOptions,
+        })
+      } else if ('redirects' in collection) {
+        // Create redirects collection using the redirects configuration
+        return createRedirectsCollectionConfig({
+          collectionConfig: collection as IncomingRedirectsCollectionConfig,
+          pluginConfig: pluginOptions,
+        })
+      }
+      return collection
+    })
 
     return {
       ...config,

--- a/pages/src/types/RedirectsCollectionConfig.ts
+++ b/pages/src/types/RedirectsCollectionConfig.ts
@@ -1,0 +1,15 @@
+import { CollectionConfig } from 'payload'
+import {
+  IncomingRedirectsCollectionConfigAttributes,
+  RedirectsCollectionConfigAttributes,
+} from './RedirectsCollectionConfigAttributes.js'
+
+/** The plugins incoming config for page collections. */
+export type IncomingRedirectsCollectionConfig = CollectionConfig & {
+  redirects: IncomingRedirectsCollectionConfigAttributes
+}
+
+/** A collection config with additional attributes for page collections after they have been processed. */
+export type RedirectsCollectionConfig = CollectionConfig & {
+  redirects: RedirectsCollectionConfigAttributes
+}

--- a/pages/src/types/RedirectsCollectionConfigAttributes.ts
+++ b/pages/src/types/RedirectsCollectionConfigAttributes.ts
@@ -1,0 +1,5 @@
+/** The incoming attributes for the redirects collection config. */
+export type IncomingRedirectsCollectionConfigAttributes = {}
+
+/** The attributes for the redirects collection config after they have been processed using the incoming config attributes. */
+export type RedirectsCollectionConfigAttributes = {}


### PR DESCRIPTION
This PR updates the approach used by the pages plugin to create and extend collection configs.

The new approach allows collection config creation functions to receive the plugin config, enabling future features such as multi-tenancy support.

### Migration Guide

**Old approach:**
```ts
import { createPageCollectionConfig, createRedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'

const Pages: CollectionConfig = createPageCollectionConfig({
  slug: 'pages',
  page: { /* config */ },
  fields: [/* fields */],
})

const Redirects = createRedirectsCollectionConfig({})
```

**New approach:**
```ts
import { PageCollectionConfig, RedirectsCollectionConfig } from '@jhb.software/payload-pages-plugin'

const Pages: PageCollectionConfig = {
  slug: 'pages',
  page: { /* config */ },
  fields: [/* fields */],
}

const Redirects: RedirectsCollectionConfig = {
  slug: 'redirects',
  redirects: {},
  fields: [],
}