### PR TITLE
feat(pages): pass full req to payload.findByID in getBreadcrumbs

### DIFF
--- a/pages/dev/plugin.test.ts
+++ b/pages/dev/plugin.test.ts
@@ -2318,6 +2318,80 @@ describe('Request-scoped ancestor caching', () => {
   })
 })
 
+describe('Request context is forwarded to nested findByID calls during breadcrumb computation', () => {
+  let parentPage: { id: DefaultIDType }
+
+  beforeAll(async () => {
+    await deleteCollection('pages')
+
+    parentPage = await payload.create({
+      collection: 'pages',
+      locale: 'de',
+      data: {
+        title: 'Context Parent',
+        slug: 'context-parent',
+        content: 'parent',
+        ...virtualFields,
+      },
+    })
+  })
+
+  test('nested findByID receives the full req including user and context', async () => {
+    const findByIDSpy = vi.spyOn(payload, 'findByID')
+
+    await payload.create({
+      collection: 'pages',
+      locale: 'de',
+      data: {
+        title: 'Context Child',
+        slug: 'context-child',
+        content: 'child',
+        parent: parentPage.id,
+        ...virtualFields,
+      },
+    })
+
+    // Find the nested findByID call that fetches the parent during breadcrumb computation
+    const parentFetch = findByIDSpy.mock.calls.find(
+      (call) => call[0].id === parentPage.id && call[0].collection === 'pages',
+    )
+
+    expect(parentFetch).toBeDefined()
+    const reqArg = parentFetch![0].req
+
+    // The nested call should receive a req with the payload instance (not a bare object)
+    expect(reqArg).toBeDefined()
+    expect(reqArg!.payload).toBeDefined()
+    expect(reqArg!.transactionID).toBeDefined()
+
+    // The full req should include context (not just the ancestor cache)
+    expect(reqArg!.context).toBeDefined()
+  })
+
+  test('custom req.context properties are preserved in nested findByID calls', async () => {
+    const findByIDSpy = vi.spyOn(payload, 'findByID')
+
+    // Use payload.find with a custom context property
+    await payload.find({
+      collection: 'pages',
+      locale: 'de',
+      where: { parent: { equals: parentPage.id } },
+      context: { customProperty: 'test-value' },
+    })
+
+    // Find the nested findByID call for the parent
+    const parentFetch = findByIDSpy.mock.calls.find(
+      (call) => call[0].id === parentPage.id && call[0].collection === 'pages',
+    )
+
+    expect(parentFetch).toBeDefined()
+    const reqArg = parentFetch![0].req
+
+    // The custom context property should be forwarded through to the nested call
+    expect(reqArg!.context).toHaveProperty('customProperty', 'test-value')
+  })
+})
+
 /**
  * Helper function to remove id field from objects in an array
  */

--- a/pages/src/utils/getBreadcrumbs.ts
+++ b/pages/src/utils/getBreadcrumbs.ts
@@ -179,10 +179,8 @@ async function findByIDCached({
         disableErrors: true,
         locale,
         req: {
-          // passing the transactionID ensures that the parent document can also be found if it was created in the same uncommitted transaction
-          transactionID: req.transactionID,
-          // do not pass the full req here, otherwise there will be issues with the locale flattening
-          context: { [ANCESTOR_CACHE_KEY]: cache },
+          ...req,
+          context: { ...req.context, [ANCESTOR_CACHE_KEY]: cache },
         },
         select: {
           breadcrumbs: true,


### PR DESCRIPTION
## Summary

- Pass the full `req` (spread with context override) to the nested `payload.findByID` call in `findByIDCached` instead of only forwarding `transactionID`. This preserves user authentication, headers, and custom `req.context` properties during parent document lookups for breadcrumb computation.
- Add tests verifying the full `req` and custom context properties are forwarded to nested calls.

### Background

Previously, only `transactionID` was forwarded to avoid a locale flattening issue. Investigation confirmed the concern was unfounded — the `beforeRead` hook always passes `locale: 'all'` for localized collections regardless of `req.locale`, and the explicit `locale` parameter to `findByID` controls the query. The approach mirrors how Payload's own hierarchy feature handles this (payloadcms/payload#14747).

Closes #56

## Test plan

- [x] All 51 localized tests pass (MongoDB + SQLite)
- [x] All 12 unlocalized tests pass (MongoDB + SQLite)
- [x] All 7 multi-tenant tests pass (MongoDB + SQLite)
- [x] 2 new tests verify req context forwarding