### PR TITLE
Add admin panel links to agent responses and open in new tab

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Unreleased
 
 - Add markdown rendering for assistant messages using `react-markdown` and `remark-gfm`
+- Include admin panel URL patterns in the system prompt so the agent can produce clickable links to documents it creates, updates, or finds (respects `config.routes.admin`)
+- Open markdown links in a new tab so clicking through to the admin panel preserves the current chat conversation

--- a/chat-agent/src/schema.test.ts
+++ b/chat-agent/src/schema.test.ts
@@ -180,6 +180,26 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('"buttonText"')
   })
 
+  it('includes admin panel URL patterns so the agent can link documents', () => {
+    const prompt = buildSystemPrompt({
+      collections: [{ slug: 'posts', fields: [] }],
+      globals: [{ slug: 'settings', fields: [] }],
+    })
+    expect(prompt).toContain('Admin Panel')
+    expect(prompt).toContain('/admin/collections/')
+    expect(prompt).toContain('/admin/globals/')
+  })
+
+  it('uses the custom admin route prefix from config.routes.admin', () => {
+    const prompt = buildSystemPrompt({
+      collections: [{ slug: 'posts', fields: [] }],
+      globals: [],
+      routes: { admin: '/cms' },
+    })
+    expect(prompt).toContain('/cms/collections/')
+    expect(prompt).not.toContain('/admin/collections/')
+  })
+
   it('handles missing fields gracefully', () => {
     const config = {
       collections: [{ slug: 'empty' }],

--- a/chat-agent/src/schema.ts
+++ b/chat-agent/src/schema.ts
@@ -143,6 +143,8 @@ export function buildSystemPrompt(
     sections.push(customPrefix)
   }
 
+  const adminRoute = payloadConfig.routes?.admin ?? '/admin'
+
   sections.push(
     'You are a CMS content assistant with access to the Payload CMS database.',
     'You can read and write content using the provided tools.',
@@ -160,6 +162,9 @@ export function buildSystemPrompt(
     '- Keep `depth` at 0 (the default) unless you specifically need populated relationship data. Depth 0 returns relationship IDs only.',
     '- Use `limit` to fetch only as many documents as needed.',
     '- For listing/browsing, select only summary fields (e.g. id, title, slug, status) first, then fetch full details with findByID only when needed.',
+    '',
+    '## Admin Panel Links',
+    `When referencing a document (after create/update/find), render it as a markdown link to its admin page so the user can open it. Use the title as the label, ID as fallback. Patterns (relative URLs): \`${adminRoute}/collections/<slug>/<id>\`, \`${adminRoute}/collections/<slug>\`, \`${adminRoute}/globals/<slug>\`.`,
   )
 
   // Collections

--- a/chat-agent/src/ui/MarkdownContent.tsx
+++ b/chat-agent/src/ui/MarkdownContent.tsx
@@ -5,10 +5,25 @@ import remarkGfm from 'remark-gfm'
 
 import './MarkdownContent.css'
 
+/**
+ * Open every markdown link in a new tab so clicking on an admin panel
+ * link (e.g. to a document the agent just created) doesn't navigate the
+ * user away from the chat view and lose conversation state.
+ */
+const markdownComponents = {
+  a: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props} rel="noopener noreferrer" target="_blank">
+      {children}
+    </a>
+  ),
+}
+
 export function MarkdownContent({ children }: { children: string }) {
   return (
     <div className="chat-agent-markdown">
-      <Markdown remarkPlugins={[remarkGfm]}>{children}</Markdown>
+      <Markdown components={markdownComponents} remarkPlugins={[remarkGfm]}>
+        {children}
+      </Markdown>
     </div>
   )
 }

--- a/chat-agent/src/ui/MessageBubble.test.tsx
+++ b/chat-agent/src/ui/MessageBubble.test.tsx
@@ -49,6 +49,18 @@ describe('MessageBubble', () => {
     expect(strong!.textContent).toBe('world')
   })
 
+  it('opens markdown links in a new tab to preserve the chat view', () => {
+    const message = makeMessage({
+      role: 'assistant',
+      text: 'See [the post](/admin/collections/posts/123).',
+    })
+    const { container } = render(<MessageBubble message={message} />)
+    const link = container.querySelector('a')
+    expect(link).not.toBeNull()
+    expect(link!.getAttribute('target')).toBe('_blank')
+    expect(link!.getAttribute('rel')).toContain('noopener')
+  })
+
   it('renders user messages as plain text without markdown', () => {
     const message = makeMessage({
       role: 'user',


### PR DESCRIPTION
## Summary
Enable the chat agent to generate clickable links to the Payload CMS admin panel when referencing documents it creates, updates, or finds. Links open in a new tab to preserve the chat conversation state.

## Key Changes
- **System prompt enhancement**: Added admin panel URL patterns to the system prompt so the agent knows how to construct links to collections and globals. The patterns respect the custom `config.routes.admin` prefix if configured.
- **Markdown link handling**: Modified `MarkdownContent` component to open all markdown links in a new tab with proper security attributes (`target="_blank"` and `rel="noopener noreferrer"`), preventing navigation away from the chat view.
- **Test coverage**: Added tests to verify admin URL patterns are included in the prompt, custom admin routes are respected, and markdown links open in new tabs.

## Implementation Details
- The admin route prefix defaults to `/admin` but can be customized via `payloadConfig.routes?.admin`
- Links are rendered with `rel="noopener noreferrer"` for security when opening in new tabs
- The agent is instructed to use document titles as link labels with IDs as fallback, improving UX

https://claude.ai/code/session_01MqJnmdHL1z9Y74a4kTMdme