### PR TITLE
feat(chat-agent)!: rename chat-* collections to agent-*

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat!: rename the `chat-conversations` collection to `agent-conversations` and the default `chat-token-usage` budget collection to `agent-token-usage`. Existing projects must migrate data or override `createPayloadBudget({ slug: 'chat-token-usage' })` to keep the previous slug.
+
 ## 0.1.0-beta.3
 
 - feat: surface tool-call status in the chat UI (running / failed / denied) and show failed tool error text in a collapsible panel instead of only a colored dot.

--- a/chat-agent/dev/payload-types.ts
+++ b/chat-agent/dev/payload-types.ts
@@ -71,8 +71,8 @@ export interface Config {
     posts: Post;
     categories: Category;
     media: Media;
-    'chat-token-usage': ChatTokenUsage;
-    'chat-conversations': ChatConversation;
+    'agent-token-usage': AgentTokenUsage;
+    'agent-conversations': AgentConversation;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -84,8 +84,8 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
-    'chat-token-usage': ChatTokenUsageSelect<false> | ChatTokenUsageSelect<true>;
-    'chat-conversations': ChatConversationsSelect<false> | ChatConversationsSelect<true>;
+    'agent-token-usage': AgentTokenUsageSelect<false> | AgentTokenUsageSelect<true>;
+    'agent-conversations': AgentConversationsSelect<false> | AgentConversationsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -216,9 +216,9 @@ export interface Category {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "chat-token-usage".
+ * via the `definition` "agent-token-usage".
  */
-export interface ChatTokenUsage {
+export interface AgentTokenUsage {
   id: string;
   scope: string;
   period: string;
@@ -231,9 +231,9 @@ export interface ChatTokenUsage {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "chat-conversations".
+ * via the `definition` "agent-conversations".
  */
-export interface ChatConversation {
+export interface AgentConversation {
   id: string;
   title: string;
   messages:
@@ -293,12 +293,12 @@ export interface PayloadLockedDocument {
         value: string | Media;
       } | null)
     | ({
-        relationTo: 'chat-token-usage';
-        value: string | ChatTokenUsage;
+        relationTo: 'agent-token-usage';
+        value: string | AgentTokenUsage;
       } | null)
     | ({
-        relationTo: 'chat-conversations';
-        value: string | ChatConversation;
+        relationTo: 'agent-conversations';
+        value: string | AgentConversation;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -409,9 +409,9 @@ export interface MediaSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "chat-token-usage_select".
+ * via the `definition` "agent-token-usage_select".
  */
-export interface ChatTokenUsageSelect<T extends boolean = true> {
+export interface AgentTokenUsageSelect<T extends boolean = true> {
   scope?: T;
   period?: T;
   model?: T;
@@ -423,9 +423,9 @@ export interface ChatTokenUsageSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "chat-conversations_select".
+ * via the `definition` "agent-conversations_select".
  */
-export interface ChatConversationsSelect<T extends boolean = true> {
+export interface AgentConversationsSelect<T extends boolean = true> {
   title?: T;
   messages?: T;
   user?: T;

--- a/chat-agent/src/budget.ts
+++ b/chat-agent/src/budget.ts
@@ -12,7 +12,7 @@ import type { CollectionConfig, DefaultDocumentIDType, PayloadRequest } from 'pa
 
 import type { BudgetConfig, BudgetUsage } from './types.js'
 
-export const DEFAULT_USAGE_COLLECTION_SLUG = 'chat-token-usage'
+export const DEFAULT_USAGE_COLLECTION_SLUG = 'agent-token-usage'
 
 /**
  * Resolves a `BudgetConfig`-compatible "period key" from a request. Built-in
@@ -52,7 +52,7 @@ export interface CreatePayloadBudgetOptions {
   /**
    * Collection slug used for the usage store. Override when you need more
    * than one independent budget in the same project, or to avoid a naming
-   * clash. Default: `'chat-token-usage'`.
+   * clash. Default: `'agent-token-usage'`.
    */
   slug?: string
 }

--- a/chat-agent/src/conversations.test.ts
+++ b/chat-agent/src/conversations.test.ts
@@ -88,7 +88,7 @@ describe('conversationsCollection', () => {
   })
 
   // Without this hook, a user who hits Payload's default collection REST
-  // (`POST /api/chat-conversations`) could send `data.user = '<other-id>'`.
+  // (`POST /api/agent-conversations`) could send `data.user = '<other-id>'`.
   // Access filters would still hide the record from them, but the
   // collection would end up with records owned by someone who never
   // created them. The hook forces `data.user` to the authenticated user
@@ -133,7 +133,7 @@ describe('conversationsCollection', () => {
 // ---------------------------------------------------------------------------
 
 describe('chatAgentPlugin conversations', () => {
-  it('registers the chat-conversations collection', () => {
+  it('registers the agent-conversations collection', () => {
     const plugin = chatAgentPlugin({
       defaultModel: 'claude-sonnet-4-20250514',
       model: fakeModel,

--- a/chat-agent/src/conversations.ts
+++ b/chat-agent/src/conversations.ts
@@ -12,7 +12,7 @@ import type { AccessArgs, CollectionConfig, Endpoint, PayloadRequest } from 'pay
 import { isPluginAccessAllowed } from './access.js'
 import { AGENT_MODES, type AgentMode } from './types.js'
 
-export const CONVERSATIONS_SLUG = 'chat-conversations'
+export const CONVERSATIONS_SLUG = 'agent-conversations'
 
 // ---------------------------------------------------------------------------
 // Collection definition
@@ -86,7 +86,7 @@ export const conversationsCollection: CollectionConfig = {
   hooks: {
     // Force the `user` field to the authenticated user, regardless of what the
     // client sent. Without this, a user hitting Payload's default REST
-    // (`POST /api/chat-conversations`) could create a record with
+    // (`POST /api/agent-conversations`) could create a record with
     // `data.user` set to someone else's id — they still can't read/update/
     // delete it thanks to the access filters, but they'd pollute the
     // collection. The `update` guard also protects against a client trying to

--- a/chat-agent/src/ui/use-chat.ts
+++ b/chat-agent/src/ui/use-chat.ts
@@ -4,7 +4,7 @@
  * Thin wrapper around the Vercel AI SDK's useChat hook.
  *
  * Re-exports the hook with defaults configured for the chat agent endpoint,
- * plus conversation persistence via the chat-conversations collection.
+ * plus conversation persistence via the agent-conversations collection.
  */
 
 import type { UIMessage } from 'ai'


### PR DESCRIPTION
Rename the `chat-conversations` collection to `agent-conversations` and
the default `chat-token-usage` budget collection slug to
`agent-token-usage` so the slugs match the plugin's "agent" framing.

BREAKING CHANGE: existing projects must migrate data to the new slugs or
pass `createPayloadBudget({ slug: 'chat-token-usage' })` to preserve the
previous usage collection slug.

https://claude.ai/code/session_01UFdmD2Jt9eZHxbB96zQMka