### PR TITLE
refactor(alt-text): stop auto-injecting health widget into defaultLayout

### DIFF
--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- refactor: stop auto-injecting the alt text health widget into `admin.dashboard.defaultLayout`. The widget is still registered under `admin.dashboard.widgets`; add `{ widgetSlug: 'alt-text-health', width: 'full' }` to your `defaultLayout` to show it by default.
+
 ## 0.4.4
 
 - style: standardize icons to use Geist icon set (16x16 filled)

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -23,7 +23,6 @@ When the plugin is enabled for an upload collection, it will:
 3. Add a bulk generate button to the collection list view
    - This button will allow you to generate alt text for multiple images at once
 4. Register an `Alt text health` dashboard widget
-   - The widget is available in Payload's dashboard editor and can be added via `admin.dashboard.defaultLayout` (see below)
    - Results are cached and revalidated when documents in the configured upload collections change
 
 ## Installation
@@ -100,7 +99,7 @@ buildConfig({
   admin: {
     dashboard: {
       defaultLayout: [
-        { widgetSlug: 'collections', width: 'full' },
+        // ...other default widgets
         { widgetSlug: 'alt-text-health', width: 'full' },
       ],
     },

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -23,8 +23,7 @@ When the plugin is enabled for an upload collection, it will:
 3. Add a bulk generate button to the collection list view
    - This button will allow you to generate alt text for multiple images at once
 4. Register an `Alt text health` dashboard widget
-   - The widget is available in Payload's dashboard editor
-   - It is added to the default dashboard layout for first-time and reset layouts
+   - The widget is available in Payload's dashboard editor and can be added via `admin.dashboard.defaultLayout` (see below)
    - Results are cached and revalidated when documents in the configured upload collections change
 
 ## Installation
@@ -93,6 +92,22 @@ This is also the recommended escape hatch if you hit Payload's Postgres SQL-buil
 The plugin registers an `Alt text health` dashboard widget that shows alt text coverage across all configured upload collections, with cached queries that revalidate on document changes. Collections with missing alt text show a clickable badge linking to the affected images.
 
 <img width="696" height="246" alt="image" src="https://github.com/user-attachments/assets/75df7349-0307-4047-b1ac-6b2ee0814464" />
+
+The widget is registered under `admin.dashboard.widgets` with the slug `alt-text-health`. To show it by default on the dashboard, add it to your `admin.dashboard.defaultLayout`:
+
+```ts
+buildConfig({
+  admin: {
+    dashboard: {
+      defaultLayout: [
+        { widgetSlug: 'collections', width: 'full' },
+        { widgetSlug: 'alt-text-health', width: 'full' },
+      ],
+    },
+  },
+  // ...
+})
+```
 
 Set `healthCheck: false` in the plugin config to disable the REST endpoint, cache revalidation hooks, and dashboard widget. If your project replaces the default dashboard via `admin.components.views.dashboard`, you need to integrate the widget into your custom dashboard yourself.
 

--- a/alt-text/dev/src/payload.config.ts
+++ b/alt-text/dev/src/payload.config.ts
@@ -17,6 +17,12 @@ export default buildConfig({
       email: 'dev@payloadcms.com',
       password: 'test',
     },
+    dashboard: {
+      defaultLayout: [
+        { widgetSlug: 'collections', width: 'full' },
+        { widgetSlug: 'alt-text-health', width: 'full' },
+      ],
+    },
     meta: { titleSuffix: '- Alt Text Dev' },
     user: 'users',
   },

--- a/alt-text/dev/src/payload.config.ts
+++ b/alt-text/dev/src/payload.config.ts
@@ -18,10 +18,7 @@ export default buildConfig({
       password: 'test',
     },
     dashboard: {
-      defaultLayout: [
-        { widgetSlug: 'collections', width: 'full' },
-        { widgetSlug: 'alt-text-health', width: 'full' },
-      ],
+      defaultLayout: [{ widgetSlug: 'alt-text-health', width: 'full' }],
     },
     meta: { titleSuffix: '- Alt Text Dev' },
     user: 'users',

--- a/alt-text/dev_unlocalized/src/payload.config.ts
+++ b/alt-text/dev_unlocalized/src/payload.config.ts
@@ -15,10 +15,7 @@ export default buildConfig({
       password: 'test',
     },
     dashboard: {
-      defaultLayout: [
-        { widgetSlug: 'collections', width: 'full' },
-        { widgetSlug: 'alt-text-health', width: 'full' },
-      ],
+      defaultLayout: [{ widgetSlug: 'alt-text-health', width: 'full' }],
     },
     meta: { titleSuffix: '- Alt Text Unlocalized Dev' },
     user: 'users',

--- a/alt-text/dev_unlocalized/src/payload.config.ts
+++ b/alt-text/dev_unlocalized/src/payload.config.ts
@@ -14,6 +14,12 @@ export default buildConfig({
       email: 'dev@payloadcms.com',
       password: 'test',
     },
+    dashboard: {
+      defaultLayout: [
+        { widgetSlug: 'collections', width: 'full' },
+        { widgetSlug: 'alt-text-health', width: 'full' },
+      ],
+    },
     meta: { titleSuffix: '- Alt Text Unlocalized Dev' },
     user: 'users',
   },

--- a/alt-text/src/plugin.ts
+++ b/alt-text/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { Config, PayloadRequest, Widget, WidgetInstance } from 'payload'
+import type { Config, Widget } from 'payload'
 
 import type {
   AltTextPluginConfig,
@@ -29,46 +29,6 @@ const altTextHealthWidgetDefinition = {
   maxWidth: 'full',
   minWidth: 'medium',
 } satisfies { ComponentPath: string } & Widget
-
-type DashboardDefaultLayout = Config['admin'] extends infer TAdmin
-  ? TAdmin extends { dashboard?: infer TDashboard }
-    ? TDashboard extends { defaultLayout?: infer TDefaultLayout }
-      ? TDefaultLayout
-      : never
-    : never
-  : never
-
-const defaultAltTextHealthWidgetLayout: WidgetInstance = {
-  widgetSlug: 'alt-text-health',
-  width: 'full',
-}
-
-function appendAltTextHealthWidgetToLayout(layout: WidgetInstance[]): WidgetInstance[] {
-  if (layout.some((widget) => widget.widgetSlug === 'alt-text-health')) {
-    return layout
-  }
-
-  return [...layout, defaultAltTextHealthWidgetLayout]
-}
-
-function getDashboardDefaultLayout(defaultLayout: DashboardDefaultLayout | undefined) {
-  if (!defaultLayout) {
-    return [
-      {
-        widgetSlug: 'collections',
-        width: 'full',
-      },
-      defaultAltTextHealthWidgetLayout,
-    ] satisfies WidgetInstance[]
-  }
-
-  if (Array.isArray(defaultLayout)) {
-    return appendAltTextHealthWidgetToLayout(defaultLayout)
-  }
-
-  return async ({ req }: { req: PayloadRequest }) =>
-    appendAltTextHealthWidgetToLayout(await defaultLayout({ req }))
-}
 
 export const payloadAltTextPlugin =
   (incomingPluginConfig: IncomingAltTextPluginConfig) =>
@@ -194,9 +154,6 @@ export const payloadAltTextPlugin =
         ...config.admin,
         dashboard: {
           ...config.admin?.dashboard,
-          ...(enableHealthCheck && {
-            defaultLayout: getDashboardDefaultLayout(config.admin?.dashboard?.defaultLayout),
-          }),
           widgets,
         },
       },

--- a/vercel-deployments/dev/src/payload.config.ts
+++ b/vercel-deployments/dev/src/payload.config.ts
@@ -16,12 +16,7 @@ export default buildConfig({
       password: 'test',
     },
     dashboard: {
-      // Show the Vercel deployments widget by default on the dashboard so it is
-      // visible without requiring users to add it manually via the admin UI.
-      defaultLayout: [
-        { widgetSlug: 'collections', width: 'full' },
-        { widgetSlug: 'vercel-deployments', width: 'full' },
-      ],
+      defaultLayout: [{ widgetSlug: 'vercel-deployments', width: 'full' }],
     },
     meta: { titleSuffix: '- Vercel Deployments Dev' },
     user: 'users',

--- a/vercel-deployments/dev/src/payload.config.ts
+++ b/vercel-deployments/dev/src/payload.config.ts
@@ -15,6 +15,14 @@ export default buildConfig({
       email: 'dev@payloadcms.com',
       password: 'test',
     },
+    dashboard: {
+      // Show the Vercel deployments widget by default on the dashboard so it is
+      // visible without requiring users to add it manually via the admin UI.
+      defaultLayout: [
+        { widgetSlug: 'collections', width: 'full' },
+        { widgetSlug: 'vercel-deployments', width: 'full' },
+      ],
+    },
     meta: { titleSuffix: '- Vercel Deployments Dev' },
     user: 'users',
   },


### PR DESCRIPTION
## Summary
- alt-text: stop mutating `admin.dashboard.defaultLayout`; the health widget is still registered under `admin.dashboard.widgets`, consumers opt in by adding `{ widgetSlug: 'alt-text-health', width: 'full' }` to their own `defaultLayout`. README and CHANGELOG updated.
- alt-text dev + dev_unlocalized apps: set `defaultLayout` explicitly so the widget still shows by default.
- vercel-deployments dev app: set `defaultLayout` explicitly so the deployments widget shows by default — matches the alt-text approach.