### PR TITLE
fix(chat-agent): keep streamed messages visible and retarget saves after sidebar switch

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- fix: keep streamed messages on screen after the first save of a new conversation (the AI SDK's chat instance was being recreated empty when `chatId` flipped from `undefined` to the server-assigned id, so the UI fell back to the empty new-chat state even though the URL retained the conversation id)
+- fix: keep streamed messages visible after the first save of a new conversation
+- fix: retarget saves to the new conversation id after switching conversations from the sidebar (previous behaviour PATCHed the prior conversation)
 
 ## 0.1.0-beta.2
 

--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: keep streamed messages on screen after the first save of a new conversation (the AI SDK's chat instance was being recreated empty when `chatId` flipped from `undefined` to the server-assigned id, so the UI fell back to the empty new-chat state even though the URL retained the conversation id)
+
 ## 0.1.0-beta.2
 
 - fix: normalize all Payload label shapes (`string`, localized `Record`, `LabelFunction`, `false`) in `getCollectionSchema` / `getGlobalSchema` output instead of emitting `"[object Object]"`.

--- a/chat-agent/src/ui/use-chat.test.tsx
+++ b/chat-agent/src/ui/use-chat.test.tsx
@@ -2,7 +2,7 @@
 import type { UIMessage } from 'ai'
 
 import { act, cleanup, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { MessageMetadata } from '../types.js'
 
@@ -19,15 +19,29 @@ const message = (
     role,
   }) as UIMessage<MessageMetadata>
 
+/** Minimal UIMessageChunk SSE payload that completes a single assistant turn. */
+function sseStream(): string {
+  // Keep keys in AI-SDK `UIMessageChunk` order (discriminator first).
+  /* eslint-disable perfectionist/sort-objects */
+  const chunks: Record<string, unknown>[] = [
+    { type: 'start', messageId: 'asst-1' },
+    { type: 'start-step' },
+    { type: 'text-start', id: 't1' },
+    { type: 'text-delta', id: 't1', delta: 'ok' },
+    { type: 'text-end', id: 't1' },
+    { type: 'finish-step' },
+    { type: 'finish' },
+  ]
+  /* eslint-enable perfectionist/sort-objects */
+  return chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join('') + 'data: [DONE]\n\n'
+}
+
 describe('useChat', () => {
   afterEach(cleanup)
 
-  // Reproduces the bug where, after the very first message in a new
-  // conversation is saved, the parent flips `chatId` from `undefined` to the
-  // server-assigned id. Previously this caused the underlying AI SDK chat to
-  // be recreated with empty messages, so the just-streamed user/assistant
-  // pair vanished from the UI even though the URL retained the conversation
-  // id.
+  // Reproduces the first-save bug: after the very first message in a new
+  // conversation is saved, the parent flips `chatId` from `undefined` to
+  // the server-assigned id, which used to recreate the AI SDK's chat empty.
   it('keeps messages when chatId changes from undefined to a server id after first save', () => {
     const { rerender, result } = renderHook(
       ({ chatId }: { chatId: string | undefined }) =>
@@ -53,10 +67,8 @@ describe('useChat', () => {
     expect(result.current.messages[1]?.id).toBe('m2')
   })
 
-  // When the user clicks a different conversation in the sidebar,
-  // `loadConversation` calls `setMessages(msgs)` AND flips the `chatId`. The
-  // new messages must be the ones that survive — not whatever was on screen
-  // beforehand.
+  // Sidebar switch: `loadConversation` flips `chatId` AND calls
+  // `setMessages(msgs)`. The new messages must win.
   it('surfaces messages set via setMessages when chatId also changes in the same render', () => {
     const { rerender, result } = renderHook(
       ({ chatId }: { chatId: string | undefined }) =>
@@ -79,5 +91,59 @@ describe('useChat', () => {
 
     expect(result.current.messages).toHaveLength(2)
     expect(result.current.messages.map((m) => m.id)).toEqual(['b1', 'b2'])
+  })
+
+  // After a sidebar switch from convo-a to convo-b, the next save must
+  // PATCH convo-b. Previously the hook cached the initial chatId in a ref
+  // and never re-synced it, so saves silently overwrote the previous
+  // conversation with the new one's messages.
+  it('persists to the current chatId after a sidebar switch, not the previous one', async () => {
+    const asUrl = (input: RequestInfo | URL): string =>
+      typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = asUrl(input)
+      if (url === '/api/chat-agent/chat') {
+        return Promise.resolve(
+          new Response(sseStream(), {
+            headers: { 'Content-Type': 'text/event-stream' },
+          }),
+        )
+      }
+      if (init?.method === 'PATCH' || init?.method === 'POST') {
+        const id = url.split('/').pop() ?? 'new'
+        return Promise.resolve(
+          new Response(JSON.stringify({ id }), {
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+      throw new Error(`Unexpected fetch: ${init?.method ?? 'GET'} ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    try {
+      const { rerender, result } = renderHook(
+        ({ chatId }: { chatId: string | undefined }) =>
+          useChat({ chatId, endpointUrl: '/api/chat-agent/chat' }),
+        { initialProps: { chatId: 'convo-a' as string | undefined } },
+      )
+
+      rerender({ chatId: 'convo-b' })
+
+      await act(async () => {
+        await result.current.sendMessage({ text: 'hello in b' })
+      })
+
+      const saveCalls = fetchMock.mock.calls
+        .map(([input]) => asUrl(input))
+        .filter((url) => url.includes('/conversations/'))
+      expect(saveCalls.length).toBeGreaterThan(0)
+      for (const url of saveCalls) {
+        expect(url).toContain('/convo-b')
+        expect(url).not.toContain('/convo-a')
+      }
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/chat-agent/src/ui/use-chat.test.tsx
+++ b/chat-agent/src/ui/use-chat.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import type { UIMessage } from 'ai'
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { MessageMetadata } from '../types.js'
+
+import { useChat } from './use-chat.js'
+
+const message = (
+  id: string,
+  role: 'assistant' | 'user',
+  text: string,
+): UIMessage<MessageMetadata> =>
+  ({
+    id,
+    parts: [{ type: 'text' as const, text }],
+    role,
+  }) as UIMessage<MessageMetadata>
+
+describe('useChat', () => {
+  afterEach(cleanup)
+
+  // Reproduces the bug where, after the very first message in a new
+  // conversation is saved, the parent flips `chatId` from `undefined` to the
+  // server-assigned id. Previously this caused the underlying AI SDK chat to
+  // be recreated with empty messages, so the just-streamed user/assistant
+  // pair vanished from the UI even though the URL retained the conversation
+  // id.
+  it('keeps messages when chatId changes from undefined to a server id after first save', () => {
+    const { rerender, result } = renderHook(
+      ({ chatId }: { chatId: string | undefined }) =>
+        useChat({ chatId, endpointUrl: '/api/chat-agent/chat' }),
+      { initialProps: { chatId: undefined as string | undefined } },
+    )
+
+    act(() => {
+      result.current.setMessages([
+        message('m1', 'user', 'Hello'),
+        message('m2', 'assistant', 'Hi there'),
+      ])
+    })
+    expect(result.current.messages).toHaveLength(2)
+
+    // Simulate the post-save transition: the parent calls
+    // `setActiveChatId(serverId)` after `onSave` fires, so the next render of
+    // ChatView passes the real chat id where there used to be `undefined`.
+    rerender({ chatId: 'server-assigned-id' })
+
+    expect(result.current.messages).toHaveLength(2)
+    expect(result.current.messages[0]?.id).toBe('m1')
+    expect(result.current.messages[1]?.id).toBe('m2')
+  })
+
+  // When the user clicks a different conversation in the sidebar,
+  // `loadConversation` calls `setMessages(msgs)` AND flips the `chatId`. The
+  // new messages must be the ones that survive — not whatever was on screen
+  // beforehand.
+  it('surfaces messages set via setMessages when chatId also changes in the same render', () => {
+    const { rerender, result } = renderHook(
+      ({ chatId }: { chatId: string | undefined }) =>
+        useChat({ chatId, endpointUrl: '/api/chat-agent/chat' }),
+      { initialProps: { chatId: 'convo-a' as string | undefined } },
+    )
+
+    act(() => {
+      result.current.setMessages([message('a1', 'user', 'A question')])
+    })
+    expect(result.current.messages).toHaveLength(1)
+
+    act(() => {
+      result.current.setMessages([
+        message('b1', 'user', 'B question'),
+        message('b2', 'assistant', 'B answer'),
+      ])
+      rerender({ chatId: 'convo-b' })
+    })
+
+    expect(result.current.messages).toHaveLength(2)
+    expect(result.current.messages.map((m) => m.id)).toEqual(['b1', 'b2'])
+  })
+})

--- a/chat-agent/src/ui/use-chat.ts
+++ b/chat-agent/src/ui/use-chat.ts
@@ -89,7 +89,13 @@ export function useChat(options?: string | UseChatOptions) {
   const onSave = typeof options === 'object' ? options?.onSave : undefined
 
   const conversationsUrl = `${endpointUrl}/conversations`
+  // Tracks the persistence id across saves so subsequent saves PATCH instead
+  // of POSTing a duplicate. Re-synced to `chatId` on every render so a
+  // sidebar switch retargets saves to the new conversation, and overridden
+  // by `persistMessages` after a POST so the tool-approval auto-send (which
+  // can fire before React re-renders) also PATCHes the new id.
   const conversationIdRef = useRef<string | undefined>(chatId)
+  conversationIdRef.current = chatId
 
   // Keep a live view of messages so the error handler can read the latest
   // state without re-memoizing (AI SDK's `onError` signature only receives the
@@ -181,16 +187,9 @@ export function useChat(options?: string | UseChatOptions) {
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     transport,
   }
-  // Intentionally do NOT pass `chatId` as the AI SDK's `id`. Our `chatId` is
-  // the persistence id (used by `saveConversation` to choose POST vs PATCH);
-  // the AI SDK's `id` keys its internal Chat instance and any change to it
-  // tears down the current chat and replaces it with an empty one. Coupling
-  // them caused the just-streamed messages of a brand-new conversation to
-  // disappear the instant the first save flipped `chatId` from `undefined`
-  // to the server-assigned id (the URL kept the id, but the UI fell back to
-  // the empty "new chat" state). `loadConversation` and `newConversation`
-  // already drive the message list explicitly via `setMessages`, so the AI
-  // SDK never needs to know about the persistence id.
+  // Don't pass `chatId` as the AI SDK's `id`: the SDK recreates its Chat
+  // (and drops messages) whenever `id` changes. Our `chatId` is the
+  // persistence id only; the SDK's internal id can stay opaque.
   if (initialMessages) {
     chatOptions.messages = initialMessages
   }

--- a/chat-agent/src/ui/use-chat.ts
+++ b/chat-agent/src/ui/use-chat.ts
@@ -181,9 +181,16 @@ export function useChat(options?: string | UseChatOptions) {
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     transport,
   }
-  if (chatId) {
-    chatOptions.id = chatId
-  }
+  // Intentionally do NOT pass `chatId` as the AI SDK's `id`. Our `chatId` is
+  // the persistence id (used by `saveConversation` to choose POST vs PATCH);
+  // the AI SDK's `id` keys its internal Chat instance and any change to it
+  // tears down the current chat and replaces it with an empty one. Coupling
+  // them caused the just-streamed messages of a brand-new conversation to
+  // disappear the instant the first save flipped `chatId` from `undefined`
+  // to the server-assigned id (the URL kept the id, but the UI fell back to
+  // the empty "new chat" state). `loadConversation` and `newConversation`
+  // already drive the message list explicitly via `setMessages`, so the AI
+  // SDK never needs to know about the persistence id.
   if (initialMessages) {
     chatOptions.messages = initialMessages
   }


### PR DESCRIPTION
## Summary

- Stop passing the persistence `chatId` as the AI SDK's chat id so the Chat instance (and its just-streamed messages) isn't torn down when the post-save handler assigns the server id.
- Re-sync `conversationIdRef` to the current `chatId` prop on every render so sidebar-driven conversation switches don't leave the ref pointing at the previous conversation and PATCH the wrong record.
- Add `use-chat.test.tsx` covering both regressions.

## Test plan

- [ ] `pnpm --filter @jhb.software/payload-chat-agent test` passes
- [ ] Start a new conversation, send a message, confirm the streamed pair stays visible after the server assigns an id
- [ ] Switch conversations via the sidebar, send a message, confirm the save targets the newly selected conversation