### PR TITLE
fix(pages): pass draft flag when fetching parent documents for breadcrumb generation

### DIFF
--- a/pages/dev/plugin.test.ts
+++ b/pages/dev/plugin.test.ts
@@ -2392,6 +2392,81 @@ describe('Request context is forwarded to nested findByID calls during breadcrum
   })
 })
 
+describe('Draft breadcrumbs reflect unpublished parent changes', () => {
+  let parentPage: { id: DefaultIDType }
+  let childPage: { id: DefaultIDType }
+
+  beforeAll(async () => {
+    await deleteCollection('authors')
+    await deleteCollection('pages')
+
+    // Create a published parent page
+    parentPage = await payload.create({
+      collection: 'pages',
+      locale: 'de',
+      data: {
+        title: 'Draft Parent',
+        slug: 'draft-parent-published',
+        content: 'parent',
+        ...virtualFields,
+      },
+    })
+
+    // Update the parent with a draft version (new slug, not published)
+    await payload.update({
+      collection: 'pages',
+      id: parentPage.id,
+      locale: 'de',
+      draft: true,
+      data: {
+        title: 'Draft Parent Updated',
+        slug: 'draft-parent-draft',
+        content: 'parent updated',
+        ...virtualFields,
+      },
+    })
+
+    // Create a child page referencing the parent
+    childPage = await payload.create({
+      collection: 'pages',
+      locale: 'de',
+      data: {
+        title: 'Draft Child',
+        slug: 'draft-child',
+        content: 'child',
+        parent: parentPage.id,
+        ...virtualFields,
+      },
+    })
+  })
+
+  test('child breadcrumbs reflect draft parent slug changes when fetched in draft mode', async () => {
+    // Fetch child in non-draft mode -> should use the published parent slug
+    const childPublished = await payload.findByID({
+      collection: 'pages',
+      id: childPage.id,
+      locale: 'de',
+    })
+
+    // Fetch child in draft mode (simulating a REST request with ?draft=true)
+    const childDraft = await payload.findByID({
+      collection: 'pages',
+      id: childPage.id,
+      locale: 'de',
+      draft: true,
+      req: { query: { draft: 'true' } },
+    })
+
+    // Non-draft mode: parent breadcrumb should use the published slug
+    expect(childPublished.breadcrumbs[0].slug).toBe('draft-parent-published')
+    expect(childPublished.path).toBe('/de/draft-parent-published/draft-child')
+
+    // Draft mode: parent breadcrumb should reflect the draft parent slug
+    expect(childDraft.breadcrumbs[0].slug).toBe('draft-parent-draft')
+    expect(childDraft.path).toBe('/de/draft-parent-draft/draft-child')
+  })
+})
+
 describe('Circular parent reference prevention', () => {
   beforeEach(async () => await deleteAllCollections(config, ['users']))
 

--- a/pages/dev_unlocalized/plugin.test.ts
+++ b/pages/dev_unlocalized/plugin.test.ts
@@ -1,5 +1,5 @@
 import payload, { CollectionSlug, ValidationError } from 'payload'
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import config from './src/payload.config'
 import type { Config } from 'payload/generated-types'
 
@@ -31,6 +31,10 @@ afterAll(async () => {
   } else {
     console.log('Could not destroy database')
   }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('Path and breadcrumb virtual fields are returned correctly for find operation.', () => {
@@ -476,6 +480,98 @@ describe('Slug field behaves as expected for create and update operations', () =
     } catch (error) {
       expect(error).toBeInstanceOf(ValidationError)
     }
+  })
+})
+
+describe('Draft breadcrumbs reflect unpublished parent changes', () => {
+  let parentPage: { id: DefaultIDType }
+  let childPage: { id: DefaultIDType }
+
+  beforeAll(async () => {
+    // Delete dependent collections before pages to respect foreign key constraints
+    await deleteCollection('authors')
+    await deleteCollection('blogposts')
+    await deleteCollection('pages')
+
+    // Create a published parent page
+    parentPage = await payload.create({
+      collection: 'pages',
+      data: {
+        title: 'Draft Parent',
+        slug: 'draft-parent-published',
+        content: 'parent',
+        ...virtualFields,
+      },
+    })
+
+    // Update the parent with a draft version (new slug, not published)
+    await payload.update({
+      collection: 'pages',
+      id: parentPage.id,
+      draft: true,
+      data: {
+        title: 'Draft Parent Updated',
+        slug: 'draft-parent-draft',
+        content: 'parent updated',
+        ...virtualFields,
+      },
+    })
+
+    // Create a child page referencing the parent
+    childPage = await payload.create({
+      collection: 'pages',
+      data: {
+        title: 'Draft Child',
+        slug: 'draft-child',
+        content: 'child',
+        parent: parentPage.id,
+        ...virtualFields,
+      },
+    })
+  })
+
+  test('local API draft: true without req.query.draft still forwards draft to parent fetch', async () => {
+    // Known limitation: Payload does not expose the `draft` operation flag to
+    // beforeRead/afterChange hooks, so local API callers using draft: true without
+    // also setting req.query.draft will not get draft breadcrumbs.
+    const findByIDSpy = vi.spyOn(payload, 'findByID')
+
+    // Fetch child as draft via local API (no req.query.draft)
+    await payload.findByID({
+      collection: 'pages',
+      id: childPage.id,
+      draft: true,
+    })
+
+    const parentFetch = findByIDSpy.mock.calls.find(
+      (call) => call[0].id === parentPage.id && call[0].collection === 'pages',
+    )
+    expect(parentFetch).toBeDefined()
+    expect(parentFetch![0].draft).toBe(true)
+  })
+
+  test('child breadcrumbs reflect draft parent slug changes when fetched in draft mode', async () => {
+    // Fetch child in non-draft mode -> should use the published parent slug
+    const childPublished = await payload.findByID({
+      collection: 'pages',
+      id: childPage.id,
+    })
+
+    // Fetch child in draft mode (simulating a REST request with ?draft=true)
+    const childDraft = await payload.findByID({
+      collection: 'pages',
+      id: childPage.id,
+      draft: true,
+      req: { query: { draft: 'true' } },
+    })
+
+    // Non-draft mode: parent breadcrumb should use the published slug
+    expect(childPublished.breadcrumbs[0].slug).toBe('draft-parent-published')
+    expect(childPublished.path).toBe('/draft-parent-published/draft-child')
+
+    // Draft mode: parent breadcrumb should reflect the draft parent slug
+    expect(childDraft.breadcrumbs[0].slug).toBe('draft-parent-draft')
+    expect(childDraft.path).toBe('/draft-parent-draft/draft-child')
   })
 })
 

--- a/pages/src/hooks/setVirtualFields.ts
+++ b/pages/src/hooks/setVirtualFields.ts
@@ -20,6 +20,19 @@ export function dependentFields(collectionConfig: PageCollectionConfig): string[
 }
 
 /**
+ * Derives the draft flag from the request query parameters.
+ * Handles both the string "true" (from REST API URL query params) and boolean true.
+ * Returns `true` when in draft mode, `undefined` otherwise (to omit the param).
+ *
+ * Note: Payload does not expose the `draft` operation flag to beforeRead/afterChange hooks,
+ * so local API callers that need draft breadcrumbs must pass `req: { query: { draft: 'true' } }`.
+ */
+function draftFromRequest(req: { query?: Record<string, unknown> }): true | undefined {
+  const draft = req.query?.draft
+  return draft === true || draft === 'true' ? true : undefined
+}
+
+/**
  * A [CollectionBeforeReadHook] that sets the values for all virtual fields (path, breadcrumbs, alternatePaths) before a document is read.
  *
  * A "before read" hook is used, because it is fired before localized fields are flattened which is necessary for generating the alternate paths.
@@ -39,6 +52,7 @@ export const setVirtualFieldsBeforeRead: CollectionBeforeReadHook = async ({
 
   const locale = localeFromRequest(req)
   const locales = localesFromRequest(req)
+  const draft = draftFromRequest(req)
 
   if (doc.isRootPage) {
     // Root pages don't need async lookups, so no try-catch needed
@@ -64,6 +78,7 @@ export const setVirtualFieldsBeforeRead: CollectionBeforeReadHook = async ({
   try {
     return await setPageDocumentVirtualFields({
       doc,
+      draft,
       locale: locales ? 'all' : undefined, // For localized pages, the CollectionBeforeReadHook should always return the field values for all locales
       locales,
       pageConfigAttributes: pageConfig.page,
@@ -95,6 +110,7 @@ export const setVirtualFieldsAfterChange: CollectionAfterChangeHook = async ({
   // This type of hook is only called for one locale (therefore the locale cannot be set to 'all')
   const locale = localeFromRequest(req)
   const locales = localesFromRequest(req)
+  const draft = draftFromRequest(req)
 
   const pageConfig = asPageCollectionConfigOrThrow(collection)
   const parentField = pageConfig.page.parent.name
@@ -115,6 +131,7 @@ export const setVirtualFieldsAfterChange: CollectionAfterChangeHook = async ({
     try {
       docWithVirtualFields = await setPageDocumentVirtualFields({
         doc,
+        draft,
         locale,
         locales,
         pageConfigAttributes: pageConfig.page,
@@ -160,6 +177,7 @@ export const setVirtualFieldsAfterChange: CollectionAfterChangeHook = async ({
     } else if (previousDoc.slug) {
       const result = await setPageDocumentVirtualFields({
         doc: previousDoc,
+        draft,
         locale,
         locales,
         pageConfigAttributes: pageConfig.page,

--- a/pages/src/utils/getBreadcrumbs.ts
+++ b/pages/src/utils/getBreadcrumbs.ts
@@ -11,6 +11,7 @@ import { ROOT_PAGE_SLUG } from './setRootPageVirtualFields.js'
 export async function getBreadcrumbs({
   breadcrumbLabelField,
   data,
+  draft,
   locale,
   locales,
   parentCollection,
@@ -19,6 +20,11 @@ export async function getBreadcrumbs({
 }: {
   breadcrumbLabelField: string
   data: Record<string, any>
+  /**
+   * Whether to fetch parent documents as drafts. When true, draft-only parents (never published)
+   * are included and draft changes to slugs/titles are reflected in the breadcrumbs.
+   */
+  draft?: boolean
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   locale: 'all' | Locale | undefined
   locales: Locale[] | undefined
@@ -65,6 +71,7 @@ export async function getBreadcrumbs({
     ? await findByIDCached({
         id: parentId,
         collection: parentCollection,
+        draft,
         locale,
         req,
       })
@@ -151,16 +158,18 @@ const ANCESTOR_CACHE_KEY = 'pagesPluginAncestorCache'
 async function findByIDCached({
   id,
   collection,
+  draft,
   locale,
   req,
 }: {
   collection: CollectionSlug
+  draft?: boolean
   id: number | string
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   locale: 'all' | Locale | undefined
   req: PayloadRequest
 }): Promise<null | Record<string, unknown>> {
-  const cacheKey = `${collection}:${id}:${locale ?? ''}`
+  const cacheKey = `${collection}:${id}:${locale ?? ''}:${draft ? 'draft' : 'published'}`
   // Cache the Promise (not the resolved value) so that concurrent lookups for the same
   // parent (e.g. beforeRead hooks running in parallel via Promise.all) share a single DB query.
   const cache = (req.context[ANCESTOR_CACHE_KEY] ??= new Map()) as Map<
@@ -177,6 +186,7 @@ async function findByIDCached({
         collection,
         depth: 0,
         disableErrors: true,
+        draft,
         locale,
         req: {
           ...req,

--- a/pages/src/utils/setPageVirtualFields.ts
+++ b/pages/src/utils/setPageVirtualFields.ts
@@ -10,12 +10,14 @@ import { getBreadcrumbs } from './getBreadcrumbs.js'
 /** Sets the virtual fields (breadcrumbs, path, alternatePaths) of the given root page document. */
 export async function setPageDocumentVirtualFields({
   doc,
+  draft,
   locale,
   locales,
   pageConfigAttributes,
   req,
 }: {
   doc: Record<string, any>
+  draft?: boolean
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   locale: 'all' | Locale | undefined
   locales: Locale[] | undefined
@@ -26,6 +28,7 @@ export async function setPageDocumentVirtualFields({
     const breadcrumbs = (await getBreadcrumbs({
       breadcrumbLabelField: pageConfigAttributes.breadcrumbs.labelField,
       data: doc,
+      draft,
       locales,
       parentCollection: pageConfigAttributes.parent.collection,
       parentField: pageConfigAttributes.parent.name,
@@ -80,6 +83,7 @@ export async function setPageDocumentVirtualFields({
     const breadcrumbs = (await getBreadcrumbs({
       breadcrumbLabelField: pageConfigAttributes.breadcrumbs.labelField,
       data: doc,
+      draft,
       locale: undefined,
       locales,
       parentCollection: pageConfigAttributes.parent.collection,


### PR DESCRIPTION
## Summary

- Thread `draft` flag from `req.query.draft` through `setVirtualFields` → `setPageVirtualFields` → `getBreadcrumbs` → `findByIDCached` so parent documents are fetched as drafts when the request is in draft/preview mode.
- Update `findByIDCached` cache key to include draft/published suffix, preventing cross-contamination between draft and published breadcrumbs.
- `draftFromRequest` returns `true | undefined` (not `boolean`) to avoid passing explicit `draft: false` to Payload's `findByID`.

## Blocked: Payload does not expose `draft` to collection hooks

Payload does not pass the `draft` operation flag to `CollectionBeforeReadHook` or `CollectionAfterChangeHook` — only `req`, `doc`, `collection`, and `context` are available. This means:

- **REST API / live preview** (`?draft=true`): works, because `req.query.draft` is set by Payload.
- **Local API** (`payload.findByID({ draft: true })`): **does not work** — the `draft` flag is consumed internally by Payload before hooks run and is not exposed on `req` or in hook args.

A failing test (`local API draft: true without req.query.draft still forwards draft to parent fetch`) documents this limitation. It will start passing once Payload exposes `draft` to collection-level hooks.

Workaround for local API callers: pass `req: { query: { draft: 'true' } }` alongside `draft: true`.

Related: payloadcms/payload#15769 introduces a hierarchy feature with the same problem — their `collectionAfterRead` hook uses `doc._status === 'draft'` as a proxy, which is incorrect for the case where a published child (no pending draft changes) has a parent with draft changes.

Closes #55