### PR TITLE
fix(pages-plugin): respect collection access settings in custom fields (slug, parent etc.) #24

### DIFF
--- a/pages/dev/src/app/(payload)/admin/importMap.js
+++ b/pages/dev/src/app/(payload)/admin/importMap.js
@@ -1,5 +1,5 @@
 import { IsRootPageField as IsRootPageField_817212d6f65b4eb37176541413db3f8c } from '@jhb.software/payload-pages-plugin/server'
-import { SlugField as SlugField_e6458422044c3374e7ca411c92428566 } from '@jhb.software/payload-pages-plugin/client'
+import { SlugFieldWrapper as SlugFieldWrapper_817212d6f65b4eb37176541413db3f8c } from '@jhb.software/payload-pages-plugin/server'
 import { ParentField as ParentField_817212d6f65b4eb37176541413db3f8c } from '@jhb.software/payload-pages-plugin/server'
 import { PathField as PathField_e6458422044c3374e7ca411c92428566 } from '@jhb.software/payload-pages-plugin/client'
 import { BreadcrumbsField as BreadcrumbsField_e6458422044c3374e7ca411c92428566 } from '@jhb.software/payload-pages-plugin/client'
@@ -7,7 +7,7 @@ import { PreviewButtonField as PreviewButtonField_e6458422044c3374e7ca411c924285
 
 export const importMap = {
   "@jhb.software/payload-pages-plugin/server#IsRootPageField": IsRootPageField_817212d6f65b4eb37176541413db3f8c,
-  "@jhb.software/payload-pages-plugin/client#SlugField": SlugField_e6458422044c3374e7ca411c92428566,
+  "@jhb.software/payload-pages-plugin/server#SlugFieldWrapper": SlugFieldWrapper_817212d6f65b4eb37176541413db3f8c,
   "@jhb.software/payload-pages-plugin/server#ParentField": ParentField_817212d6f65b4eb37176541413db3f8c,
   "@jhb.software/payload-pages-plugin/client#PathField": PathField_e6458422044c3374e7ca411c92428566,
   "@jhb.software/payload-pages-plugin/client#BreadcrumbsField": BreadcrumbsField_e6458422044c3374e7ca411c92428566,

--- a/pages/dev/src/collections/pages.ts
+++ b/pages/dev/src/collections/pages.ts
@@ -5,6 +5,11 @@ export const Pages: PageCollectionConfig = {
   admin: {
     useAsTitle: 'title',
   },
+  access: {
+    update: () => false,
+    create: () => false,
+    delete: () => false
+  },
   page: {
     parent: {
       collection: 'pages',

--- a/pages/src/collections/PageCollectionConfig.ts
+++ b/pages/src/collections/PageCollectionConfig.ts
@@ -1,4 +1,4 @@
-import { ClientCollectionConfig, CollectionConfig, Field } from 'payload'
+import { ClientCollectionConfig, CollectionConfig } from 'payload'
 import { breadcrumbsField } from '../fields/breadcrumbsField.js'
 import { isRootPageField } from '../fields/isRootPageField.js'
 import { parentField } from '../fields/parentField.js'

--- a/pages/src/components/client/IsRootPageStatus.tsx
+++ b/pages/src/components/client/IsRootPageStatus.tsx
@@ -1,15 +1,15 @@
 'use client'
 import { CheckboxField, useField } from '@payloadcms/ui'
 import { CheckboxFieldClientProps } from '@payloadcms/ui/fields/Checkbox'
-import { PluginPagesTranslationKeys } from '../../translations/index.js'
 import { usePluginTranslation } from '../../utils/usePluginTranslations.js'
 /**
  * Field which displays either a checkbox to set the page to be root page or a message if the page is the root page.
  */
-export const IsRootPageStatus: React.FC<CheckboxFieldClientProps & { hasRootPage: boolean }> = ({
+export const IsRootPageStatus: React.FC<CheckboxFieldClientProps & { hasRootPage: boolean; readOnly?: boolean }> = ({
   field,
   path,
   hasRootPage,
+  readOnly,
 }) => {
   const { value } = useField<boolean>({ path: path! })
   const isRootPage = value ?? false
@@ -36,7 +36,7 @@ export const IsRootPageStatus: React.FC<CheckboxFieldClientProps & { hasRootPage
       </div>
     )
   } else if (!hasRootPage && !isRootPage) {
-    return <CheckboxField path={path} field={field} />
+    return <CheckboxField path={path} field={field} readOnly={readOnly} />
   }
 
   return null

--- a/pages/src/components/server/IsRootPageField.tsx
+++ b/pages/src/components/server/IsRootPageField.tsx
@@ -1,4 +1,4 @@
-import { CheckboxFieldServerComponent, serverProps, Where } from 'payload'
+import { CheckboxFieldServerComponent, Where } from 'payload'
 import { IsRootPageStatus } from '../client/IsRootPageStatus.js'
 
 /**
@@ -11,6 +11,8 @@ export const IsRootPageField: CheckboxFieldServerComponent = async ({
   collectionSlug,
   payload,
   req,
+  permissions,
+  readOnly,
   // @ts-expect-error: TODO: extend the CheckboxFieldServerComponent type to allow passing the baseFilter
   baseFilter,
 }) => {
@@ -25,12 +27,16 @@ export const IsRootPageField: CheckboxFieldServerComponent = async ({
   })
 
   const hasRootPage = response.totalDocs > 0
+  
+  // Determine if field should be readonly based on permissions
+  const isReadOnly = readOnly || (permissions !== true && permissions?.update !== true)
 
   return (
     <IsRootPageStatus
       field={clientField}
       path={(path as string | undefined) ?? field?.name!}
       hasRootPage={hasRootPage}
+      readOnly={isReadOnly}
     />
   )
 }

--- a/pages/src/components/server/ParentField.tsx
+++ b/pages/src/components/server/ParentField.tsx
@@ -11,6 +11,8 @@ export const ParentField: RelationshipFieldServerComponent = async ({
   payload,
   clientField,
   data,
+  permissions,
+  readOnly,
 }) => {
   const {
     parent: { name: parentField, sharedDocument: sharedParentDocument },
@@ -20,7 +22,10 @@ export const ParentField: RelationshipFieldServerComponent = async ({
   })
 
   var parentValue: string | undefined = data?.[parentField] ?? undefined
-  var readOnly = Boolean(sharedParentDocument && parentValue)
+  // Check both shared parent document and permissions
+  var isReadOnly = Boolean(sharedParentDocument && parentValue) || 
+                   readOnly || 
+                   (permissions !== true && permissions?.update !== true)
 
-  return <RelationshipField path={path as string} field={clientField} readOnly={readOnly} />
+  return <RelationshipField path={path as string} field={clientField} readOnly={isReadOnly} />
 }

--- a/pages/src/components/server/SlugFieldWrapper.tsx
+++ b/pages/src/components/server/SlugFieldWrapper.tsx
@@ -1,0 +1,21 @@
+import { TextFieldServerComponent } from 'payload'
+import SlugField from '../client/SlugField.js'
+
+/**
+ * Server component wrapper for SlugField that handles access-aware readOnly state.
+ */
+export const SlugFieldWrapper: TextFieldServerComponent = async ({
+  clientField,
+  path,
+  permissions,
+  readOnly,
+}) => {
+  const isReadOnly = readOnly || (permissions !== true && permissions?.update !== true)
+  return (
+    <SlugField
+      field={clientField}
+      path={path as string}
+      readOnly={isReadOnly}
+    />
+  )
+}

--- a/pages/src/exports/server.ts
+++ b/pages/src/exports/server.ts
@@ -1,2 +1,3 @@
 export { IsRootPageField } from '../components/server/IsRootPageField.js'
 export { ParentField } from '../components/server/ParentField.js'
+export { SlugFieldWrapper } from '../components/server/SlugFieldWrapper.js'

--- a/pages/src/fields/parentField.ts
+++ b/pages/src/fields/parentField.ts
@@ -64,7 +64,7 @@ export function parentField(
             [parentField]: true,
           },
         })
-        const fetchedParentValue = response.docs.at(0)?.[parentField] ?? null
+        const fetchedParentValue = (response.docs.at(0) as any)?.[parentField] ?? null
 
         if (fetchedParentValue) {
           return fetchedParentValue

--- a/pages/src/fields/slugField.ts
+++ b/pages/src/fields/slugField.ts
@@ -36,7 +36,7 @@ export function internalSlugField({
       readOnly: !!staticValue,
       components: {
         Field: {
-          path: '@jhb.software/payload-pages-plugin/client#SlugField',
+          path: '@jhb.software/payload-pages-plugin/server#SlugFieldWrapper',
           clientProps: {
             readOnly: !!staticValue,
             defaultValue: staticValue,


### PR DESCRIPTION
## Summary
• Added SlugFieldWrapper server component to handle access-aware readOnly state
• Updated IsRootPageField and ParentField to evaluate permissions and pass readOnly to client components  
• Enhanced IsRootPageStatus client component to accept and use readOnly prop
• Fixed slug field configuration to use new wrapper component instead of direct client component

## Test plan
- [x] Verify custom fields (slug, isRootPage, parent) respect collection access control settings
- [x] Test that fields become readonly when `update: false` is set on collection access
- [x] Ensure existing functionality remains intact for collections with normal access permissions
- [x] Confirm TypeScript compilation and linting passes