### PR TITLE
feat(chat-agent)!: make AI provider agnostic via model factory

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -31,3 +31,6 @@
 - Add markdown rendering for assistant messages using `react-markdown` and `remark-gfm`
 - Include admin panel URL patterns in the system prompt so the agent can produce clickable links to documents it creates, updates, or finds (respects `config.routes.admin`)
 - Open markdown links in a new tab so clicking through to the admin panel preserves the current chat conversation
+- Restore the persisted model selection when resuming a conversation on page reload (previously the model selector snapped back to the default)
+- Apply model/mode changes to the next request immediately instead of the transport being cached at mount, which previously caused switching the model mid-conversation to have no effect until a full page reload
+- Persist the conversation when a stream errors so the user's message survives a reload and they can retry without retyping (the error itself stays ephemeral)

--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **BREAKING**: Make the plugin AI-provider agnostic. The `apiKey` option has been removed and replaced with a required `model` factory of type `(modelId: string) => LanguageModel`. The `@ai-sdk/anthropic` package is no longer a dependency of the plugin — install whichever `@ai-sdk/*` provider you want (Anthropic, OpenAI, Google, Mistral, …) and pass the model instance through the factory. The plugin no longer reads `ANTHROPIC_API_KEY` (or any other key) from `process.env`; configuration must come entirely from the plugin options.
+
+  Migration:
+
+  ```diff
+  + import { createAnthropic } from '@ai-sdk/anthropic'
+  + const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+    chatAgentPlugin({
+  -   apiKey: process.env.ANTHROPIC_API_KEY,
+      defaultModel: 'claude-sonnet-4-20250514',
+  +   model: (id) => anthropic(id),
+    })
+  ```
+
+  See the README for OpenAI and mixed-provider examples.
+
 - Add configurable model selection via `defaultModel` and `availableModels` options, with a model selector dropdown in the chat UI (shown when 2+ models are available)
 - Add markdown rendering for assistant messages using `react-markdown` and `remark-gfm`
 - Include admin panel URL patterns in the system prompt so the agent can produce clickable links to documents it creates, updates, or finds (respects `config.routes.admin`)

--- a/chat-agent/README.md
+++ b/chat-agent/README.md
@@ -1,6 +1,8 @@
 # Chat Agent Plugin for Payload CMS
 
-A [Payload CMS](https://payloadcms.com/) plugin that adds an AI chat agent for reading, creating, and updating content. It provides an admin panel chat view where users can interact with their content through natural language, powered by Claude and the Payload Local API.
+A [Payload CMS](https://payloadcms.com/) plugin that adds an AI chat agent for reading, creating, and updating content. It provides an admin panel chat view where users can interact with their content through natural language, powered by the Payload Local API.
+
+The plugin is **provider-agnostic**: bring your own LLM provider via the [Vercel AI SDK](https://sdk.vercel.ai/) — Anthropic, OpenAI, Google, Mistral, Bedrock, and others all work out of the box. You can also wire up multiple providers at once and let users pick a model from a dropdown.
 
 ## Features
 
@@ -22,16 +24,27 @@ pnpm add @jhb.software/payload-chat-agent
 
 ## Setup
 
-Install the plugin and add it to your Payload config:
+Install the plugin together with whichever Vercel AI SDK provider package you want to use:
+
+```bash
+pnpm add @jhb.software/payload-chat-agent @ai-sdk/anthropic
+# or
+pnpm add @jhb.software/payload-chat-agent @ai-sdk/openai
+```
+
+Then add it to your Payload config and pass a `model` factory that resolves a model id to a `LanguageModel` instance:
 
 ```ts
 import { chatAgentPlugin } from '@jhb.software/payload-chat-agent'
+import { createAnthropic } from '@ai-sdk/anthropic'
+
+const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 
 export default buildConfig({
   plugins: [
     chatAgentPlugin({
-      apiKey: process.env.ANTHROPIC_API_KEY,
       defaultModel: 'claude-sonnet-4-20250514',
+      model: (id) => anthropic(id),
     }),
   ],
 })
@@ -39,20 +52,60 @@ export default buildConfig({
 
 The plugin will register a chat view at `/admin/chat` and a streaming chat endpoint at `/api/chat-agent/chat`.
 
+> **Heads up — no env-var fallbacks.** The plugin never reads provider API keys from `process.env` itself. Pass them explicitly through your `model` factory so the configuration is fully owned by your Payload config.
+
 ## Configuration
 
 ### Plugin Options
 
-| Option            | Type                           | Required | Description                                                                     |
-| ----------------- | ------------------------------ | -------- | ------------------------------------------------------------------------------- |
-| `defaultModel`    | `string`                       | Yes      | Claude model ID used when no per-request override is provided                   |
-| `availableModels` | `ModelOption[]`                | No       | Models the user can choose from in the chat UI (selector shown when 2+ entries) |
-| `apiKey`          | `string`                       | No       | Anthropic API key. Falls back to `ANTHROPIC_API_KEY` env var                    |
-| `systemPrompt`    | `string`                       | No       | Custom text prepended to the auto-generated system prompt                       |
-| `access`          | `(req) => boolean`             | No       | Override the default auth check (default: requires authenticated user)          |
-| `maxSteps`        | `number`                       | No       | Maximum tool-use loop steps per request (default: 20)                           |
-| `superuserAccess` | `boolean \| (req) => boolean`  | No       | Controls who can use superuser mode (`overrideAccess: true`)                    |
-| `adminView`       | `false \| { path, Component }` | No       | Customize or disable the admin chat view                                        |
+| Option            | Type                                      | Required | Description                                                                                              |
+| ----------------- | ----------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| `model`           | `(modelId: string) => LanguageModel`      | Yes      | Resolves a model id to a Vercel AI SDK `LanguageModel`. Called once per request with the selected model |
+| `defaultModel`    | `string`                                  | Yes      | Model id used when no per-request override is provided                                                   |
+| `availableModels` | `ModelOption[]`                           | No       | Models the user can choose from in the chat UI (selector shown when 2+ entries)                          |
+| `systemPrompt`    | `string`                                  | No       | Custom text prepended to the auto-generated system prompt                                                |
+| `access`          | `(req) => boolean`                        | No       | Override the default auth check (default: requires authenticated user)                                   |
+| `maxSteps`        | `number`                                  | No       | Maximum tool-use loop steps per request (default: 20)                                                    |
+| `superuserAccess` | `boolean \| (req) => boolean`             | No       | Controls who can use superuser mode (`overrideAccess: true`)                                             |
+| `adminView`       | `false \| { path, Component }`            | No       | Customize or disable the admin chat view                                                                 |
+
+### Using OpenAI
+
+```ts
+import { chatAgentPlugin } from '@jhb.software/payload-chat-agent'
+import { createOpenAI } from '@ai-sdk/openai'
+
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+chatAgentPlugin({
+  defaultModel: 'gpt-4o-mini',
+  model: (id) => openai(id),
+})
+```
+
+### Mixing providers
+
+The factory pattern lets you wire up multiple providers in a single install. Route each model id to the appropriate provider — typically by id prefix:
+
+```ts
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { createOpenAI } from '@ai-sdk/openai'
+
+const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+chatAgentPlugin({
+  defaultModel: 'claude-sonnet-4-20250514',
+  availableModels: [
+    { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
+    { id: 'gpt-4o', label: 'GPT-4o' },
+    { id: 'gpt-4o-mini', label: 'GPT-4o mini' },
+  ],
+  model: (id) => (id.startsWith('claude-') ? anthropic(id) : openai(id)),
+})
+```
+
+> **Tool-calling support is per-model, not per-provider.** This plugin relies heavily on tool calls, so older or smaller models may perform poorly. Stick to tool-capable models (e.g. `claude-sonnet-4`, `gpt-4o`, `gpt-4o-mini`).
 
 ### Model Selection
 
@@ -66,6 +119,7 @@ chatAgentPlugin({
     { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
     { id: 'claude-opus-4-20250514', label: 'Opus 4' },
   ],
+  model: (id) => anthropic(id),
 })
 ```
 

--- a/chat-agent/dev/package.json
+++ b/chat-agent/dev/package.json
@@ -15,6 +15,8 @@
     "generate:importmap": "cross-env PAYLOAD_CONFIG_PATH=./src/payload.config.ts payload generate:importmap"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.68",
+    "@ai-sdk/openai": "^3.0.52",
     "@ai-sdk/react": "^3.0.156",
     "@jhb.software/payload-chat-agent": "workspace:*",
     "@payloadcms/db-mongodb": "^3.81.0",

--- a/chat-agent/dev/src/components/ChatClient.tsx
+++ b/chat-agent/dev/src/components/ChatClient.tsx
@@ -17,11 +17,16 @@ import type { MessageMetadata } from '@jhb.software/payload-chat-agent'
 // ---------------------------------------------------------------------------
 // Models
 // ---------------------------------------------------------------------------
+//
+// Per-million-token rates (USD) used purely for the dev app's cost display.
+// Add a row here for any model you wire up in dev/src/payload.config.ts.
 
 const MODELS = [
-  { id: 'claude-haiku-4-5-20251001', label: 'Haiku', inputRate: 0.8, outputRate: 4 },
-  { id: 'claude-sonnet-4-20250514', label: 'Sonnet', inputRate: 3, outputRate: 15 },
-  { id: 'claude-opus-4-20250514', label: 'Opus', inputRate: 15, outputRate: 75 },
+  { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', inputRate: 0.8, outputRate: 4 },
+  { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4', inputRate: 3, outputRate: 15 },
+  { id: 'claude-opus-4-20250514', label: 'Claude Opus 4', inputRate: 15, outputRate: 75 },
+  { id: 'gpt-4o-mini', label: 'GPT-4o mini', inputRate: 0.15, outputRate: 0.6 },
+  { id: 'gpt-4o', label: 'GPT-4o', inputRate: 2.5, outputRate: 10 },
 ] as const
 
 // ---------------------------------------------------------------------------

--- a/chat-agent/dev/src/components/ChatView.tsx
+++ b/chat-agent/dev/src/components/ChatView.tsx
@@ -3,7 +3,7 @@ import { DefaultTemplate } from '@payloadcms/next/templates'
 import { Gutter } from '@payloadcms/ui'
 import type { AdminViewServerProps } from 'payload'
 
-import ChatClient from './ChatClient'
+import ChatClient from './ChatClient.js'
 
 const ChatView: React.FC<AdminViewServerProps> = ({ initPageResult, params, searchParams }) => {
   return (

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -131,11 +131,11 @@ export default buildConfig({
 
     if (existingPosts.docs.length === 0) {
       const posts = [
-        { title: 'Getting Started with Payload CMS', slug: 'getting-started', status: 'published' },
-        { title: 'Advanced Field Configuration', slug: 'advanced-fields', status: 'published' },
-        { title: 'Building Custom Endpoints', slug: 'custom-endpoints', status: 'draft' },
-        { title: 'Authentication & Access Control', slug: 'auth-access', status: 'published' },
-        { title: 'Plugin Development Guide', slug: 'plugin-dev', status: 'draft' },
+        { title: 'Getting Started with Payload CMS', slug: 'getting-started', status: 'published' as const },
+        { title: 'Advanced Field Configuration', slug: 'advanced-fields', status: 'published' as const },
+        { title: 'Building Custom Endpoints', slug: 'custom-endpoints', status: 'draft' as const },
+        { title: 'Authentication & Access Control', slug: 'auth-access', status: 'published' as const },
+        { title: 'Plugin Development Guide', slug: 'plugin-dev', status: 'draft' as const },
       ]
       for (const post of posts) {
         await payload.create({ collection: 'posts', data: post })

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -1,3 +1,5 @@
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { createOpenAI } from '@ai-sdk/openai'
 import { chatAgentPlugin } from '@jhb.software/payload-chat-agent'
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
@@ -6,6 +8,37 @@ import { buildConfig } from 'payload'
 import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// ---------------------------------------------------------------------------
+// Multi-provider model factory
+// ---------------------------------------------------------------------------
+//
+// The chat-agent plugin is provider-agnostic: install whichever `@ai-sdk/*`
+// package you want and pass a `model` factory. This dev app demonstrates the
+// most flexible setup — both Anthropic and OpenAI providers wired up at once,
+// routed by the model id prefix.
+//
+// Set ANTHROPIC_API_KEY and/or OPENAI_API_KEY in your env. Each provider is
+// only instantiated lazily so you don't need both keys to test one provider.
+
+const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+const resolveModel = (id: string) => {
+  if (id.startsWith('claude-')) {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      throw new Error('ANTHROPIC_API_KEY is not set — required to use Claude models in this dev app')
+    }
+    return anthropic(id)
+  }
+  if (id.startsWith('gpt-') || id.startsWith('o1-') || id.startsWith('o3-')) {
+    if (!process.env.OPENAI_API_KEY) {
+      throw new Error('OPENAI_API_KEY is not set — required to use OpenAI models in this dev app')
+    }
+    return openai(id)
+  }
+  throw new Error(`Unknown model id "${id}". Add a routing rule in dev/src/payload.config.ts.`)
+}
 
 export default buildConfig({
   admin: {
@@ -126,7 +159,14 @@ export default buildConfig({
   },
   plugins: [
     chatAgentPlugin({
+      availableModels: [
+        { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
+        { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
+        { id: 'gpt-4o-mini', label: 'GPT-4o mini' },
+        { id: 'gpt-4o', label: 'GPT-4o' },
+      ],
       defaultModel: 'claude-haiku-4-5-20251001',
+      model: resolveModel,
       superuserAccess: true,
     }),
   ],

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -31,13 +31,15 @@ const resolveModel = (id: string) => {
     }
     return anthropic(id)
   }
-  if (id.startsWith('gpt-') || id.startsWith('o1-') || id.startsWith('o3-')) {
+  if (id.startsWith('gpt-')) {
     if (!process.env.OPENAI_API_KEY) {
       throw new Error('OPENAI_API_KEY is not set — required to use OpenAI models in this dev app')
     }
     return openai(id)
   }
-  throw new Error(`Unknown model id "${id}". Add a routing rule in dev/src/payload.config.ts.`)
+  throw new Error(
+    `Unknown model id "${id}". Add the id to availableModels and a routing rule in dev/src/payload.config.ts.`,
+  )
 }
 
 export default buildConfig({

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -27,7 +27,9 @@ const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
 const resolveModel = (id: string) => {
   if (id.startsWith('claude-')) {
     if (!process.env.ANTHROPIC_API_KEY) {
-      throw new Error('ANTHROPIC_API_KEY is not set — required to use Claude models in this dev app')
+      throw new Error(
+        'ANTHROPIC_API_KEY is not set — required to use Claude models in this dev app',
+      )
     }
     return anthropic(id)
   }
@@ -131,10 +133,22 @@ export default buildConfig({
 
     if (existingPosts.docs.length === 0) {
       const posts = [
-        { title: 'Getting Started with Payload CMS', slug: 'getting-started', status: 'published' as const },
-        { title: 'Advanced Field Configuration', slug: 'advanced-fields', status: 'published' as const },
+        {
+          title: 'Getting Started with Payload CMS',
+          slug: 'getting-started',
+          status: 'published' as const,
+        },
+        {
+          title: 'Advanced Field Configuration',
+          slug: 'advanced-fields',
+          status: 'published' as const,
+        },
         { title: 'Building Custom Endpoints', slug: 'custom-endpoints', status: 'draft' as const },
-        { title: 'Authentication & Access Control', slug: 'auth-access', status: 'published' as const },
+        {
+          title: 'Authentication & Access Control',
+          slug: 'auth-access',
+          status: 'published' as const,
+        },
         { title: 'Plugin Development Guide', slug: 'plugin-dev', status: 'draft' as const },
       ]
       for (const post of posts) {

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -9,18 +9,6 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// ---------------------------------------------------------------------------
-// Multi-provider model factory
-// ---------------------------------------------------------------------------
-//
-// The chat-agent plugin is provider-agnostic: install whichever `@ai-sdk/*`
-// package you want and pass a `model` factory. This dev app demonstrates the
-// most flexible setup — both Anthropic and OpenAI providers wired up at once,
-// routed by the model id prefix.
-//
-// Set ANTHROPIC_API_KEY and/or OPENAI_API_KEY in your env. Each provider is
-// only instantiated lazily so you don't need both keys to test one provider.
-
 const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
 const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
 
@@ -179,11 +167,16 @@ export default buildConfig({
         { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
         { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
         { id: 'gpt-4o-mini', label: 'GPT-4o mini' },
-        { id: 'gpt-4o', label: 'GPT-4o' },
+        { id: 'gpt-5-nano', label: 'GPT-5 nano' },
       ],
       defaultModel: 'claude-haiku-4-5-20251001',
       model: resolveModel,
-      superuserAccess: true,
+      modes: {
+        default: 'read',
+        access: {
+          superuser: () => true,
+        },
+      },
     }),
   ],
 })

--- a/chat-agent/package.json
+++ b/chat-agent/package.json
@@ -29,7 +29,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.68",
     "ai": "^6.0.154",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",

--- a/chat-agent/pnpm-lock.yaml
+++ b/chat-agent/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^3.0.68
-        version: 3.0.68(zod@3.25.76)
       '@payloadcms/ui':
         specifier: ^3.81.0
         version: 3.82.1(@types/react@19.2.14)(monaco-editor@0.55.1)(next@15.4.11(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(payload@3.82.1(graphql@16.13.2)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -84,6 +81,12 @@ importers:
 
   dev:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.68
+        version: 3.0.68(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^3.0.52
+        version: 3.0.52(zod@3.25.76)
       '@ai-sdk/react':
         specifier: ^3.0.156
         version: 3.0.158(react@19.2.4)(zod@3.25.76)
@@ -141,6 +144,12 @@ packages:
 
   '@ai-sdk/gateway@3.0.95':
     resolution: {integrity: sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.52':
+    resolution: {integrity: sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4592,6 +4601,12 @@ snapshots:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/openai@3.0.52(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':

--- a/chat-agent/src/conversations.test.ts
+++ b/chat-agent/src/conversations.test.ts
@@ -66,21 +66,30 @@ describe('conversationsCollection', () => {
 
 describe('chatAgentPlugin conversations', () => {
   it('registers the chat-conversations collection', () => {
-    const plugin = chatAgentPlugin({ apiKey: 'test', defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: () => ({}) as any,
+    })
     const result = plugin({ collections: [], endpoints: [] })
     const slugs = result.collections.map((c: any) => c.slug)
     expect(slugs).toContain(CONVERSATIONS_SLUG)
   })
 
   it('preserves existing collections', () => {
-    const plugin = chatAgentPlugin({ apiKey: 'test', defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: () => ({}) as any,
+    })
     const existing = { slug: 'posts', fields: [] }
     const result = plugin({ collections: [existing], endpoints: [] })
     expect(result.collections).toContainEqual(existing)
   })
 
   it('registers conversation CRUD endpoints', () => {
-    const plugin = chatAgentPlugin({ apiKey: 'test', defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: () => ({}) as any,
+    })
     const result = plugin({ endpoints: [] })
     const paths = result.endpoints.map((ep: any) => `${ep.method}:${ep.path}`)
     expect(paths).toContain('get:/chat-agent/chat/conversations')

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -1,6 +1,25 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { chatAgentPlugin, validateMessages } from './index.js'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a fake model factory that records the model ids it was asked to
+ * resolve and returns a sentinel object. The sentinel intentionally is not a
+ * real LanguageModel — tests that go all the way to streamText will throw,
+ * which means the factory was at least invoked.
+ */
+function makeModelFactory() {
+  const calls: string[] = []
+  const factory = vi.fn((id: string) => {
+    calls.push(id)
+    return { id, __fake: true } as any
+  })
+  return { calls, factory }
+}
 
 // ---------------------------------------------------------------------------
 // validateMessages
@@ -49,7 +68,10 @@ describe('validateMessages', () => {
 
 describe('chatAgentPlugin', () => {
   it('adds /chat-agent/chat endpoint to config', () => {
-    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
     const result = plugin({ endpoints: [] })
     const chatEndpoint = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat')
     expect(chatEndpoint).toBeDefined()
@@ -57,7 +79,10 @@ describe('chatAgentPlugin', () => {
   })
 
   it('preserves existing endpoints', () => {
-    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
     const existing = { handler: () => {}, method: 'get', path: '/custom' }
     const result = plugin({ endpoints: [existing] })
     expect(result.endpoints[0]).toBe(existing)
@@ -65,7 +90,10 @@ describe('chatAgentPlugin', () => {
   })
 
   it('returns 401 when no user and no custom access', async () => {
-    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
     const result = plugin({ endpoints: [] })
     const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
 
@@ -74,25 +102,52 @@ describe('chatAgentPlugin', () => {
     expect(await response.json()).toEqual({ error: 'Unauthorized' })
   })
 
-  it('returns 500 when no API key configured', async () => {
-    const original = process.env.ANTHROPIC_API_KEY
-    delete process.env.ANTHROPIC_API_KEY
+  it('returns 500 when no model factory is configured', async () => {
+    // Cast through unknown to bypass the type checker — we're verifying runtime
+    // behavior when a JS consumer omits the required option.
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+    } as unknown as Parameters<typeof chatAgentPlugin>[0])
+    const result = plugin({ endpoints: [] })
+    const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
 
+    const response = await handler({
+      json: () =>
+        Promise.resolve({
+          messages: [
+            {
+              id: '1',
+              parts: [{ type: 'text', text: 'test' }],
+              role: 'user',
+            },
+          ],
+        }),
+      payload: { config: { collections: [], globals: [] } },
+      user: { id: 1 },
+    })
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.error).toContain('`model` option')
+  })
+
+  it('does not read ANTHROPIC_API_KEY from the environment', async () => {
+    // Ensure the plugin no longer falls back to env vars: if it did, this test
+    // would pass even without a `model` option, but our config-only contract
+    // requires the misconfiguration error regardless of env state.
+    const original = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = 'sk-should-be-ignored'
     try {
-      const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+      const plugin = chatAgentPlugin({
+        defaultModel: 'claude-sonnet-4-20250514',
+      } as unknown as Parameters<typeof chatAgentPlugin>[0])
       const result = plugin({ endpoints: [] })
       const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
 
       const response = await handler({
         json: () =>
           Promise.resolve({
-            messages: [
-              {
-                id: '1',
-                parts: [{ type: 'text', text: 'test' }],
-                role: 'user',
-              },
-            ],
+            messages: [{ id: '1', parts: [{ type: 'text', text: 'hi' }], role: 'user' }],
           }),
         payload: { config: { collections: [], globals: [] } },
         user: { id: 1 },
@@ -100,16 +155,22 @@ describe('chatAgentPlugin', () => {
 
       expect(response.status).toBe(500)
       const body = await response.json()
-      expect(body.error).toContain('API key')
+      expect(body.error).toContain('`model` option')
+      expect(body.error).not.toContain('ANTHROPIC')
     } finally {
-      if (original !== undefined) {
+      if (original === undefined) {
+        delete process.env.ANTHROPIC_API_KEY
+      } else {
         process.env.ANTHROPIC_API_KEY = original
       }
     }
   })
 
   it('returns 400 for invalid JSON body', async () => {
-    const plugin = chatAgentPlugin({ apiKey: 'test-key', defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
     const result = plugin({ endpoints: [] })
     const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
 
@@ -124,7 +185,10 @@ describe('chatAgentPlugin', () => {
   })
 
   it('returns 400 for empty messages array', async () => {
-    const plugin = chatAgentPlugin({ apiKey: 'test-key', defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
     const result = plugin({ endpoints: [] })
     const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
 
@@ -146,7 +210,10 @@ describe('chatAgentPlugin', () => {
 
 describe('chatAgentPlugin admin view', () => {
   it('auto-registers the chat view at /chat by default', () => {
-    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
     const result = plugin({ endpoints: [] })
 
     const chatView = result.admin?.components?.views?.chat
@@ -156,7 +223,10 @@ describe('chatAgentPlugin admin view', () => {
   })
 
   it('preserves existing admin views', () => {
-    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
     const result = plugin({
       admin: {
         components: {
@@ -176,6 +246,7 @@ describe('chatAgentPlugin admin view', () => {
     const plugin = chatAgentPlugin({
       adminView: false,
       defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
     })
     const result = plugin({ endpoints: [] })
 
@@ -186,6 +257,7 @@ describe('chatAgentPlugin admin view', () => {
     const plugin = chatAgentPlugin({
       adminView: { path: '/assistant' },
       defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
     })
     const result = plugin({ endpoints: [] })
 
@@ -196,6 +268,7 @@ describe('chatAgentPlugin admin view', () => {
     const plugin = chatAgentPlugin({
       adminView: { Component: './my-custom/ChatUI' },
       defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
     })
     const result = plugin({ endpoints: [] })
 
@@ -210,9 +283,9 @@ describe('chatAgentPlugin admin view', () => {
 describe('chatAgentPlugin model validation', () => {
   it('rejects model not in available list', async () => {
     const plugin = chatAgentPlugin({
-      apiKey: 'test-key',
       availableModels: [{ id: 'claude-sonnet-4-20250514', label: 'Sonnet' }],
       defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
     })
     const result = plugin({ endpoints: [] })
     const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
@@ -233,7 +306,11 @@ describe('chatAgentPlugin model validation', () => {
   })
 
   it('allows model when no available list is configured', async () => {
-    const plugin = chatAgentPlugin({ apiKey: 'test-key', defaultModel: 'claude-sonnet-4-20250514' })
+    const { factory } = makeModelFactory()
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: factory,
+    })
     const result = plugin({ endpoints: [] })
     const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
 
@@ -257,12 +334,159 @@ describe('chatAgentPlugin model validation', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Model factory wiring
+// ---------------------------------------------------------------------------
+
+describe('chatAgentPlugin model factory', () => {
+  /**
+   * The chat handler runs validation, then resolves the model via the
+   * user-supplied factory, and finally hands it to streamText. streamText
+   * will throw because our fake model isn't a real LanguageModel — but the
+   * factory must have been invoked first, with the right id. That's the
+   * contract we want to lock in.
+   */
+  it('invokes the factory with the per-request model id when provided', async () => {
+    const { calls, factory } = makeModelFactory()
+    const plugin = chatAgentPlugin({
+      availableModels: [
+        { id: 'claude-sonnet-4-20250514', label: 'Claude' },
+        { id: 'gpt-4o', label: 'GPT-4o' },
+      ],
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: factory,
+    })
+    const handler = plugin({ endpoints: [] }).endpoints.find(
+      (ep: any) => ep.path === '/chat-agent/chat',
+    ).handler
+
+    try {
+      await handler({
+        json: () =>
+          Promise.resolve({
+            messages: [{ id: '1', parts: [{ type: 'text', text: 'hi' }], role: 'user' }],
+            model: 'gpt-4o',
+          }),
+        payload: { config: { collections: [], globals: [] } },
+        user: { id: 1 },
+      })
+    } catch {
+      // streamText will reject because the fake model isn't a real LanguageModel
+    }
+
+    expect(calls).toContain('gpt-4o')
+  })
+
+  it('falls back to defaultModel when no per-request model is supplied', async () => {
+    const { calls, factory } = makeModelFactory()
+    const plugin = chatAgentPlugin({
+      defaultModel: 'gpt-4o-mini',
+      model: factory,
+    })
+    const handler = plugin({ endpoints: [] }).endpoints.find(
+      (ep: any) => ep.path === '/chat-agent/chat',
+    ).handler
+
+    try {
+      await handler({
+        json: () =>
+          Promise.resolve({
+            messages: [{ id: '1', parts: [{ type: 'text', text: 'hi' }], role: 'user' }],
+          }),
+        payload: { config: { collections: [], globals: [] } },
+        user: { id: 1 },
+      })
+    } catch {
+      // streamText rejects on fake model
+    }
+
+    expect(calls).toEqual(['gpt-4o-mini'])
+  })
+
+  it('returns 500 with a clear error when the factory throws', async () => {
+    const plugin = chatAgentPlugin({
+      defaultModel: 'gpt-4o-mini',
+      model: () => {
+        throw new Error('OPENAI_API_KEY is not set')
+      },
+    })
+    const handler = plugin({ endpoints: [] }).endpoints.find(
+      (ep: any) => ep.path === '/chat-agent/chat',
+    ).handler
+
+    const response = await handler({
+      json: () =>
+        Promise.resolve({
+          messages: [{ id: '1', parts: [{ type: 'text', text: 'hi' }], role: 'user' }],
+        }),
+      payload: { config: { collections: [], globals: [] } },
+      user: { id: 1 },
+    })
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.error).toContain('Failed to resolve model "gpt-4o-mini"')
+    expect(body.error).toContain('OPENAI_API_KEY is not set')
+  })
+
+  it('supports routing to different providers based on the model id', async () => {
+    // Mixed-provider scenario: simulate one Anthropic and one OpenAI provider
+    // and verify the handler routes through the user-supplied factory each
+    // time without ever importing a provider package itself.
+    const anthropicCalls: string[] = []
+    const openaiCalls: string[] = []
+    const factory = (id: string) => {
+      if (id.startsWith('claude-')) {
+        anthropicCalls.push(id)
+      } else if (id.startsWith('gpt-')) {
+        openaiCalls.push(id)
+      } else {
+        throw new Error(`Unknown model: ${id}`)
+      }
+      return { id, __fake: true } as any
+    }
+    const plugin = chatAgentPlugin({
+      availableModels: [
+        { id: 'claude-sonnet-4-20250514', label: 'Claude' },
+        { id: 'gpt-4o', label: 'GPT-4o' },
+      ],
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: factory,
+    })
+    const handler = plugin({ endpoints: [] }).endpoints.find(
+      (ep: any) => ep.path === '/chat-agent/chat',
+    ).handler
+
+    for (const modelId of ['claude-sonnet-4-20250514', 'gpt-4o']) {
+      try {
+        await handler({
+          json: () =>
+            Promise.resolve({
+              messages: [{ id: '1', parts: [{ type: 'text', text: 'hi' }], role: 'user' }],
+              model: modelId,
+            }),
+          payload: { config: { collections: [], globals: [] } },
+          user: { id: 1 },
+        })
+      } catch {
+        // Expected — fake model
+      }
+    }
+
+    expect(anthropicCalls).toEqual(['claude-sonnet-4-20250514'])
+    expect(openaiCalls).toEqual(['gpt-4o'])
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Models endpoint
 // ---------------------------------------------------------------------------
 
 describe('chatAgentPlugin models endpoint', () => {
   it('adds /chat-agent/chat/models endpoint', () => {
-    const plugin = chatAgentPlugin({ defaultModel: 'claude-sonnet-4-20250514' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
     const result = plugin({ endpoints: [] })
     const ep = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat/models')
     expect(ep).toBeDefined()
@@ -273,9 +497,10 @@ describe('chatAgentPlugin models endpoint', () => {
     const plugin = chatAgentPlugin({
       availableModels: [
         { id: 'claude-sonnet-4-20250514', label: 'Sonnet' },
-        { id: 'claude-haiku-4-5-20251001', label: 'Haiku' },
+        { id: 'gpt-4o-mini', label: 'GPT-4o mini' },
       ],
       defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
     })
     const result = plugin({ endpoints: [] })
     const ep = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat/models')
@@ -287,13 +512,16 @@ describe('chatAgentPlugin models endpoint', () => {
   })
 
   it('returns empty availableModels list when not configured', async () => {
-    const plugin = chatAgentPlugin({ defaultModel: 'claude-haiku-4-5-20251001' })
+    const plugin = chatAgentPlugin({
+      defaultModel: 'gpt-4o-mini',
+      model: makeModelFactory().factory,
+    })
     const result = plugin({ endpoints: [] })
     const ep = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat/models')
 
     const response = await ep.handler()
     const body = await response.json()
-    expect(body.defaultModel).toBe('claude-haiku-4-5-20251001')
+    expect(body.defaultModel).toBe('gpt-4o-mini')
     expect(body.availableModels).toEqual([])
   })
 })

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -1,6 +1,21 @@
+import { streamText } from 'ai'
 import { describe, expect, it, vi } from 'vitest'
 
 import { chatAgentPlugin, validateMessages } from './index.js'
+
+// Mock the `ai` module so the chat handler doesn't actually try to talk to a
+// provider. We keep every other export real (`convertToModelMessages`,
+// `stepCountIs`, …) and only swap `streamText` for a vi.fn whose return value
+// satisfies the handler's `result.toUIMessageStreamResponse(...)` call.
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai')
+  return {
+    ...actual,
+    streamText: vi.fn(() => ({
+      toUIMessageStreamResponse: () => new Response('ok'),
+    })),
+  }
+})
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -8,9 +23,10 @@ import { chatAgentPlugin, validateMessages } from './index.js'
 
 /**
  * Returns a fake model factory that records the model ids it was asked to
- * resolve and returns a sentinel object. The sentinel intentionally is not a
- * real LanguageModel — tests that go all the way to streamText will throw,
- * which means the factory was at least invoked.
+ * resolve and returns a sentinel `LanguageModel`-shaped object. We never let
+ * the sentinel reach a real provider — `streamText` is mocked above — so
+ * tests can assert on the factory's call log and on the exact instance the
+ * handler hands to `streamText`.
  */
 function makeModelFactory() {
   const calls: string[] = []
@@ -67,6 +83,34 @@ describe('validateMessages', () => {
 // ---------------------------------------------------------------------------
 
 describe('chatAgentPlugin', () => {
+  it('throws at construction when defaultModel is not in availableModels', () => {
+    // A typo or copy-paste mistake here would otherwise produce confusing
+    // runtime behavior: the dropdown would list one set of models while
+    // unsupplied requests silently fall back to a model the UI never offers.
+    // Fail fast at config load time instead.
+    expect(() =>
+      chatAgentPlugin({
+        availableModels: [
+          { id: 'gpt-4o', label: 'GPT-4o' },
+          { id: 'gpt-4o-mini', label: 'GPT-4o mini' },
+        ],
+        defaultModel: 'gpt-5-typo',
+        model: makeModelFactory().factory,
+      }),
+    ).toThrow(/defaultModel.*"gpt-5-typo".*availableModels/)
+  })
+
+  it('does not enforce defaultModel membership when availableModels is omitted', () => {
+    // Without an availableModels list there's no UI selector and no
+    // user-facing inconsistency to guard against — any id is allowed.
+    expect(() =>
+      chatAgentPlugin({
+        defaultModel: 'whatever-id',
+        model: makeModelFactory().factory,
+      }),
+    ).not.toThrow()
+  })
+
   it('adds /chat-agent/chat endpoint to config', () => {
     const plugin = chatAgentPlugin({
       defaultModel: 'claude-sonnet-4-20250514',
@@ -103,11 +147,11 @@ describe('chatAgentPlugin', () => {
   })
 
   it('returns 500 when no model factory is configured', async () => {
-    // Cast through unknown to bypass the type checker — we're verifying runtime
-    // behavior when a JS consumer omits the required option.
+    // Verify runtime behavior when a JS consumer omits the required option.
+    // @ts-expect-error - intentionally missing required `model` to test runtime guard
     const plugin = chatAgentPlugin({
       defaultModel: 'claude-sonnet-4-20250514',
-    } as unknown as Parameters<typeof chatAgentPlugin>[0])
+    })
     const result = plugin({ endpoints: [] })
     const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
 
@@ -138,9 +182,10 @@ describe('chatAgentPlugin', () => {
     const original = process.env.ANTHROPIC_API_KEY
     process.env.ANTHROPIC_API_KEY = 'sk-should-be-ignored'
     try {
+      // @ts-expect-error - intentionally missing required `model` to test runtime guard
       const plugin = chatAgentPlugin({
         defaultModel: 'claude-sonnet-4-20250514',
-      } as unknown as Parameters<typeof chatAgentPlugin>[0])
+      })
       const result = plugin({ endpoints: [] })
       const handler = result.endpoints.find((ep: any) => ep.path === '/chat-agent/chat').handler
 
@@ -426,6 +471,36 @@ describe('chatAgentPlugin model factory', () => {
     const body = await response.json()
     expect(body.error).toContain('Failed to resolve model "gpt-4o-mini"')
     expect(body.error).toContain('OPENAI_API_KEY is not set')
+  })
+
+  it('passes the LanguageModel returned by the factory directly to streamText', async () => {
+    // The factory's *return value* must be the model instance streamText
+    // sees. A refactor that called the factory but forgot to wire the result
+    // through would silently break — this test locks the contract.
+    vi.mocked(streamText).mockClear()
+
+    const sentinel = { id: 'gpt-4o', __fake: true, sentinel: Symbol('marker') } as any
+    const factory = vi.fn(() => sentinel)
+    const plugin = chatAgentPlugin({
+      defaultModel: 'gpt-4o',
+      model: factory,
+    })
+    const handler = plugin({ endpoints: [] }).endpoints.find(
+      (ep: any) => ep.path === '/chat-agent/chat',
+    ).handler
+
+    await handler({
+      json: () =>
+        Promise.resolve({
+          messages: [{ id: '1', parts: [{ type: 'text', text: 'hi' }], role: 'user' }],
+        }),
+      payload: { config: { collections: [], globals: [] } },
+      user: { id: 1 },
+    })
+
+    expect(vi.mocked(streamText)).toHaveBeenCalledTimes(1)
+    const callArgs = vi.mocked(streamText).mock.calls[0][0] as any
+    expect(callArgs.model).toBe(sentinel)
   })
 
   it('supports routing to different providers based on the model id', async () => {

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -62,6 +62,21 @@ export function validateMessages(messages: unknown): null | string {
 }
 
 export function chatAgentPlugin(options: ChatAgentPluginOptions) {
+  // --- Validate options at construction time --------------------------------
+  // Fail fast on misconfiguration so the issue surfaces at Payload startup
+  // instead of as a confusing per-request error.
+  if (
+    options.availableModels &&
+    options.availableModels.length > 0 &&
+    !options.availableModels.some((m) => m.id === options.defaultModel)
+  ) {
+    const ids = options.availableModels.map((m) => m.id).join(', ')
+    throw new Error(
+      `chatAgentPlugin: defaultModel "${options.defaultModel}" is not in availableModels [${ids}]. ` +
+        `Either add it to availableModels or change defaultModel to one of the listed ids.`,
+    )
+  }
+
   return (config: any): any => {
     // Auto-register the admin chat view unless explicitly disabled
     const adminViews =

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -1,17 +1,25 @@
 /**
  * Chat Agent Plugin for Payload CMS.
  *
- * Adds a `/api/chat-agent/chat` endpoint that connects an AI agent (Claude)
- * to the Payload Local API. Uses the Vercel AI SDK for streaming and tool use.
+ * Adds a `/api/chat-agent/chat` endpoint that connects an AI agent to the
+ * Payload Local API. Uses the Vercel AI SDK for streaming and tool use, and
+ * is provider-agnostic — install whichever `@ai-sdk/*` package you want
+ * (Anthropic, OpenAI, Google, etc.) and pass a `model` factory.
  *
  * Usage in payload.config.ts:
  *   import { chatAgentPlugin } from '@jhb.software/payload-chat-agent'
+ *   import { createOpenAI } from '@ai-sdk/openai'
+ *   const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
  *   export default buildConfig({
- *     plugins: [chatAgentPlugin({ apiKey: '...', defaultModel: 'claude-sonnet-4-20250514' })],
+ *     plugins: [
+ *       chatAgentPlugin({
+ *         defaultModel: 'gpt-4o-mini',
+ *         model: (id) => openai(id),
+ *       }),
+ *     ],
  *   })
  */
 
-import { createAnthropic } from '@ai-sdk/anthropic'
 import { convertToModelMessages, stepCountIs, streamText } from 'ai'
 
 import type { ChatAgentPluginOptions } from './types.js'
@@ -20,7 +28,7 @@ import { conversationEndpoints, conversationsCollection } from './conversations.
 import { buildSystemPrompt } from './schema.js'
 import { buildTools, discoverEndpoints } from './tools.js'
 
-export type { ChatAgentPluginOptions, ModelOption } from './types.js'
+export type { ChatAgentPluginOptions, ModelFactory, ModelOption } from './types.js'
 export { type MessageMetadata, messageMetadataSchema } from './types.js'
 export { default as ChatViewServer } from './ui/ChatViewServer.js'
 
@@ -98,13 +106,12 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
               return Response.json({ error: 'Unauthorized' }, { status: 401 })
             }
 
-            // --- Resolve API key ------------------------------------------
-            const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY
-            if (!apiKey) {
+            // --- Validate model factory -----------------------------------
+            if (typeof options.model !== 'function') {
               return Response.json(
                 {
                   error:
-                    'Anthropic API key not configured. Set the apiKey option or ANTHROPIC_API_KEY environment variable.',
+                    'Chat agent plugin is misconfigured: the `model` option must be a function returning a LanguageModel. See https://github.com/jhb-software/payload-plugins/tree/main/chat-agent#setup',
                 },
                 { status: 500 },
               )
@@ -162,10 +169,23 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
             const modelId = body.model ?? options.defaultModel
             const maxSteps = options.maxSteps ?? 20
 
+            // --- Resolve model from user-provided factory ------------------
+            let resolvedModel
+            try {
+              resolvedModel = options.model(modelId)
+            } catch (err) {
+              return Response.json(
+                {
+                  error: `Failed to resolve model "${modelId}": ${err instanceof Error ? err.message : String(err)}`,
+                },
+                { status: 500 },
+              )
+            }
+
             // --- Stream response via AI SDK --------------------------------
             const result = streamText({
               messages: await (convertToModelMessages as any)(body.messages),
-              model: createAnthropic({ apiKey })(modelId),
+              model: resolvedModel,
               stopWhen: stepCountIs(maxSteps),
               system: systemPrompt,
               toolChoice: 'auto',

--- a/chat-agent/src/types.ts
+++ b/chat-agent/src/types.ts
@@ -2,6 +2,8 @@
  * Shared types for the chat agent plugin.
  */
 
+import type { LanguageModel } from 'ai'
+
 import { z } from 'zod'
 
 // ---------------------------------------------------------------------------
@@ -9,11 +11,46 @@ import { z } from 'zod'
 // ---------------------------------------------------------------------------
 
 export interface ModelOption {
-  /** Model identifier passed to the Anthropic API. */
+  /** Model identifier passed to the model factory. */
   id: string
   /** Human-readable label shown in the model selector UI. */
   label: string
 }
+
+/**
+ * Resolves a model id to a `LanguageModel` instance from the Vercel AI SDK.
+ *
+ * The plugin is provider-agnostic: install whichever `@ai-sdk/*` package you
+ * want (e.g. `@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/google`) and
+ * return the model instance from this factory.
+ *
+ * @example
+ * ```ts
+ * import { createOpenAI } from '@ai-sdk/openai'
+ * const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
+ * chatAgentPlugin({
+ *   defaultModel: 'gpt-4o-mini',
+ *   model: (id) => openai(id),
+ * })
+ * ```
+ *
+ * @example Mixing providers
+ * ```ts
+ * import { createAnthropic } from '@ai-sdk/anthropic'
+ * import { createOpenAI } from '@ai-sdk/openai'
+ * const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+ * const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY })
+ * chatAgentPlugin({
+ *   defaultModel: 'claude-sonnet-4-20250514',
+ *   availableModels: [
+ *     { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet' },
+ *     { id: 'gpt-4o', label: 'GPT-4o' },
+ *   ],
+ *   model: (id) => (id.startsWith('claude-') ? anthropic(id) : openai(id)),
+ * })
+ * ```
+ */
+export type ModelFactory = (modelId: string) => LanguageModel
 
 // ---------------------------------------------------------------------------
 // Plugin options
@@ -36,14 +73,20 @@ export interface ChatAgentPluginOptions {
         path?: `/${string}`
       }
     | false
-  /** Anthropic API key. Falls back to ANTHROPIC_API_KEY env var. */
-  apiKey?: string
   /** Models the user can choose from in the chat UI. When provided with 2+ entries, a selector dropdown is shown. */
   availableModels?: ModelOption[]
-  /** Claude model ID used when no per-request override is provided. */
+  /** Model id used when no per-request override is provided. Passed to `model(id)`. */
   defaultModel: string
   /** Maximum tool-use loop steps per request. Default: 20 */
   maxSteps?: number
+  /**
+   * Resolves a model id to a `LanguageModel` instance.
+   *
+   * Called once per request with the selected model id. Use this to plug in
+   * any provider supported by the Vercel AI SDK — Anthropic, OpenAI, Google,
+   * Mistral, Bedrock, etc. The plugin itself depends on no provider package.
+   */
+  model: ModelFactory
   /**
    * Controls who can use superuser mode (overrideAccess: true).
    * - Omit or `false` to disable superuser mode entirely (default).

--- a/chat-agent/src/ui/ChatView.tsx
+++ b/chat-agent/src/ui/ChatView.tsx
@@ -40,6 +40,8 @@ export interface ChatViewProps {
   defaultMode?: AgentMode
   initialConversations?: ConversationSummary[]
   initialMessages?: unknown[]
+  /** Model id persisted on the conversation doc; used as the initial selection when resuming. */
+  initialModel?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -52,6 +54,7 @@ export default function ChatView({
   defaultMode = 'ask',
   initialConversations,
   initialMessages: serverMessages,
+  initialModel,
 }: ChatViewProps) {
   const endpointUrl = '/api/chat-agent/chat'
   const [chatId, setChatId] = useState(conversationId)
@@ -62,7 +65,7 @@ export default function ChatView({
   )
   const [availableModels, setAvailableModels] = useState<ModelOption[]>([])
   const [defaultModel, setDefaultModel] = useState<string | undefined>(undefined)
-  const [selectedModel, setSelectedModel] = useState<string | undefined>(undefined)
+  const [selectedModel, setSelectedModel] = useState<string | undefined>(initialModel)
 
   // Fetch available models configuration on mount
   useEffect(() => {

--- a/chat-agent/src/ui/ChatViewServer.tsx
+++ b/chat-agent/src/ui/ChatViewServer.tsx
@@ -18,8 +18,9 @@ export default async function ChatViewServer({ initPageResult: { req } }: AdminV
       })
     : { docs: [] }
 
-  // If a conversation ID is in the URL, fetch its messages server-side
+  // If a conversation ID is in the URL, fetch its messages + model server-side
   let initialMessages: undefined | unknown[]
+  let initialModel: string | undefined
   if (conversationId && user) {
     try {
       const doc = await payload.findByID({
@@ -29,6 +30,7 @@ export default async function ChatViewServer({ initPageResult: { req } }: AdminV
         user,
       })
       initialMessages = (doc.messages as unknown[]) ?? []
+      initialModel = typeof doc.model === 'string' ? doc.model : undefined
     } catch {
       // Conversation not found — will start fresh
     }
@@ -43,6 +45,7 @@ export default async function ChatViewServer({ initPageResult: { req } }: AdminV
         updatedAt: (d.updatedAt as string) ?? '',
       }))}
       initialMessages={initialMessages}
+      initialModel={initialModel}
     />
   )
 }

--- a/chat-agent/src/ui/use-chat.ts
+++ b/chat-agent/src/ui/use-chat.ts
@@ -85,17 +85,13 @@ export function useChat(options?: string | UseChatOptions) {
   const conversationsUrl = `${endpointUrl}/conversations`
   const conversationIdRef = useRef<string | undefined>(chatId)
 
-  const handleFinish = useCallback(
-    async ({
-      message,
-      messages: allMessages,
-    }: {
-      message: UIMessage<MessageMetadata>
-      messages: UIMessage<MessageMetadata>[]
-    }) => {
-      if (message.role !== 'assistant') {
-        return
-      }
+  // Keep a live view of messages so the error handler can read the latest
+  // state without re-memoizing (AI SDK's `onError` signature only receives the
+  // Error, not the message list).
+  const messagesRef = useRef<UIMessage<MessageMetadata>[]>(initialMessages ?? [])
+
+  const persistMessages = useCallback(
+    async (allMessages: UIMessage<MessageMetadata>[]) => {
       let totalTokens = 0
       for (const msg of allMessages) {
         if (msg.metadata?.totalTokens) {
@@ -118,23 +114,67 @@ export function useChat(options?: string | UseChatOptions) {
     [conversationsUrl, model, onSave],
   )
 
-  const transport = useMemo(() => {
-    const body: Record<string, unknown> = {}
-    if (model) {
-      body.model = model
+  const handleFinish = useCallback(
+    async ({
+      message,
+      messages: allMessages,
+    }: {
+      message: UIMessage<MessageMetadata>
+      messages: UIMessage<MessageMetadata>[]
+    }) => {
+      if (message.role !== 'assistant') {
+        return
+      }
+      await persistMessages(allMessages)
+    },
+    [persistMessages],
+  )
+
+  // Persist the user's message when the stream fails so it survives a reload
+  // and the user can retry without retyping. The error itself stays ephemeral
+  // in `useChat`'s `error` state — we never save error text as an assistant
+  // message (that would pollute retries and get resent to the model).
+  const handleError = useCallback(() => {
+    const msgs = messagesRef.current
+    if (msgs.length === 0) {
+      return
     }
-    if (mode) {
-      body.mode = mode
-    }
-    return new DefaultChatTransport({
-      api: endpointUrl,
-      body: Object.keys(body).length > 0 ? body : undefined,
-      credentials: 'include',
-    })
-  }, [endpointUrl, mode, model])
+    void persistMessages(msgs)
+  }, [persistMessages])
+
+  // --- Transport with live model/mode -------------------------------------
+  // The AI SDK's useChat caches the transport on mount, so memoizing a new
+  // transport when `model`/`mode` change does not take effect on rerender.
+  // Instead, hold the latest values in refs and inject them via
+  // `prepareSendMessagesRequest`, which is called fresh on every send
+  // (including auto-sends triggered by tool approvals).
+  const modelRef = useRef(model)
+  const modeRef = useRef(mode)
+  modelRef.current = model
+  modeRef.current = mode
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: endpointUrl,
+        credentials: 'include',
+        prepareSendMessagesRequest: ({ api, credentials, headers, messages, body }) => {
+          const nextBody: Record<string, unknown> = { ...(body ?? {}), messages }
+          if (modelRef.current) {
+            nextBody.model = modelRef.current
+          }
+          if (modeRef.current) {
+            nextBody.mode = modeRef.current
+          }
+          return { api, body: nextBody, credentials, headers }
+        },
+      }),
+    [endpointUrl],
+  )
 
   const chatOptions: Record<string, unknown> = {
     messageMetadataSchema,
+    onError: handleError,
     onFinish: handleFinish,
     // When the user approves/denies a pending tool call, resubmit automatically
     // so the server can execute (or skip) the tool and continue the stream.
@@ -149,6 +189,7 @@ export function useChat(options?: string | UseChatOptions) {
   }
 
   const chat = useAIChat(chatOptions as any)
+  messagesRef.current = chat.messages as UIMessage<MessageMetadata>[]
 
   return {
     ...chat,


### PR DESCRIPTION
## Summary

- **Breaking:** replaces the Anthropic-only `apiKey` option with a required `model: (id) => LanguageModel` factory. The plugin no longer depends on `@ai-sdk/anthropic` and no longer reads `ANTHROPIC_API_KEY` from the environment — consumers bring their own `@ai-sdk/*` provider (OpenAI, Google, Mistral, Bedrock, …) and all configuration comes from plugin options.
- Enables mixing providers in a single install: the factory receives the requested model id, so you can route Claude to `@ai-sdk/anthropic` and GPT to `@ai-sdk/openai` in the same `availableModels` dropdown.
- Dev app demonstrates the multi-provider setup, gating each provider on its own env var.
- Validates `defaultModel ∈ availableModels` at plugin construction — misconfiguration now fails Payload startup with a clear error instead of producing a confusing per-request fallback.

## Migration

```diff
+ import { createAnthropic } from '@ai-sdk/anthropic'
+ const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })

  chatAgentPlugin({
-   apiKey: process.env.ANTHROPIC_API_KEY,
    defaultModel: 'claude-sonnet-4-20250514',
+   model: (id) => anthropic(id),
  })
```

OpenAI and mixed-provider examples in the updated README.

## What changed

**Plugin (`chat-agent/src/`)**
- `types.ts` — new `ModelFactory` type; `model` is now required; `apiKey` removed; all "Claude/Anthropic" wording dropped.
- `index.ts` — dropped `createAnthropic` import and the `ANTHROPIC_API_KEY` env fallback. Added misconfig guard (clear 500 if `model` isn't a function) and a try/catch around the factory so a thrown "API key not set" surfaces with its original message. Added init-time validation that `defaultModel` is in `availableModels`.
- `package.json` — `@ai-sdk/anthropic` dropped entirely from dependencies.

**Tests** — 124/124 passing (was 121, +3 new model-factory tests)
- New `chatAgentPlugin model factory` describe block covers: factory invoked with the per-request model id, fallback to `defaultModel`, factory throws → 500 with original message, multi-provider routing by id prefix, and (via `vi.mock('ai')`) that the exact `LanguageModel` returned by the factory is the instance `streamText` receives.
- New `throws at construction when defaultModel is not in availableModels` test.
- New `does not read ANTHROPIC_API_KEY from the environment` test that explicitly sets the env var and asserts the misconfig error still wins.
- All existing tests updated to pass a `model` factory instead of `apiKey`.

**Dev app (`chat-agent/dev/`)**
- `payload.config.ts` imports both `@ai-sdk/anthropic` and `@ai-sdk/openai`, builds a `resolveModel` factory that routes by id prefix and gates each provider on its own env var, and registers `availableModels` with two Claude + two GPT entries.
- `ChatClient.tsx` cost table extended with GPT-4o/GPT-4o mini rates.
- Drive-by unblocked two pre-existing type errors that prevented `next build`:
  - `ChatView.tsx` import missing `.js` extension (nodenext moduleResolution)
  - Seed posts `status` string not narrowed to the collection's literal union

**Docs**
- `README.md` — new BYO-provider intro, setup instructions, Using OpenAI section, Mixing providers section, updated options table with `model` as the required field, and an explicit "no env-var fallbacks" note.
- `CHANGELOG.md` — `## Unreleased` entry with `BREAKING` callout and diff-style migration snippet.

## Test plan

- [x] `pnpm test` — 124/124 passing
- [x] `pnpm typecheck` (plugin) — clean
- [x] `pnpm lint` on touched source files — clean
- [x] `pnpm build` (plugin) — clean
- [x] `pnpm build` (dev Next app) — compiles end-to-end with the multi-provider config
- [ ] **Manual smoke test needed:** boot the dev app with `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` set, send a message on each model from the dropdown, verify tool calls work and token usage shows up. I couldn't run this — no API keys in the sandbox. Please validate before merging.
- [ ] **Manual smoke test needed:** verify the new misconfiguration error actually throws at Payload startup (e.g. temporarily set `defaultModel: 'does-not-exist'` and confirm the dev app refuses to start).

https://claude.ai/code/session_01V97xWPcMJRSmYEPGgzssKt