### PR TITLE
fix: improve release workflow safety and ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ on:
           - major
           - none
 
+# Prevent concurrent releases to avoid race conditions when pushing to main
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -72,19 +77,28 @@ jobs:
             exit 1
           fi
 
-      - name: Publish to npm
-        run: cd ${{ inputs.plugin }} && pnpm publish --no-git-checks --provenance --access public
-
-      - name: Commit version bump and create tag
+      # Commit and push BEFORE npm publish so that if push fails,
+      # we haven't published an irreversible npm release yet.
+      - name: Commit version bump and push
+        if: inputs.bump != 'none'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if [ "${{ inputs.bump }}" != "none" ]; then
-            git add ${{ inputs.plugin }}/package.json
-            git commit -m "release(${{ inputs.plugin }}): v${{ steps.version.outputs.version }}"
-          fi
+          git add ${{ inputs.plugin }}/package.json
+          git commit -m "release(${{ inputs.plugin }}): v${{ steps.version.outputs.version }}"
+          # Pull with rebase in case main advanced (e.g. from a merge) since checkout
+          git pull --rebase origin main
+          git push origin main
+
+      - name: Publish to npm
+        run: cd ${{ inputs.plugin }} && pnpm publish --no-git-checks --provenance --access public
+
+      # Tag and GitHub release happen after npm publish so the tag
+      # only exists when the package is actually on the registry.
+      - name: Create tag
+        run: |
           git tag "${{ inputs.plugin }}@${{ steps.version.outputs.version }}"
-          git push origin main --tags
+          git push origin "${{ inputs.plugin }}@${{ steps.version.outputs.version }}"
 
       - name: Extract changelog for version
         id: changelog

--- a/vercel-deployments/package.json
+++ b/vercel-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jhb.software/payload-vercel-deployments",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Payload CMS plugin for managing Vercel deployments of static websites — includes a dashboard widget and authenticated API endpoints.",
   "bugs": "https://github.com/jhb-software/payload-plugins/issues",
   "repository": "https://github.com/jhb-software/payload-plugins",


### PR DESCRIPTION
## Summary
This PR improves the release workflow by reordering critical steps to prevent race conditions and ensure npm publishes only after git changes are safely committed and pushed.

## Key Changes
- **Added concurrency control**: Prevents concurrent releases to avoid race conditions when pushing to main
- **Reordered release steps**: Commits and pushes version bumps to git *before* publishing to npm, ensuring that if the git push fails, the npm publish hasn't occurred yet (which would be irreversible)
- **Separated tag creation**: Tag creation and push now happen *after* npm publish, ensuring tags only exist when the package is actually on the registry
- **Improved git safety**: Added `git pull --rebase` before pushing to handle cases where main has advanced since checkout (e.g., from merges)
- **Bumped vercel-deployments version**: Updated from 0.2.0 to 0.2.1

## Implementation Details
The workflow now follows this safer sequence:
1. Version bump calculation
2. Commit and push version changes to main (with rebase to handle concurrent changes)
3. Publish to npm
4. Create and push git tag

This ordering ensures that if any step fails, the previous steps are already committed to git, and npm publishes only happen when we're confident the git state is correct.

https://claude.ai/code/session_01X2RaoKEGwbQTWxsyBuWyMG