### PR TITLE
fix(pages): disable bulk edit for virtual fields

### DIFF
--- a/pages/src/fields/alternatePathsField.ts
+++ b/pages/src/fields/alternatePathsField.ts
@@ -18,6 +18,7 @@ export function alternatePathsField(): Field {
     validate: (_: any): true => true,
     admin: {
       readOnly: true,
+      disableBulkEdit: true,
       hidden: true,
     },
     hooks: {

--- a/pages/src/fields/breadcrumbsField.ts
+++ b/pages/src/fields/breadcrumbsField.ts
@@ -63,6 +63,7 @@ export function breadcrumbsField(): Field {
     ],
     admin: {
       readOnly: true,
+      disableBulkEdit: true,
       position: 'sidebar',
       components: {
         Field: '@jhb.software/payload-pages-plugin/client#BreadcrumbsField',

--- a/pages/src/fields/pathField.ts
+++ b/pages/src/fields/pathField.ts
@@ -18,6 +18,7 @@ export function pathField(): Field {
     localized: true,
     admin: {
       readOnly: true,
+      disableBulkEdit: true,
       position: 'sidebar',
       components: {
         Field: '@jhb.software/payload-pages-plugin/client#PathField',


### PR DESCRIPTION
## Summary

Adds `disableBulkEdit: true` to all virtual fields in the pages plugin (path, breadcrumbs, alternatePaths). Since these fields are generated on the fly, it does not make sense for users to bulk edit them.

## Changes

- `pathField.ts`: Added `disableBulkEdit: true` to admin config
- `breadcrumbsField.ts`: Added `disableBulkEdit: true` to admin config  
- `alternatePathsField.ts`: Added `disableBulkEdit: true` to admin config

## Testing

- ✅ All 33 automated tests pass
- ✅ TypeScript compilation successful
- ✅ Build successful (53 files compiled)
- ✅ Manual UI testing: Confirmed virtual fields do not appear in bulk edit field selector
- ✅ Regular fields (Title, Content, Parent Page, is Root Page) still appear correctly