### PR TITLE
feat-agent): add nav link and fix access config

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -6,4 +6,5 @@
 - Add markdown rendering for assistant messages using `react-markdown` and `remark-gfm`
 - Include admin panel URL patterns in the system prompt so the agent can produce clickable links to documents it creates, updates, or finds (respects `config.routes.admin`)
 - Open markdown links in a new tab so clicking through to the admin panel preserves the current chat conversation
-- Add a "Chat" link at the top of the admin nav sidebar (via `beforeNavLinks`) that navigates to the chat view; respects the configured `adminView.path` and is omitted when `adminView: false`
+- Add a "Chat" link at the top of the admin nav sidebar (via `beforeNavLinks`) that navigates to the chat view; respects the configured `adminView.path` and can be hidden with the new `navLink: false` option
+- Remove support for `adminView: false`; the admin chat view is now always registered (use `navLink: false` to hide the sidebar button instead)

--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Open markdown links in a new tab so clicking through to the admin panel preserves the current chat conversation
 - Add a "Chat" link at the top of the admin nav sidebar (via `beforeNavLinks`) that navigates to the chat view; respects the configured `adminView.path` and can be hidden with the new `navLink: false` option
 - Remove support for `adminView: false`; the admin chat view is now always registered (use `navLink: false` to hide the sidebar button instead)
+- Nav link is now a server component (`ChatNavLinkServer`) that checks the plugin's `access` function before rendering; users without access do not see the link

--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: the plugin-level `access` function now gates every chat-agent surface. Previously, setting `access: () => false` still allowed any authenticated user to hit the `/chat-agent/chat/models` endpoint, all conversation CRUD endpoints, and the admin `/chat` view itself. Now a denied access check returns 401 on every endpoint and renders a "Not authorized" message in the admin view.
+- Improve mode selector labels to describe behavior ("Read only", "Confirm writes", "Read & write", "Superuser (bypass permissions)") instead of raw mode names.
 - **BREAKING**: Make the plugin AI-provider agnostic. The `apiKey` option has been removed and replaced with a required `model` factory of type `(modelId: string) => LanguageModel`. The `@ai-sdk/anthropic` package is no longer a dependency of the plugin — install whichever `@ai-sdk/*` provider you want (Anthropic, OpenAI, Google, Mistral, …) and pass the model instance through the factory. The plugin no longer reads `ANTHROPIC_API_KEY` (or any other key) from `process.env`; configuration must come entirely from the plugin options.
 
   Migration:

--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Add markdown rendering for assistant messages using `react-markdown` and `remark-gfm`
 - Include admin panel URL patterns in the system prompt so the agent can produce clickable links to documents it creates, updates, or finds (respects `config.routes.admin`)
 - Open markdown links in a new tab so clicking through to the admin panel preserves the current chat conversation
-- Add a "Chat" link at the top of the admin nav sidebar (via `beforeNavLinks`) that navigates to the chat view; respects the configured `adminView.path` and can be hidden with the new `navLink: false` option
+- Add a "Chat Agent" link at the top of the admin nav sidebar (via `beforeNavLinks`) that navigates to the chat view; styled to match Payload's built-in nav links (including active-state indicator), respects the configured `adminView.path`, and can be hidden with the new `navLink: false` option
 - Remove support for `adminView: false`; the admin chat view is now always registered (use `navLink: false` to hide the sidebar button instead)
 - Nav link is now a server component (`ChatNavLinkServer`) that checks the plugin's `access` function before rendering; users without access do not see the link
 - Restore the persisted model selection when resuming a conversation on page reload (previously the model selector snapped back to the default)

--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Add markdown rendering for assistant messages using `react-markdown` and `remark-gfm`
 - Include admin panel URL patterns in the system prompt so the agent can produce clickable links to documents it creates, updates, or finds (respects `config.routes.admin`)
 - Open markdown links in a new tab so clicking through to the admin panel preserves the current chat conversation
+- Add a "Chat" link at the top of the admin nav sidebar (via `beforeNavLinks`) that navigates to the chat view; respects the configured `adminView.path` and is omitted when `adminView: false`

--- a/chat-agent/README.md
+++ b/chat-agent/README.md
@@ -43,16 +43,17 @@ The plugin will register a chat view at `/admin/chat` and a streaming chat endpo
 
 ### Plugin Options
 
-| Option            | Type                           | Required | Description                                                                     |
-| ----------------- | ------------------------------ | -------- | ------------------------------------------------------------------------------- |
-| `defaultModel`    | `string`                       | Yes      | Claude model ID used when no per-request override is provided                   |
-| `availableModels` | `ModelOption[]`                | No       | Models the user can choose from in the chat UI (selector shown when 2+ entries) |
-| `apiKey`          | `string`                       | No       | Anthropic API key. Falls back to `ANTHROPIC_API_KEY` env var                    |
-| `systemPrompt`    | `string`                       | No       | Custom text prepended to the auto-generated system prompt                       |
-| `access`          | `(req) => boolean`             | No       | Override the default auth check (default: requires authenticated user)          |
-| `maxSteps`        | `number`                       | No       | Maximum tool-use loop steps per request (default: 20)                           |
-| `superuserAccess` | `boolean \| (req) => boolean`  | No       | Controls who can use superuser mode (`overrideAccess: true`)                    |
-| `adminView`       | `false \| { path, Component }` | No       | Customize or disable the admin chat view                                        |
+| Option            | Type                          | Required | Description                                                                     |
+| ----------------- | ----------------------------- | -------- | ------------------------------------------------------------------------------- |
+| `defaultModel`    | `string`                      | Yes      | Claude model ID used when no per-request override is provided                   |
+| `availableModels` | `ModelOption[]`               | No       | Models the user can choose from in the chat UI (selector shown when 2+ entries) |
+| `apiKey`          | `string`                      | No       | Anthropic API key. Falls back to `ANTHROPIC_API_KEY` env var                    |
+| `systemPrompt`    | `string`                      | No       | Custom text prepended to the auto-generated system prompt                       |
+| `access`          | `(req) => boolean`            | No       | Override the default auth check (default: requires authenticated user)          |
+| `maxSteps`        | `number`                      | No       | Maximum tool-use loop steps per request (default: 20)                           |
+| `superuserAccess` | `boolean \| (req) => boolean` | No       | Controls who can use superuser mode (`overrideAccess: true`)                    |
+| `adminView`       | `{ path, Component }`         | No       | Customize the admin chat view route or component                                |
+| `navLink`         | `boolean`                     | No       | Show a "Chat" link at the top of the admin nav sidebar (default: `true`)        |
 
 ### Model Selection
 

--- a/chat-agent/dev/src/app/(payload)/admin/importMap.js
+++ b/chat-agent/dev/src/app/(payload)/admin/importMap.js
@@ -21,8 +21,8 @@ import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93
 import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { ChatNavLinkServer as ChatNavLinkServer_a7b3c2d1e4f5a6b7c8d9e0f1a2b3c4d5 } from '@jhb.software/payload-chat-agent'
 import { ChatViewServer as ChatViewServer_58e4688362c6fde9fcb5d132423d2812 } from '@jhb.software/payload-chat-agent'
-import { ChatNavLink as ChatNavLink_2ad1e9a1d4de61f5c812a5d6a18e9a7c } from '@jhb.software/payload-chat-agent/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 export const importMap = {
@@ -49,7 +49,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@jhb.software/payload-chat-agent#ChatNavLinkServer": ChatNavLinkServer_a7b3c2d1e4f5a6b7c8d9e0f1a2b3c4d5,
   "@jhb.software/payload-chat-agent#ChatViewServer": ChatViewServer_58e4688362c6fde9fcb5d132423d2812,
-  "@jhb.software/payload-chat-agent/client#ChatNavLink": ChatNavLink_2ad1e9a1d4de61f5c812a5d6a18e9a7c,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/chat-agent/dev/src/app/(payload)/admin/importMap.js
+++ b/chat-agent/dev/src/app/(payload)/admin/importMap.js
@@ -22,6 +22,7 @@ import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997e
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ChatViewServer as ChatViewServer_58e4688362c6fde9fcb5d132423d2812 } from '@jhb.software/payload-chat-agent'
+import { ChatNavLink as ChatNavLink_2ad1e9a1d4de61f5c812a5d6a18e9a7c } from '@jhb.software/payload-chat-agent/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 export const importMap = {
@@ -49,5 +50,6 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@jhb.software/payload-chat-agent#ChatViewServer": ChatViewServer_58e4688362c6fde9fcb5d132423d2812,
+  "@jhb.software/payload-chat-agent/client#ChatNavLink": ChatNavLink_2ad1e9a1d4de61f5c812a5d6a18e9a7c,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -163,6 +163,7 @@ export default buildConfig({
   },
   plugins: [
     chatAgentPlugin({
+      access: () => true,
       availableModels: [
         { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
         { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },

--- a/chat-agent/src/access.ts
+++ b/chat-agent/src/access.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type PluginAccessFn = (req: any) => boolean | Promise<boolean>
+
+export function getPluginAccess(payload: any): PluginAccessFn | undefined {
+  return payload?.config?.custom?.chatAgent?.access as PluginAccessFn | undefined
+}
+
+/**
+ * Shared access check for the chat agent plugin.
+ *
+ * Reads the plugin's `access` function and evaluates it against the current
+ * request. When no access function is configured, falls back to
+ * "any authenticated user".
+ */
+export async function isPluginAccessAllowed(req: any): Promise<boolean> {
+  const access = getPluginAccess(req?.payload)
+  if (access) {
+    return Boolean(await access(req))
+  }
+  return !!req?.user
+}

--- a/chat-agent/src/conversations.test.ts
+++ b/chat-agent/src/conversations.test.ts
@@ -108,6 +108,30 @@ function findHandler(endpoints: any[], method: string, path: string) {
   return endpoints.find((ep: any) => ep.method === method && ep.path === path)?.handler
 }
 
+/** Builds a payload.config.custom.chatAgent.access shape for handler tests. */
+function payloadWithAccess(access: (req: any) => boolean | Promise<boolean>, extra: any = {}) {
+  return { config: { custom: { chatAgent: { access } } }, ...extra }
+}
+
+describe('conversation endpoints respect plugin access()', () => {
+  it.each([
+    ['get', '/chat-agent/chat/conversations'],
+    ['get', '/chat-agent/chat/conversations/:id'],
+    ['post', '/chat-agent/chat/conversations'],
+    ['patch', '/chat-agent/chat/conversations/:id'],
+    ['delete', '/chat-agent/chat/conversations/:id'],
+  ])('%s %s returns 401 when plugin access denies', async (method, path) => {
+    const handler = findHandler(conversationEndpoints, method, path)
+    const res = await handler({
+      json: () => Promise.resolve({}),
+      payload: payloadWithAccess(() => false),
+      routeParams: { id: 'c1' },
+      user: { id: 'u1' },
+    })
+    expect(res.status).toBe(401)
+  })
+})
+
 describe('conversation endpoint handlers', () => {
   // --- List ---------------------------------------------------------------
 

--- a/chat-agent/src/conversations.ts
+++ b/chat-agent/src/conversations.ts
@@ -9,6 +9,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { isPluginAccessAllowed } from './access.js'
+
 export const CONVERSATIONS_SLUG = 'chat-conversations'
 
 // ---------------------------------------------------------------------------
@@ -82,7 +84,7 @@ export const conversationsCollection = {
 
 /** GET /api/chat-agent/chat/conversations — list user's conversations */
 async function listConversations(req: any): Promise<Response> {
-  if (!req.user) {
+  if (!(await isPluginAccessAllowed(req))) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -99,7 +101,7 @@ async function listConversations(req: any): Promise<Response> {
 
 /** GET /api/chat-agent/chat/conversations/:id — get single conversation */
 async function getConversation(req: any): Promise<Response> {
-  if (!req.user) {
+  if (!(await isPluginAccessAllowed(req))) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -123,7 +125,7 @@ async function getConversation(req: any): Promise<Response> {
 
 /** POST /api/chat-agent/chat/conversations — create a conversation */
 async function createConversation(req: any): Promise<Response> {
-  if (!req.user) {
+  if (!(await isPluginAccessAllowed(req))) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -150,7 +152,7 @@ async function createConversation(req: any): Promise<Response> {
 
 /** PATCH /api/chat-agent/chat/conversations/:id — update a conversation */
 async function updateConversation(req: any): Promise<Response> {
-  if (!req.user) {
+  if (!(await isPluginAccessAllowed(req))) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -197,7 +199,7 @@ async function updateConversation(req: any): Promise<Response> {
 
 /** DELETE /api/chat-agent/chat/conversations/:id — delete a conversation */
 async function deleteConversation(req: any): Promise<Response> {
-  if (!req.user) {
+  if (!(await isPluginAccessAllowed(req))) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/chat-agent/src/exports/client.ts
+++ b/chat-agent/src/exports/client.ts
@@ -5,5 +5,6 @@
  * This is the entry point for `@jhb.software/payload-chat-agent/client`.
  */
 
+export { ChatNavLink, type ChatNavLinkProps } from '../ui/ChatNavLink.js'
 export { default as ChatView } from '../ui/ChatView.js'
 export { type ChatMessageUI, useChat, type UseChatOptions } from '../ui/use-chat.js'

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -860,7 +860,7 @@ describe('chatAgentPlugin models endpoint', () => {
     const result = plugin({ endpoints: [] })
     const ep = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat/models')
 
-    const response = await ep.handler()
+    const response = await ep.handler({ user: { id: 1 } })
     const body = await response.json()
     expect(body.defaultModel).toBe('claude-sonnet-4-20250514')
     expect(body.availableModels).toHaveLength(2)
@@ -874,9 +874,99 @@ describe('chatAgentPlugin models endpoint', () => {
     const result = plugin({ endpoints: [] })
     const ep = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat/models')
 
-    const response = await ep.handler()
+    const response = await ep.handler({ user: { id: 1 } })
     const body = await response.json()
     expect(body.defaultModel).toBe('gpt-4o-mini')
     expect(body.availableModels).toEqual([])
+  })
+
+  it('returns 401 when plugin access() denies', async () => {
+    const plugin = chatAgentPlugin({
+      access: () => false,
+      defaultModel: 'gpt-4o-mini',
+      model: makeModelFactory().factory,
+    })
+    const config = plugin({ endpoints: [] })
+    const ep = config.endpoints.find((ep: any) => ep.path === '/chat-agent/chat/models')
+
+    const response = await ep.handler({
+      payload: { config: { custom: config.custom } },
+      user: { id: 1 },
+    })
+    expect(response.status).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Plugin-level access() gates every surface
+// ---------------------------------------------------------------------------
+
+describe('chatAgentPlugin access()', () => {
+  // When an authenticated user is present but the plugin's access() returns
+  // false, every chat-agent endpoint must refuse. Before the fix, only the
+  // modes + chat endpoints honored access(); /models and the conversation
+  // CRUD routes still worked for any logged-in user.
+  const denyingPlugin = () =>
+    chatAgentPlugin({
+      access: () => false,
+      defaultModel: 'gpt-4o-mini',
+      model: makeModelFactory().factory,
+    })
+
+  it('denies /chat-agent/modes', async () => {
+    const config = denyingPlugin()({ endpoints: [] })
+    const handler = config.endpoints.find((ep: any) => ep.path === '/chat-agent/modes').handler
+    const response = await handler({
+      payload: { config: { custom: config.custom } },
+      user: { id: 1 },
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('denies /chat-agent/chat', async () => {
+    const config = denyingPlugin()({ endpoints: [] })
+    const handler = config.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
+    const response = await handler({
+      json: () => Promise.resolve({ messages: [] }),
+      payload: { config: { custom: config.custom } },
+      user: { id: 1 },
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('denies /chat-agent/chat/models', async () => {
+    const config = denyingPlugin()({ endpoints: [] })
+    const handler = config.endpoints.find(
+      (ep: any) => ep.path === '/chat-agent/chat/models',
+    ).handler
+    const response = await handler({
+      payload: { config: { custom: config.custom } },
+      user: { id: 1 },
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('denies every conversation CRUD endpoint', async () => {
+    const config = denyingPlugin()({ endpoints: [] })
+    const payload = { config: { custom: config.custom } }
+    const routes = [
+      ['get', '/chat-agent/chat/conversations'],
+      ['get', '/chat-agent/chat/conversations/:id'],
+      ['post', '/chat-agent/chat/conversations'],
+      ['patch', '/chat-agent/chat/conversations/:id'],
+      ['delete', '/chat-agent/chat/conversations/:id'],
+    ] as const
+    for (const [method, path] of routes) {
+      const handler = config.endpoints.find(
+        (ep: any) => ep.method === method && ep.path === path,
+      ).handler
+      const response = await handler({
+        json: () => Promise.resolve({}),
+        payload,
+        routeParams: { id: 'c1' },
+        user: { id: 1 },
+      })
+      expect(response.status, `${method} ${path}`).toBe(401)
+    }
   })
 })

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -172,16 +172,6 @@ describe('chatAgentPlugin admin view', () => {
     expect(result.admin.components.views.chat).toBeDefined()
   })
 
-  it('disables admin view when adminView is false', () => {
-    const plugin = chatAgentPlugin({
-      adminView: false,
-      defaultModel: 'claude-sonnet-4-20250514',
-    })
-    const result = plugin({ endpoints: [] })
-
-    expect(result.admin?.components?.views?.chat).toBeUndefined()
-  })
-
   it('uses custom path when provided', () => {
     const plugin = chatAgentPlugin({
       adminView: { path: '/assistant' },
@@ -244,10 +234,10 @@ describe('chatAgentPlugin nav link', () => {
     expect(navLink.clientProps?.path).toBe('/chat')
   })
 
-  it('does NOT inject the nav link when adminView is false', () => {
+  it('does NOT inject the nav link when navLink is false', () => {
     const plugin = chatAgentPlugin({
-      adminView: false,
       defaultModel: 'claude-sonnet-4-20250514',
+      navLink: false,
     })
     const result = plugin({ endpoints: [] })
 
@@ -256,6 +246,30 @@ describe('chatAgentPlugin nav link', () => {
       typeof c === 'string' ? c.includes('ChatNavLink') : c?.path?.includes('ChatNavLink'),
     )
     expect(navLink).toBeUndefined()
+  })
+
+  it('still registers the admin chat view when navLink is false', () => {
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      navLink: false,
+    })
+    const result = plugin({ endpoints: [] })
+
+    expect(result.admin?.components?.views?.chat).toBeDefined()
+    expect(result.admin.components.views.chat.path).toBe('/chat')
+  })
+
+  it('injects the nav link when navLink is explicitly true', () => {
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      navLink: true,
+    })
+    const result = plugin({ endpoints: [] })
+
+    const navLink = result.admin.components.beforeNavLinks.find(
+      (c: any) => typeof c === 'object' && c?.path?.includes('ChatNavLink'),
+    )
+    expect(navLink).toBeDefined()
   })
 
   it('preserves existing beforeNavLinks entries', () => {

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -409,6 +409,33 @@ describe('chatAgentPlugin nav link', () => {
     expect(navLink).toBeDefined()
   })
 
+  it('uses a server component for the nav link', () => {
+    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const result = plugin({ endpoints: [] })
+
+    const navLink = result.admin.components.beforeNavLinks.find(
+      (c: any) => typeof c === 'object' && c?.path?.includes('ChatNavLink'),
+    )
+    expect(navLink.path).toContain('ChatNavLinkServer')
+    expect(navLink.path).not.toContain('/client')
+  })
+
+  it('stores the access function in config.custom.chatAgent', () => {
+    const access = () => true
+    const plugin = chatAgentPlugin({ access, defaultModel: 'claude-sonnet-4-20250514' })
+    const result = plugin({ endpoints: [] })
+
+    expect(result.custom?.chatAgent?.access).toBe(access)
+  })
+
+  it('stores chatAgent config even without a custom access function', () => {
+    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const result = plugin({ endpoints: [] })
+
+    expect(result.custom?.chatAgent).toBeDefined()
+    expect(result.custom.chatAgent.access).toBeUndefined()
+  })
+
   it('preserves existing beforeNavLinks entries', () => {
     const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
     const existing = '@my-org/existing#SomeNavLink'

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -204,6 +204,74 @@ describe('chatAgentPlugin admin view', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Nav sidebar button (beforeNavLinks)
+// ---------------------------------------------------------------------------
+
+describe('chatAgentPlugin nav link', () => {
+  it('injects a chat nav link into admin.components.beforeNavLinks by default', () => {
+    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const result = plugin({ endpoints: [] })
+
+    const beforeNavLinks = result.admin?.components?.beforeNavLinks
+    expect(Array.isArray(beforeNavLinks)).toBe(true)
+    const navLink = beforeNavLinks.find((c: any) =>
+      typeof c === 'string' ? c.includes('ChatNavLink') : c?.path?.includes('ChatNavLink'),
+    )
+    expect(navLink).toBeDefined()
+  })
+
+  it('passes the configured chat path to the nav link as a client prop', () => {
+    const plugin = chatAgentPlugin({
+      adminView: { path: '/assistant' },
+      defaultModel: 'claude-sonnet-4-20250514',
+    })
+    const result = plugin({ endpoints: [] })
+
+    const navLink = result.admin.components.beforeNavLinks.find(
+      (c: any) => typeof c === 'object' && c?.path?.includes('ChatNavLink'),
+    )
+    expect(navLink).toBeDefined()
+    expect(navLink.clientProps?.path).toBe('/assistant')
+  })
+
+  it('defaults the nav link path to /chat when adminView is unset', () => {
+    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const result = plugin({ endpoints: [] })
+
+    const navLink = result.admin.components.beforeNavLinks.find(
+      (c: any) => typeof c === 'object' && c?.path?.includes('ChatNavLink'),
+    )
+    expect(navLink.clientProps?.path).toBe('/chat')
+  })
+
+  it('does NOT inject the nav link when adminView is false', () => {
+    const plugin = chatAgentPlugin({
+      adminView: false,
+      defaultModel: 'claude-sonnet-4-20250514',
+    })
+    const result = plugin({ endpoints: [] })
+
+    const beforeNavLinks = result.admin?.components?.beforeNavLinks ?? []
+    const navLink = beforeNavLinks.find((c: any) =>
+      typeof c === 'string' ? c.includes('ChatNavLink') : c?.path?.includes('ChatNavLink'),
+    )
+    expect(navLink).toBeUndefined()
+  })
+
+  it('preserves existing beforeNavLinks entries', () => {
+    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const existing = '@my-org/existing#SomeNavLink'
+    const result = plugin({
+      admin: { components: { beforeNavLinks: [existing] } },
+      endpoints: [],
+    })
+
+    expect(result.admin.components.beforeNavLinks).toContain(existing)
+    expect(result.admin.components.beforeNavLinks.length).toBeGreaterThan(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Model validation in chat endpoint
 // ---------------------------------------------------------------------------
 

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -61,31 +61,28 @@ export function validateMessages(messages: unknown): null | string {
 
 export function chatAgentPlugin(options: ChatAgentPluginOptions) {
   return (config: any): any => {
-    // Auto-register the admin chat view unless explicitly disabled
-    const adminViews =
-      options.adminView === false
-        ? config.admin?.components?.views
-        : {
-            ...config.admin?.components?.views,
-            chat: {
-              Component: options.adminView?.Component ?? CHAT_VIEW_COMPONENT,
-              path: options.adminView?.path ?? '/chat',
-            },
-          }
+    // Always register the admin chat view. `adminView` customizes route/component.
+    const chatPath = options.adminView?.path ?? '/chat'
+    const adminViews = {
+      ...config.admin?.components?.views,
+      chat: {
+        Component: options.adminView?.Component ?? CHAT_VIEW_COMPONENT,
+        path: chatPath,
+      },
+    }
 
-    // Inject a "Chat" link at the top of the admin nav sidebar unless the
-    // admin view is disabled. The link navigates to the configured chat path.
-    const chatPath = options.adminView === false ? undefined : (options.adminView?.path ?? '/chat')
-    const beforeNavLinks =
-      options.adminView === false
-        ? config.admin?.components?.beforeNavLinks
-        : [
-            ...(config.admin?.components?.beforeNavLinks ?? []),
-            {
-              clientProps: { path: chatPath },
-              path: CHAT_NAV_LINK_COMPONENT,
-            },
-          ]
+    // Inject a "Chat" link at the top of the admin nav sidebar by default.
+    // Opt out with `navLink: false`.
+    const showNavLink = options.navLink !== false
+    const beforeNavLinks = showNavLink
+      ? [
+          ...(config.admin?.components?.beforeNavLinks ?? []),
+          {
+            clientProps: { path: chatPath },
+            path: CHAT_NAV_LINK_COMPONENT,
+          },
+        ]
+      : config.admin?.components?.beforeNavLinks
 
     return {
       ...config,

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -24,6 +24,7 @@ import { convertToModelMessages, stepCountIs, streamText } from 'ai'
 
 import type { AgentMode, ChatAgentPluginOptions } from './types.js'
 
+import { isPluginAccessAllowed } from './access.js'
 import { conversationEndpoints, conversationsCollection } from './conversations.js'
 import {
   getDefaultMode,
@@ -142,8 +143,7 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
         // --- GET /chat-agent/modes ------------------------------------------
         {
           handler: async (req: any) => {
-            const allowed = options.access ? await options.access(req) : !!req.user
-            if (!allowed) {
+            if (!(await isPluginAccessAllowed(req))) {
               return Response.json({ error: 'Unauthorized' }, { status: 401 })
             }
 
@@ -159,7 +159,10 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
 
         // --- GET /chat-agent/chat/models ------------------------------------
         {
-          handler: () => {
+          handler: async (req: any) => {
+            if (!(await isPluginAccessAllowed(req))) {
+              return Response.json({ error: 'Unauthorized' }, { status: 401 })
+            }
             return Response.json({
               availableModels: options.availableModels ?? [],
               defaultModel: options.defaultModel,
@@ -173,8 +176,7 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
         {
           handler: async (req: any) => {
             // --- Auth check -----------------------------------------------
-            const allowed = options.access ? await options.access(req) : !!req.user
-            if (!allowed) {
+            if (!(await isPluginAccessAllowed(req))) {
               return Response.json({ error: 'Unauthorized' }, { status: 401 })
             }
 

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -31,6 +31,12 @@ export { default as ChatViewServer } from './ui/ChatViewServer.js'
 const CHAT_VIEW_COMPONENT = '@jhb.software/payload-chat-agent#ChatViewServer'
 
 /**
+ * The package-relative path to the ChatNavLink component shown at the top
+ * of the admin nav sidebar. Used by Payload's importMap system.
+ */
+const CHAT_NAV_LINK_COMPONENT = '@jhb.software/payload-chat-agent/client#ChatNavLink'
+
+/**
  * Validate that a messages array is non-empty and has valid roles.
  * Returns an error string if invalid, or null if valid.
  */
@@ -67,12 +73,27 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
             },
           }
 
+    // Inject a "Chat" link at the top of the admin nav sidebar unless the
+    // admin view is disabled. The link navigates to the configured chat path.
+    const chatPath = options.adminView === false ? undefined : (options.adminView?.path ?? '/chat')
+    const beforeNavLinks =
+      options.adminView === false
+        ? config.admin?.components?.beforeNavLinks
+        : [
+            ...(config.admin?.components?.beforeNavLinks ?? []),
+            {
+              clientProps: { path: chatPath },
+              path: CHAT_NAV_LINK_COMPONENT,
+            },
+          ]
+
     return {
       ...config,
       admin: {
         ...config.admin,
         components: {
           ...config.admin?.components,
+          beforeNavLinks,
           views: adminViews,
         },
       },

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -29,6 +29,7 @@ import { buildTools, discoverEndpoints, filterToolsByMode } from './tools.js'
 export type { ChatAgentPluginOptions, ModelOption } from './types.js'
 export { AGENT_MODES, type AgentMode, type ModesConfig } from './types.js'
 export { type MessageMetadata, messageMetadataSchema } from './types.js'
+export { default as ChatNavLinkServer } from './ui/ChatNavLinkServer.js'
 export { default as ChatViewServer } from './ui/ChatViewServer.js'
 
 /**
@@ -38,10 +39,11 @@ export { default as ChatViewServer } from './ui/ChatViewServer.js'
 const CHAT_VIEW_COMPONENT = '@jhb.software/payload-chat-agent#ChatViewServer'
 
 /**
- * The package-relative path to the ChatNavLink component shown at the top
- * of the admin nav sidebar. Used by Payload's importMap system.
+ * The package-relative path to the ChatNavLinkServer component shown at the
+ * top of the admin nav sidebar. This is a server component that checks access
+ * before rendering the client ChatNavLink.
  */
-const CHAT_NAV_LINK_COMPONENT = '@jhb.software/payload-chat-agent/client#ChatNavLink'
+const CHAT_NAV_LINK_COMPONENT = '@jhb.software/payload-chat-agent#ChatNavLinkServer'
 
 /**
  * Validate that a messages array is non-empty and has valid roles.
@@ -104,6 +106,12 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
         },
       },
       collections: [...(config.collections ?? []), conversationsCollection],
+      custom: {
+        ...config.custom,
+        chatAgent: {
+          access: options.access,
+        },
+      },
       endpoints: [
         ...(config.endpoints ?? []),
         ...conversationEndpoints,

--- a/chat-agent/src/types.ts
+++ b/chat-agent/src/types.ts
@@ -77,7 +77,15 @@ export interface ModesConfig {
 // ---------------------------------------------------------------------------
 
 export interface ChatAgentPluginOptions {
-  /** Override the default auth check (must return true to allow). */
+  /**
+   * Gates every plugin surface (endpoints, admin view, nav link). Return `true` to allow, `false` to deny.
+   *
+   * When omitted, any authenticated Payload user is allowed. Set this to
+   * restrict to specific roles, e.g. `({ user }) => user?.role === 'admin'`.
+   *
+   * For finer-grained control over which agent modes each user can use
+   * (read / ask / read-write / superuser), see `modes.access`.
+   */
   access?: (req: any) => boolean | Promise<boolean>
   /**
    * Admin panel chat view configuration. The chat view is always registered;

--- a/chat-agent/src/types.ts
+++ b/chat-agent/src/types.ts
@@ -23,19 +23,15 @@ export interface ChatAgentPluginOptions {
   /** Override the default auth check (must return true to allow). */
   access?: (req: any) => boolean | Promise<boolean>
   /**
-   * Admin panel chat view configuration.
-   * - Omit or `{}` to auto-register at `/admin/chat` (default).
-   * - `false` to disable the admin view entirely.
-   * - `{ path, Component }` to customize the route or component.
+   * Admin panel chat view configuration. The chat view is always registered;
+   * use these fields to customize the route path or replace the component.
    */
-  adminView?:
-    | {
-        /** Custom component path for Payload's importMap. */
-        Component?: string
-        /** Admin route path. Default: "/chat" */
-        path?: `/${string}`
-      }
-    | false
+  adminView?: {
+    /** Custom component path for Payload's importMap. */
+    Component?: string
+    /** Admin route path. Default: "/chat" */
+    path?: `/${string}`
+  }
   /** Anthropic API key. Falls back to ANTHROPIC_API_KEY env var. */
   apiKey?: string
   /** Models the user can choose from in the chat UI. When provided with 2+ entries, a selector dropdown is shown. */
@@ -44,6 +40,11 @@ export interface ChatAgentPluginOptions {
   defaultModel: string
   /** Maximum tool-use loop steps per request. Default: 20 */
   maxSteps?: number
+  /**
+   * Show a "Chat" link at the top of the admin nav sidebar.
+   * Set to `false` to hide it. Default: `true`.
+   */
+  navLink?: boolean
   /**
    * Controls who can use superuser mode (overrideAccess: true).
    * - Omit or `false` to disable superuser mode entirely (default).

--- a/chat-agent/src/ui/ChatNavLink.test.tsx
+++ b/chat-agent/src/ui/ChatNavLink.test.tsx
@@ -2,8 +2,10 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+let mockPathname = '/admin'
+
 vi.mock('@payloadcms/ui', () => ({
-  Link: ({ children, href, ...rest }: any) => (
+  Link: ({ children, href, prefetch: _prefetch, ...rest }: any) => (
     <a href={href} {...rest}>
       {children}
     </a>
@@ -13,21 +15,36 @@ vi.mock('@payloadcms/ui', () => ({
   }),
 }))
 
+vi.mock('next/navigation.js', () => ({
+  usePathname: () => mockPathname,
+}))
+
 const { ChatNavLink } = await import('./ChatNavLink.js')
 
 describe('ChatNavLink', () => {
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    mockPathname = '/admin'
+  })
 
-  it('renders a link to /admin/chat by default', () => {
+  it('renders a link to /admin/chat by default with the "Chat Agent" label', () => {
     render(<ChatNavLink />)
     const link = screen.getByRole('link', { name: /open chat assistant/i })
     expect(link.getAttribute('href')).toBe('/admin/chat')
-    expect(link.textContent).toContain('Chat')
+    expect(link.textContent).toContain('Chat Agent')
   })
 
   it('respects a custom path prop', () => {
     render(<ChatNavLink path="/assistant" />)
     const link = screen.getByRole('link', { name: /open chat assistant/i })
     expect(link.getAttribute('href')).toBe('/admin/assistant')
+  })
+
+  it('renders without a <Link> when the current path matches (active state)', () => {
+    mockPathname = '/admin/chat'
+    render(<ChatNavLink />)
+    // No role=link because active state drops the anchor (matches Payload's DefaultNavClient behavior)
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getByText('Chat Agent')).toBeTruthy()
   })
 })

--- a/chat-agent/src/ui/ChatNavLink.test.tsx
+++ b/chat-agent/src/ui/ChatNavLink.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@payloadcms/ui', () => ({
+  Link: ({ children, href, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+  useConfig: () => ({
+    config: { routes: { admin: '/admin' } },
+  }),
+}))
+
+const { ChatNavLink } = await import('./ChatNavLink.js')
+
+describe('ChatNavLink', () => {
+  afterEach(cleanup)
+
+  it('renders a link to /admin/chat by default', () => {
+    render(<ChatNavLink />)
+    const link = screen.getByRole('link', { name: /open chat assistant/i })
+    expect(link.getAttribute('href')).toBe('/admin/chat')
+    expect(link.textContent).toContain('Chat')
+  })
+
+  it('respects a custom path prop', () => {
+    render(<ChatNavLink path="/assistant" />)
+    const link = screen.getByRole('link', { name: /open chat assistant/i })
+    expect(link.getAttribute('href')).toBe('/admin/assistant')
+  })
+})

--- a/chat-agent/src/ui/ChatNavLink.tsx
+++ b/chat-agent/src/ui/ChatNavLink.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { Link, useConfig } from '@payloadcms/ui'
+
+export interface ChatNavLinkProps {
+  /**
+   * The admin route path for the chat view, e.g. `/chat` or `/assistant`.
+   * Passed in via `clientProps` from the plugin so it stays in sync with
+   * `adminView.path`.
+   */
+  path?: string
+}
+
+/**
+ * Renders a link to the chat view at the top of the Payload admin nav
+ * sidebar. Mounted via `admin.components.beforeNavLinks`.
+ */
+export function ChatNavLink({ path = '/chat' }: ChatNavLinkProps) {
+  const {
+    config: {
+      routes: { admin: adminRoute },
+    },
+  } = useConfig()
+
+  const href = `${adminRoute}${path}`
+
+  return (
+    <Link
+      aria-label="Open chat assistant"
+      className="nav__link"
+      href={href}
+      style={{
+        alignItems: 'center',
+        color: 'var(--theme-elevation-800)',
+        display: 'flex',
+        gap: '10px',
+        padding: '8px 0',
+        textDecoration: 'none',
+      }}
+    >
+      <MessageIcon />
+      <span>Chat</span>
+    </Link>
+  )
+}
+
+export default ChatNavLink
+
+// Geist "message" icon — https://github.com/jarvis394/geist-icons/blob/main/source/message.svg
+function MessageIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      data-testid="geist-icon"
+      height="16"
+      strokeLinejoin="round"
+      style={{ color: 'currentcolor', flexShrink: 0 }}
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        clipRule="evenodd"
+        d="M2.891 10.403l.092.229c.246.613.517 1.473.517 2.368 0 .359-.044.713-.112 1.05a7.162 7.162 0 002.322-1.297l.515-.43.663.097c.36.052.732.08 1.112.08 3.784 0 6.5-2.644 6.5-5.5S11.784 1.5 8 1.5 1.5 4.144 1.5 7c0 1.182.442 2.293 1.231 3.215l.16.188zm-.078 5.362C1.761 16 1 16 1 16s.433-.69.73-1.563C1.882 13.983 2 13.48 2 13c0-.617-.193-1.27-.409-1.81C.591 10.022 0 8.572 0 7c0-3.866 3.582-7 8-7s8 3.134 8 7-3.582 7-8 7c-.453 0-.897-.033-1.33-.096A8.656 8.656 0 015 15a9.572 9.572 0 01-2.187.765z"
+        fill="currentColor"
+        fillRule="evenodd"
+      />
+    </svg>
+  )
+}

--- a/chat-agent/src/ui/ChatNavLink.tsx
+++ b/chat-agent/src/ui/ChatNavLink.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Link, useConfig } from '@payloadcms/ui'
+import { usePathname } from 'next/navigation.js'
 
 export interface ChatNavLinkProps {
   /**
@@ -12,8 +13,10 @@ export interface ChatNavLinkProps {
 }
 
 /**
- * Renders a link to the chat view at the top of the Payload admin nav
- * sidebar. Mounted via `admin.components.beforeNavLinks`.
+ * Renders a link to the chat view styled like Payload's built-in nav links
+ * (matches the `nav__link` / `nav__link-label` structure rendered by
+ * `DefaultNavClient`, including the active-state indicator). Mounted via
+ * `admin.components.beforeNavLinks`.
  */
 export function ChatNavLink({ path = '/chat' }: ChatNavLinkProps) {
   const {
@@ -21,49 +24,39 @@ export function ChatNavLink({ path = '/chat' }: ChatNavLinkProps) {
       routes: { admin: adminRoute },
     },
   } = useConfig()
+  const pathname = usePathname()
 
   const href = `${adminRoute}${path}`
+  const isActive = pathname
+    ? pathname === href || (pathname.startsWith(href) && pathname[href.length] === '/')
+    : false
+
+  const label = (
+    <>
+      {isActive && <div className="nav__link-indicator" />}
+      <span className="nav__link-label">Chat Agent</span>
+    </>
+  )
+
+  if (isActive) {
+    return (
+      <div aria-label="Open chat assistant" className="nav__link" id="nav-chat-agent">
+        {label}
+      </div>
+    )
+  }
 
   return (
     <Link
       aria-label="Open chat assistant"
       className="nav__link"
       href={href}
-      style={{
-        alignItems: 'center',
-        color: 'var(--theme-elevation-800)',
-        display: 'flex',
-        gap: '10px',
-        padding: '8px 0',
-        textDecoration: 'none',
-      }}
+      id="nav-chat-agent"
+      prefetch={false}
     >
-      <MessageIcon />
-      <span>Chat</span>
+      {label}
     </Link>
   )
 }
 
 export default ChatNavLink
-
-// Geist "message" icon — https://github.com/jarvis394/geist-icons/blob/main/source/message.svg
-function MessageIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      data-testid="geist-icon"
-      height="16"
-      strokeLinejoin="round"
-      style={{ color: 'currentcolor', flexShrink: 0 }}
-      viewBox="0 0 16 16"
-      width="16"
-    >
-      <path
-        clipRule="evenodd"
-        d="M2.891 10.403l.092.229c.246.613.517 1.473.517 2.368 0 .359-.044.713-.112 1.05a7.162 7.162 0 002.322-1.297l.515-.43.663.097c.36.052.732.08 1.112.08 3.784 0 6.5-2.644 6.5-5.5S11.784 1.5 8 1.5 1.5 4.144 1.5 7c0 1.182.442 2.293 1.231 3.215l.16.188zm-.078 5.362C1.761 16 1 16 1 16s.433-.69.73-1.563C1.882 13.983 2 13.48 2 13c0-.617-.193-1.27-.409-1.81C.591 10.022 0 8.572 0 7c0-3.866 3.582-7 8-7s8 3.134 8 7-3.582 7-8 7c-.453 0-.897-.033-1.33-.096A8.656 8.656 0 015 15a9.572 9.572 0 01-2.187.765z"
-        fill="currentColor"
-        fillRule="evenodd"
-      />
-    </svg>
-  )
-}

--- a/chat-agent/src/ui/ChatNavLinkServer.test.tsx
+++ b/chat-agent/src/ui/ChatNavLinkServer.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@payloadcms/ui', () => ({
+  Link: ({ children, href, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+  useConfig: () => ({
+    config: { routes: { admin: '/admin' } },
+  }),
+}))
+
+const { default: ChatNavLinkServer } = await import('./ChatNavLinkServer.js')
+
+function renderServerComponent(jsx: any) {
+  // Server components are async functions returning JSX. We await them,
+  // then render the result with @testing-library/react.
+  return render(jsx)
+}
+
+describe('ChatNavLinkServer', () => {
+  afterEach(cleanup)
+
+  it('renders the nav link for an authenticated user with no custom access', async () => {
+    const jsx = await ChatNavLinkServer({
+      payload: { config: { custom: { chatAgent: {} } } },
+      user: { id: 'u1' },
+    } as any)
+
+    renderServerComponent(jsx)
+    expect(screen.getByRole('link', { name: /open chat assistant/i })).toBeTruthy()
+  })
+
+  it('hides the nav link when user is null', async () => {
+    const jsx = await ChatNavLinkServer({
+      payload: { config: { custom: { chatAgent: {} } } },
+      user: undefined,
+    } as any)
+
+    expect(jsx).toBeNull()
+  })
+
+  it('hides the nav link when custom access returns false', async () => {
+    const jsx = await ChatNavLinkServer({
+      payload: {
+        config: {
+          custom: { chatAgent: { access: () => false } },
+        },
+      },
+      user: { id: 'u1' },
+    } as any)
+
+    expect(jsx).toBeNull()
+  })
+
+  it('shows the nav link when custom access returns true', async () => {
+    const jsx = await ChatNavLinkServer({
+      payload: {
+        config: {
+          custom: { chatAgent: { access: () => true } },
+        },
+      },
+      user: { id: 'u1' },
+    } as any)
+
+    renderServerComponent(jsx)
+    expect(screen.getByRole('link', { name: /open chat assistant/i })).toBeTruthy()
+  })
+
+  it('forwards the path prop to ChatNavLink', async () => {
+    const jsx = await ChatNavLinkServer({
+      path: '/assistant',
+      payload: {
+        config: { custom: { chatAgent: {} } },
+      },
+      user: { id: 'u1' },
+    } as any)
+
+    renderServerComponent(jsx)
+    const link = screen.getByRole('link', { name: /open chat assistant/i })
+    expect(link.getAttribute('href')).toBe('/admin/assistant')
+  })
+})

--- a/chat-agent/src/ui/ChatNavLinkServer.test.tsx
+++ b/chat-agent/src/ui/ChatNavLinkServer.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@payloadcms/ui', () => ({
-  Link: ({ children, href, ...rest }: any) => (
+  Link: ({ children, href, prefetch: _prefetch, ...rest }: any) => (
     <a href={href} {...rest}>
       {children}
     </a>
@@ -11,6 +11,10 @@ vi.mock('@payloadcms/ui', () => ({
   useConfig: () => ({
     config: { routes: { admin: '/admin' } },
   }),
+}))
+
+vi.mock('next/navigation.js', () => ({
+  usePathname: () => '/admin',
 }))
 
 const { default: ChatNavLinkServer } = await import('./ChatNavLinkServer.js')

--- a/chat-agent/src/ui/ChatNavLinkServer.tsx
+++ b/chat-agent/src/ui/ChatNavLinkServer.tsx
@@ -1,5 +1,6 @@
 import type { ServerProps } from 'payload'
 
+import { isPluginAccessAllowed } from '../access.js'
 import ChatNavLink from './ChatNavLink.js'
 
 interface ChatNavLinkServerProps extends ServerProps {
@@ -14,11 +15,7 @@ interface ChatNavLinkServerProps extends ServerProps {
  * from the admin nav sidebar.
  */
 export default async function ChatNavLinkServer({ path, payload, user }: ChatNavLinkServerProps) {
-  const chatAgent = (payload as any).config?.custom?.chatAgent
-  const access = chatAgent?.access as ((req: any) => boolean | Promise<boolean>) | undefined
-
-  const allowed = access ? await access({ payload, user }) : !!user
-  if (!allowed) {
+  if (!(await isPluginAccessAllowed({ payload, user }))) {
     return null
   }
 

--- a/chat-agent/src/ui/ChatNavLinkServer.tsx
+++ b/chat-agent/src/ui/ChatNavLinkServer.tsx
@@ -1,0 +1,26 @@
+import type { ServerProps } from 'payload'
+
+import ChatNavLink from './ChatNavLink.js'
+
+interface ChatNavLinkServerProps extends ServerProps {
+  /** Admin route path for the chat view (forwarded to the client component). */
+  path?: string
+}
+
+/**
+ * Server wrapper for the ChatNavLink component. Checks the plugin's `access`
+ * function (stored in `payload.config.custom.chatAgent.access`) before
+ * rendering. If the user is not allowed, returns `null` so the link is hidden
+ * from the admin nav sidebar.
+ */
+export default async function ChatNavLinkServer({ path, payload, user }: ChatNavLinkServerProps) {
+  const chatAgent = (payload as any).config?.custom?.chatAgent
+  const access = chatAgent?.access as ((req: any) => boolean | Promise<boolean>) | undefined
+
+  const allowed = access ? await access({ payload, user }) : !!user
+  if (!allowed) {
+    return null
+  }
+
+  return <ChatNavLink path={path} />
+}

--- a/chat-agent/src/ui/ChatViewServer.test.tsx
+++ b/chat-agent/src/ui/ChatViewServer.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./ChatView.js', () => ({
+  default: () => <div data-testid="chat-view" />,
+}))
+
+const { default: ChatViewServer } = await import('./ChatViewServer.js')
+
+function makeReq(access?: (req: any) => boolean | Promise<boolean>) {
+  const payload: any = {
+    config: { custom: { chatAgent: access ? { access } : {} } },
+    find: async () => ({ docs: [] }),
+    findByID: async () => ({ messages: [] }),
+  }
+  const req: any = {
+    payload,
+    searchParams: new URLSearchParams(),
+    user: { id: 'u1' },
+  }
+  payload.req = req
+  return req
+}
+
+describe('ChatViewServer', () => {
+  afterEach(cleanup)
+
+  it('renders the chat view when access is allowed', async () => {
+    const jsx = await ChatViewServer({
+      initPageResult: { req: makeReq(() => true) },
+    } as any)
+
+    render(jsx as any)
+    expect(screen.getByTestId('chat-view')).toBeTruthy()
+  })
+
+  it('renders a not-authorized message when plugin access() denies', async () => {
+    const jsx = await ChatViewServer({
+      initPageResult: { req: makeReq(() => false) },
+    } as any)
+
+    render(jsx as any)
+    expect(screen.getByText(/not authorized/i)).toBeTruthy()
+    expect(screen.queryByTestId('chat-view')).toBeNull()
+  })
+})

--- a/chat-agent/src/ui/ChatViewServer.tsx
+++ b/chat-agent/src/ui/ChatViewServer.tsx
@@ -1,11 +1,21 @@
 import type { AdminViewServerProps } from 'payload'
 
+import { isPluginAccessAllowed } from '../access.js'
 import { CONVERSATIONS_SLUG } from '../conversations.js'
 import ChatView from './ChatView.js'
 
 export default async function ChatViewServer({ initPageResult: { req } }: AdminViewServerProps) {
   const conversationId = req.searchParams.get('conversation') ?? undefined
   const { payload, user } = req
+
+  if (!(await isPluginAccessAllowed(req))) {
+    return (
+      <div style={{ padding: '2rem' }}>
+        <h2>Not authorized</h2>
+        <p>You do not have access to the chat agent.</p>
+      </div>
+    )
+  }
 
   // Fetch the conversation list server-side so the sidebar renders immediately
   const { docs: conversations } = user

--- a/chat-agent/src/ui/ModeSelector.tsx
+++ b/chat-agent/src/ui/ModeSelector.tsx
@@ -5,7 +5,7 @@ import type { AgentMode } from '../types.js'
 const MODE_LABELS: Record<AgentMode, string> = {
   ask: 'Confirm writes',
   read: 'Read only',
-  'read-write': 'Auto write',
+  'read-write': 'Read & write',
   superuser: 'Superuser (bypass permissions)',
 }
 


### PR DESCRIPTION
## Summary

Adds a new `@jhb.software/payload-chat-agent` plugin — an AI chat agent for the Payload admin panel, provider-agnostic via the Vercel AI SDK.

## Features

- **Admin chat view** at `/admin/chat` with streaming responses, markdown rendering, and persisted conversations.
- **Nav sidebar link** (`beforeNavLinks`) — labeled "Chat Agent", uses native Payload styling, opt out with `navLink: false`.
- **Full CRUD via natural language** — the agent reads schemas from Payload collections/globals and calls the Local API.
- **Custom endpoint discovery** — any endpoint with a `custom.description` is exposed as a tool.
- **Provider-agnostic model factory** — pass `(id) => model` so you can plug in Anthropic, OpenAI, Google, Bedrock, etc. Multiple providers and per-request model selection supported.
- **Agent modes** (`read` / `ask` / `read-write` / `superuser`) with per-mode access functions. `ask` mode shows a confirmation dialog before every write.
- **Plugin-level `access`** gates every surface: admin view, nav link, streaming endpoint, modes, models, and conversation CRUD. Denied users get 401s and a "Not authorized" admin view.
- **Localized fields** read/written when the request carries a locale.
- **File uploads** — system prompt instructs the agent how to use upload-enabled collections.

## Test plan

- [ ] `pnpm --filter @jhb.software/payload-chat-agent test` passes (207 tests)
- [ ] Start the `chat-agent/dev` app, sign in, open `/admin/chat`, verify streaming + tool calls
- [ ] Switch between modes, confirm `ask` prompts on writes and `read` hides write tools
- [ ] Set `access: () => false` and confirm every `/api/chat-agent/*` route returns 401 and the admin view shows "Not authorized"
- [ ] Configure `availableModels` and verify the model picker + per-request routing