### PR TITLE
fix(chat-agent): drop incomplete tool calls before calling the provider

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat!: rename the `chat-conversations` collection to `agent-conversations` and the default `chat-token-usage` budget collection to `agent-token-usage`. Existing projects must migrate data or override `createPayloadBudget({ slug: 'chat-token-usage' })` to keep the previous slug.
 - feat: note in the system prompt that Payload uses Lexical for rich text so the agent reads/writes rich-text field values as Lexical editor JSON state instead of HTML or Markdown
 - fix: redirect unauthenticated visitors of `/admin/chat` to the login page instead of rendering the admin chrome around a "Not authorized" message
+- fix: drop tool calls that never reached a terminal state before forwarding messages to the provider, so resumed conversations with an interrupted tool call no longer fail with `tool_use.input: Input should be a valid dictionary` (or analogous orphan-tool-use errors on other providers)
 
 ## 0.1.0-beta.3
 

--- a/chat-agent/plans/014-headless-agent-runner.md
+++ b/chat-agent/plans/014-headless-agent-runner.md
@@ -1,6 +1,6 @@
 ---
 title: Headless agent runner
-description: Extract the chat endpoint's orchestration into a reusable `runAgent` function so background jobs (cron, Payload jobs queue, webhooks) can invoke the agent off-HTTP — e.g. a weekly content audit — without holding an open connection to a human client.
+description: Extract the chat endpoint's orchestration into a reusable `runAgent` function so background jobs (cron, Payload jobs queue, webhooks) can invoke the agent off-HTTP — e.g. a weekly content audit — without holding an open connection to a browser client.
 type: feature
 readiness: draft
 ---

--- a/chat-agent/plans/014-headless-agent-runner.md
+++ b/chat-agent/plans/014-headless-agent-runner.md
@@ -1,0 +1,255 @@
+---
+title: Headless agent runner
+description: Extract the chat endpoint's orchestration into a reusable `runAgent` function so background jobs (cron, Payload jobs queue, webhooks) can invoke the agent off-HTTP — e.g. a weekly content audit — without holding an open connection to a human client.
+type: feature
+readiness: draft
+---
+
+## Problem
+
+The chat agent today runs only inside the `POST /chat-agent/chat` endpoint. Everything — auth, mode resolution, budget check, tool building, system prompt, model resolution, `streamText` wiring — lives in one handler and hangs off `req` (`src/index.ts:186-362`). The moment the client disconnects, `req.signal` fires and `streamText` aborts, which is the right default for interactive chat (see plan `014-…`? no — see `index.test.ts` "cancels the provider call when the client disconnects mid-stream") but makes headless use impossible:
+
+- No way to trigger an agent run from a Payload task, cron, webhook, or CLI script.
+- No way to run an agent without a logged-in user (there is no client to authenticate).
+- No way to consume the final result as a value instead of an SSE stream.
+
+Concrete motivating use cases:
+
+- **Weekly content audit** — scan all published pages, summarise stale/broken/duplicate content, file a report in a `content-reports` collection or send it to Slack.
+- **On-publish enrichment** — when an editor publishes a blog post, run an agent pass that proposes an alt-text, a social-share blurb, and a category tag, storing them as suggested edits.
+- **Scheduled data sync** — translate newly-created pages into a secondary locale overnight via the `content-translator` plugin's tool surface.
+- **CLI debugging** — run the same agent against the local DB from a script to reproduce a production issue.
+
+None of these have a client. They need a synchronous, awaitable function that reuses the exact tool/prompt/model machinery the chat endpoint uses.
+
+## Proposal
+
+Extract a single function — `runAgent` — that owns everything the chat endpoint currently does from "after validation" through "before `toUIMessageStreamResponse`". Both the HTTP handler and a Payload job/cron become thin wrappers.
+
+### Public surface
+
+```ts
+// chat-agent/src/runAgent.ts
+import type { ModelMessage, StreamTextResult, ToolSet, UIMessage } from 'ai'
+import type { Payload, PayloadRequest } from 'payload'
+
+import type { AgentMode, ChatAgentPluginOptions } from './types.js'
+
+export interface RunAgentOptions {
+  /** Payload Local API instance. */
+  payload: Payload
+
+  /**
+   * The conversation so far. Accepts the same `UIMessage[]` shape the chat
+   * endpoint takes (from the AI SDK `useChat`), a provider-ready
+   * `ModelMessage[]`, or a single string prompt for the common one-shot case.
+   */
+  messages: ModelMessage[] | string | UIMessage[]
+
+  /**
+   * The user context the agent acts as. Pass the logged-in user for
+   * interactive use, or a synthetic service-account user for background jobs.
+   * The tools inherit this user's Payload access unless `overrideAccess` is
+   * set.
+   */
+  user: null | { id: number | string; [key: string]: unknown }
+
+  /**
+   * Bypass Payload access control when executing tools. Defaults to `false`.
+   * Background jobs typically want `true` so the agent can read/write across
+   * the whole dataset. Required to run in mode `superuser`.
+   */
+  overrideAccess?: boolean
+
+  /** Which mode to run in. Defaults to the plugin's default mode. */
+  mode?: AgentMode
+
+  /** Model id. Defaults to the plugin's `defaultModel`. */
+  model?: string
+
+  /**
+   * Per-call step cap. Defaults to the plugin's `maxSteps`. Background jobs
+   * generally want a tighter bound than interactive chat.
+   */
+  maxSteps?: number
+
+  /**
+   * Replace the derived system prompt entirely, or extend it. `(base) => string`
+   * lets jobs append task-specific instructions without re-deriving the
+   * collection/globals summary.
+   */
+  systemPrompt?: string | ((basePrompt: string) => string)
+
+  /**
+   * Filter or replace the tool set. `(base) => ToolSet` lets jobs run a
+   * narrow slice (e.g. read-only) without touching plugin config. Defaults to
+   * the plugin's per-mode tool selection.
+   */
+  tools?: ((baseTools: ToolSet) => ToolSet) | ToolSet
+
+  /** Abort signal. Interactive callers pass `req.signal`; jobs omit it. */
+  abortSignal?: AbortSignal
+
+  /**
+   * Skip the plugin's budget check/record hooks. Defaults to `false`. Set
+   * `true` for service-account runs where per-user budgets don't apply.
+   */
+  skipBudget?: boolean
+
+  /**
+   * Forwarded to `buildTools` when tools need to call custom endpoints. The
+   * HTTP handler passes `req`; background jobs can pass a minimal
+   * `{ payload, user }` shim or omit it (custom-endpoint tools are skipped).
+   */
+  req?: PayloadRequest
+}
+
+/** Result mirrors `streamText`'s handle so callers choose how to consume it. */
+export type RunAgentResult = StreamTextResult<ToolSet, never>
+
+export function createAgentRunner(
+  pluginOptions: ChatAgentPluginOptions,
+): (opts: RunAgentOptions) => Promise<RunAgentResult>
+```
+
+Consumption patterns:
+
+```ts
+// 1. HTTP handler — today's chat endpoint becomes a thin wrapper.
+const result = await runAgent({
+  payload: req.payload,
+  user: req.user,
+  messages: body.messages,
+  mode: body.mode,
+  model: body.model,
+  abortSignal: req.signal,
+  req,
+})
+return result.toUIMessageStreamResponse({ headers, messageMetadata })
+
+// 2. Background job — await to completion, read the final text.
+const result = await runAgent({
+  payload,
+  user: { id: 'system', email: 'agent@internal' },
+  overrideAccess: true,
+  mode: 'read',
+  messages: 'Audit all pages in the `pages` collection published in the last 7 days. List ones with fewer than 200 words or without a hero image.',
+  maxSteps: 40,
+  skipBudget: true,
+})
+const report = await result.text
+await payload.create({ collection: 'content-reports', data: { body: report } })
+
+// 3. One-shot tool-call — narrow the tool set explicitly.
+const result = await runAgent({
+  payload,
+  user,
+  messages: prompt,
+  tools: (base) => ({ find: base.find, findByID: base.findByID }),
+})
+```
+
+### Wiring from the plugin
+
+The plugin factory exposes `runAgent` on `config.custom.chatAgent` so consumers can reach it from their own tasks without importing the module directly:
+
+```ts
+// Consumer code — e.g. a Payload task handler.
+export const weeklyAudit: TaskHandler = async ({ req }) => {
+  const { runAgent } = req.payload.config.custom.chatAgent
+  const result = await runAgent({
+    payload: req.payload,
+    user: null,
+    overrideAccess: true,
+    mode: 'read',
+    messages: 'Produce a content audit…',
+  })
+  // …persist result.text somewhere.
+}
+```
+
+Also re-exported from the top-level entry point for callers that already have the plugin options in hand but not `payload.config.custom`:
+
+```ts
+import { createAgentRunner } from '@jhb.software/payload-chat-agent'
+const runAgent = createAgentRunner(pluginOptions)
+```
+
+### What moves where
+
+`src/index.ts:186-362` splits into:
+
+1. `src/runAgent.ts` — owns mode resolution, budget check, tool discovery, tool filtering, system-prompt build, model resolution, `streamText` call. Pure — no `Response` / HTTP awareness.
+2. `src/index.ts` handler — parses/validates the body, calls `runAgent`, wraps the result with `toUIMessageStreamResponse` and the budget headers.
+
+No consumer-visible change to the HTTP contract. Existing tests in `index.test.ts` keep passing unchanged.
+
+### Auth / service-account model
+
+Deliberately simple: the caller supplies `user` and `overrideAccess` directly. The plugin does not invent a "system user" concept — consumers already have their own conventions (a seeded admin user, a dedicated `role: 'agent'` user, `{ id: 'system' }` for audit-log readability). We validate only:
+
+- `mode: 'superuser'` requires `overrideAccess: true` (mirrors today's handler: `const overrideAccess = mode === 'superuser'`).
+- `user: null` is allowed only when `overrideAccess: true` (otherwise every tool call hits access checks with no subject and fails).
+
+Access-function callers like `options.access` and `modes.access` are skipped entirely for headless runs — those are HTTP gating logic, not execution logic.
+
+### Budget semantics for headless
+
+Per-user budgets don't apply to background jobs. Options:
+
+- `skipBudget: true` (default for headless in practice) — neither `check` nor `record` runs.
+- `skipBudget: false` with a synthetic user — the plugin consumer's `BudgetConfig.check({ req })` signature gets a synthetic `req`; that's enough rope to either charge a dedicated "system" bucket or fall through.
+
+We do **not** add a separate `systemBudget` option. If it becomes a real need we'll revisit, but most teams will track headless spend via cloud provider billing rather than per-user counters.
+
+### Persistence
+
+Out of scope. The chat endpoint persists via the client, and headless callers decide where results land — no two audit pipelines want the same schema. If demand appears we can add a thin helper:
+
+```ts
+await runAgent({ …, persistAs: { collection: 'agent-conversations', title: 'Weekly audit 2026-W16' } })
+```
+
+but ship it in a follow-up.
+
+### Messages normalisation
+
+`messages` accepts three shapes:
+
+1. `string` — wrapped as `[{ role: 'user', content: string }]` (ModelMessage).
+2. `UIMessage[]` — run through `convertToModelMessages(…, { ignoreIncompleteToolCalls: true })` (the same path the HTTP handler uses today).
+3. `ModelMessage[]` — passed through verbatim for callers that already built them.
+
+Discrimination is structural: strings by `typeof`, then `Array.isArray(messages[0]?.parts)` for `UIMessage` vs. `messages[0]?.content` for `ModelMessage`. Document the precedence in the JSDoc.
+
+### Custom endpoints tool
+
+`buildTools`' custom-endpoint branch (`src/tools.ts:477-...`) needs `req` because it calls user-defined endpoint handlers. For headless callers we have two options:
+
+- **Skip custom-endpoint tools when `req` is absent** (simplest, documented). The agent loses those tools for background runs; most don't need them.
+- **Synthesize a minimal `req`** — `{ payload, user, i18n, locale, fallbackLocale, headers: new Headers(), …Object.create(null) }`. Works for well-behaved custom endpoints but leaks the fake-req abstraction into plugin territory.
+
+Ship with option 1. Upgrade to option 2 if a consumer hits the limit.
+
+## Open questions
+
+1. **Return shape**: return the raw `streamText` handle, or a richer object (`{ text, toolCalls, usage, stream }`)? The raw handle gives callers maximum flexibility (stream vs. await) and matches the existing handler's call site — lean that way unless reviewers disagree.
+
+2. **Abort default for headless**: today the HTTP path passes `req.signal`. Headless callers who forget to pass `abortSignal` can leak a long-running `streamText` on process exit. Consider defaulting to a signal tied to `process.on('SIGTERM')` when none is given, or clearly document that callers own lifetime.
+
+3. **Step cap default for headless**: interactive uses `maxSteps: 20`. For a weekly audit that reads the whole site, 20 is too low; 100+ may be appropriate. Revisit when the first real consumer ships — for now the option is a straight pass-through and the default matches the HTTP path.
+
+4. **Discoverability**: do we ship a thin `payloadTask` helper (`createAgentTask({ input, instruction, onResult })`) that wraps `runAgent` + `payload.jobs.queue` boilerplate, or leave orchestration to the consumer? Leaning toward "not yet" — the boilerplate is ~15 lines and a helper locks in opinions about where results go.
+
+## Non-goals
+
+- **Resumable streams / long-running interactive sessions.** `experimental_resume` and stream continuation across multiple HTTP requests are a separate, bigger problem. The fix from commit `d067193` (`ignoreIncompleteToolCalls: true`) is the pragmatic patch until we tackle that deliberately.
+- **Scheduling primitives.** Payload has its `jobs` queue; teams use Vercel Cron, GitHub Actions, etc. The plugin provides the runner; the caller provides the trigger.
+- **Multi-agent orchestration.** One `runAgent` call = one agent. Fan-out/fan-in patterns live above this API.
+
+## Test plan
+
+- Unit: `runAgent` with `user: null` + `overrideAccess: false` rejects. `mode: 'superuser'` + `overrideAccess: false` rejects. `skipBudget: true` never calls `budget.check`. `messages: 'hi'` normalises to a single user ModelMessage.
+- Integration: wire a synthetic Payload + stubbed model factory; call `runAgent` with each of the three `messages` shapes and assert `streamText` receives an equivalent prompt.
+- Regression: the existing `index.test.ts` suite must pass unchanged — the HTTP handler keeps the same observable contract.
+- Docs: add a "Running the agent from a job" section to `chat-agent/README.md` with the audit example.

--- a/chat-agent/plans/015-detached-agent-runs.md
+++ b/chat-agent/plans/015-detached-agent-runs.md
@@ -1,0 +1,154 @@
+---
+title: Detached agent runs (leave-and-come-back)
+description: Let users submit a prompt and walk away — the agent keeps running server-side, persists progress as it goes, and the browser picks the conversation back up on reopen. Builds on `runAgent` (plan 014).
+type: feature
+readiness: idea
+---
+
+> **Not scheduled.** This is a future direction, kept here so the shape is documented before anyone reaches for it. Plan [014](./014-headless-agent-runner.md) (`runAgent`) ships first; this plan only becomes tractable once `runAgent` exists and removes the "HTTP handler is the only entry point" constraint.
+
+## Problem
+
+Today a chat turn's lifetime is the HTTP response stream. If the browser tab closes — deliberately or because the user walks away — the server aborts the LLM call via `req.signal` (intentional cost control) and the turn is lost. The partial state is either discarded, or saved client-side via `onError` and re-sent on next load (which is how corrupt `tool_use.input` bugs crept in; see commit `d067193`).
+
+For long-running turns — a site-wide audit, a multi-step refactor plan, a translation batch across 200 pages — this makes the UX brittle:
+
+- User has to keep the tab open and the laptop awake for minutes.
+- Any network hiccup kills the run.
+- There's no "submit and check back later" option.
+- Multi-device (start on desktop, finish reading on phone) is impossible.
+
+Background jobs via `runAgent` (plan 014) solve *scheduled* and *non-interactive* use cases but don't help an interactive user who wants to detach mid-run.
+
+## Proposal
+
+Decouple the chat turn's compute lifetime from any one HTTP connection. The user submits a prompt; the server enqueues a job; the UI subscribes to a progress feed. Closing the browser does not abort the run; reopening rehydrates wherever the agent currently is.
+
+### High-level flow
+
+```
+Browser                         Chat endpoint                 Job worker                LLM provider
+   │                                  │                            │                         │
+   │ POST /chat-agent/chat  ─────────▶│                            │                         │
+   │  { messages, mode, …,            │                            │                         │
+   │    detached: true }              │ jobs.queue({               │                         │
+   │                                  │   task: 'agent-run',       │                         │
+   │                                  │   input: {conversationId,  │                         │
+   │                                  │     messages, mode, …}})   │                         │
+   │ 202 Accepted ◀──────────────────┤                            │                         │
+   │   { runId }                      │                            │                         │
+   │                                  │                            │                         │
+   │                                  │                            │ runAgent(...)  ────────▶│
+   │ GET /chat-agent/chat/runs/:id   ─┼──────────▶ subscribe ──────▶│  (streaming)            │
+   │   (SSE)                          │                            │                         │
+   │ ◀── text delta                   │                            │  persists each          │
+   │ ◀── tool-call                    │                            │  delta to               │
+   │ ◀── tool-result                  │                            │  agent-conversations    │
+   │ ◀── finish                       │                            │                         │
+```
+
+Key properties:
+
+- The `POST /chat-agent/chat` endpoint is non-streaming when `detached: true` — it returns immediately after enqueueing.
+- The job worker is the sole consumer of the LLM stream. It persists every chunk into the conversation document (or a sibling `agent-runs` collection) as it arrives.
+- The client reconnects via a *separate* read-only SSE endpoint (`/chat-agent/chat/runs/:id`) that tails the persisted stream, so reopening the browser later just resumes the tail from whatever's stored.
+
+### Payload jobs integration
+
+This is the natural fit for Payload's jobs/queues system. Concretely:
+
+```ts
+// Consumer-side Payload config.
+jobs: {
+  tasks: [
+    {
+      slug: 'agent-run',
+      inputSchema: z.object({
+        conversationId: z.union([z.string(), z.number()]),
+        messages: z.array(z.unknown()),
+        mode: z.enum(AGENT_MODES).optional(),
+        model: z.string().optional(),
+        userId: z.union([z.string(), z.number()]).nullable(),
+      }),
+      handler: async ({ input, req }) => {
+        const { runAgent } = req.payload.config.custom.chatAgent
+        const user = input.userId
+          ? await req.payload.findByID({ collection: 'users', id: input.userId })
+          : null
+        const result = await runAgent({
+          payload: req.payload,
+          user,
+          messages: input.messages,
+          mode: input.mode,
+          model: input.model,
+          overrideAccess: user == null,
+        })
+
+        // Persist each chunk as it arrives so the browser-side tail sees progress.
+        for await (const chunk of result.fullStream) {
+          await appendToConversation(req.payload, input.conversationId, chunk)
+        }
+        return { status: 'done' }
+      },
+    },
+  ],
+},
+```
+
+What Payload gives us for free:
+
+1. **Persisted input / output.** The job record stores the prompt and the final result, so reruns and audits are trivial.
+2. **State machine.** `queued` → `running` → `succeeded` / `failed`, with timestamps. The UI can surface "running since 2m ago" without the plugin inventing a schema.
+3. **Retry policy.** Configurable per-task. For LLM runs we'd cap at 1 retry or 0 — the cost of a re-run is real money, and partial progress is already persisted in the conversation. Default to 0 and document why.
+4. **Worker lifecycle.** Payload supports both inline execution (after-response hook) and dedicated workers (`payload jobs:run` CLI, or a scheduled HTTP trigger on serverless). For agent runs we want **a dedicated worker** — a 5-minute audit will exceed most serverless request timeouts if run inline.
+5. **Scheduling primitive.** `jobs.autoRun` reuses the same task for cron-triggered runs, so plan 014's weekly audit and this plan's interactive-detach converge on a single task slug — just different triggers (cron vs. `jobs.queue`).
+
+What we'd add on top:
+
+- A conversation-scoped **persistence hook** the task calls on every stream chunk. Simplest shape: append a new `agent-conversations.messages[]` entry, or write deltas into a dedicated `agent-runs` collection keyed by `(conversationId, runId)`. The latter keeps the chat message list clean of half-written assistant turns.
+- A **tail endpoint** (`GET /chat-agent/chat/runs/:id`, SSE) that reads from the persistence store and emits an AI-SDK-compatible `UIMessageChunk` stream, so the existing `useChat` transport can consume it without a second client protocol.
+- A **resume-on-load hook** in the client: when `useChat` mounts and the last conversation message is an in-progress assistant run, auto-subscribe to the tail endpoint instead of rendering static history.
+
+### What changes for the browser
+
+`useChat`'s transport grows a third path alongside `prepareSendMessagesRequest`:
+
+- **`immediate` (today's default)** — POST streams the response inline.
+- **`detached`** — POST returns `{ runId }`; the hook opens an SSE subscription to `/chat-agent/chat/runs/:id` and treats that as the stream.
+- **`resume`** — on mount, if the conversation has a pending run, open the subscription without POSTing.
+
+The user opts in per-message or per-conversation. Detached is probably the right default for `mode: 'read-write'` / `'superuser'` turns (slow, expensive); immediate is right for most chat exchanges.
+
+### Scope boundaries
+
+Explicitly **out of scope** for this plan:
+
+- Resuming an *aborted* run. If the worker dies mid-stream, partial progress stays persisted but the run is marked `failed` — user retries manually. True mid-stream resumption would need the AI SDK's `experimental_resume` primitives and provider cooperation.
+- Cross-device session transfer beyond what reopening-the-conversation-URL gives you.
+- Real-time collaboration (two browsers watching the same run). The tail endpoint supports it mechanically, but the UI conflict-resolution story is its own design problem.
+
+### Non-obvious risks
+
+- **Cost runaway.** Without the "tab close → abort" failsafe, a runaway agent burns tokens until it hits `maxSteps`. Budget enforcement (the existing `BudgetConfig.record` hook, called on `onFinish`) becomes more important, not less.
+- **Orphaned runs.** A worker crash leaves `running` jobs stranded. Payload's job machinery handles this via stale-lease recovery, but we need to verify behaviour with long-running LLM calls specifically.
+- **Auth across tabs.** The tail endpoint must gate reads by `conversationId` ownership the same way the existing conversations endpoints do — stealing a `runId` must not leak another user's stream.
+- **Storage growth.** Persisting every delta inflates the conversation document or `agent-runs` table. For a 5-minute audit that's ~thousands of tiny records. Either compact deltas into finished messages on `onFinish`, or TTL the raw deltas and keep only the final assistant message.
+
+## Prerequisites
+
+Hard-blocked on plan 014 (`runAgent`). Until the chat handler's orchestration is extracted, there's no clean way for a job task handler to invoke an agent turn with the same tools/prompt/model config.
+
+## Test plan
+
+Sketched only — actual tests get written alongside implementation.
+
+- Job handler end-to-end: enqueue a run against a stub provider, let the worker drain it, assert the conversation document contains the final assistant message.
+- Tail endpoint: subscribe with a conversation that already has a completed run, assert the endpoint replays the persisted chunks and closes cleanly.
+- Abort semantics: close the tail subscription mid-run, assert the worker keeps running (does *not* abort) and the next subscriber catches up from whatever's persisted.
+- Authorization: a user subscribing to someone else's `runId` gets `401`, even if the `conversationId` is guessable.
+- Cost cap: a run that exceeds `maxSteps` stops cleanly and records usage once via the budget hook, no double-counting.
+
+## Related work
+
+- Plan [014](./014-headless-agent-runner.md) — `runAgent` primitive this depends on.
+- AI SDK resumable streams (`experimental_resume`, `UIMessageStream` resume primitives) — worth revisiting once this plan is picked up; may obviate part of the tail-endpoint design.

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -281,6 +281,73 @@ describe('chatAgentPlugin', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Tool-call sanitization before handing messages to the provider
+// ---------------------------------------------------------------------------
+
+describe('chatAgentPlugin tool-call sanitization', () => {
+  // Regression: when a previous assistant turn's tool call was interrupted
+  // (tab closed, network blip) the AI SDK leaves the tool part in a
+  // non-terminal state with whatever `parsePartialJson` last returned as
+  // `input` — often a string or `undefined`, not a dictionary. If those
+  // messages are forwarded verbatim, Anthropic rejects the request with:
+  //   messages.N.content.M.tool_use.input: Input should be a valid dictionary
+  // and orphan `tool_use` blocks (no matching `tool_result`) surface the
+  // same class of failure on other providers. The handler must drop these
+  // incomplete tool calls before calling the model.
+  it('drops interrupted tool calls so the provider never sees a non-dict tool_use input', async () => {
+    vi.mocked(streamText).mockClear()
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+    })
+    const handler = plugin({ endpoints: [] }).endpoints.find(
+      (ep: Endpoint) => ep.path === '/chat-agent/chat',
+    ).handler
+
+    await handler({
+      json: () =>
+        Promise.resolve({
+          messages: [
+            { id: 'u1', parts: [{ type: 'text', text: 'find docs about X' }], role: 'user' },
+            {
+              id: 'a1',
+              parts: [
+                {
+                  input: '"part',
+                  state: 'input-available',
+                  toolCallId: 'call_1',
+                  type: 'tool-search',
+                },
+              ],
+              role: 'assistant',
+            },
+          ],
+        }),
+      payload: { config: { collections: [], globals: [] } },
+      user: { id: 1 },
+    })
+
+    const sent = vi.mocked(streamText).mock.calls[0][0].messages as Array<{
+      content: unknown
+      role: string
+    }>
+    for (const msg of sent) {
+      if (!Array.isArray(msg.content)) {
+        continue
+      }
+      for (const part of msg.content as Array<{ input?: unknown; type: string }>) {
+        if (part.type !== 'tool-call') {
+          continue
+        }
+        expect(part.input).not.toBeNull()
+        expect(typeof part.input).toBe('object')
+        expect(Array.isArray(part.input)).toBe(false)
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Mode-related endpoint tests
 // ---------------------------------------------------------------------------
 

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -313,10 +313,10 @@ describe('chatAgentPlugin tool-call sanitization', () => {
               id: 'a1',
               parts: [
                 {
+                  type: 'tool-search',
                   input: '"part',
                   state: 'input-available',
                   toolCallId: 'call_1',
-                  type: 'tool-search',
                 },
               ],
               role: 'assistant',

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -328,13 +328,9 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
             // listening to.
             const result = streamText({
               abortSignal: req.signal,
-              // `ignoreIncompleteToolCalls` drops tool parts that never reached
-              // a terminal state (stream aborted mid-input, pending approval
-              // that the UI never resolved, etc.). Without it, resumed
-              // conversations can forward a `tool_use` whose `input` is still
-              // the partial value `parsePartialJson` left behind — often a
-              // string or `undefined` — and Anthropic rejects with
-              // `tool_use.input: Input should be a valid dictionary`.
+              // Drop tool parts from interrupted prior turns so the provider
+              // never sees a `tool_use` with a partial/non-dict input or an
+              // orphan `tool_use` missing its `tool_result`.
               messages: await convertToModelMessages(
                 body.messages as Parameters<typeof convertToModelMessages>[0],
                 { ignoreIncompleteToolCalls: true },

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -328,8 +328,16 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
             // listening to.
             const result = streamText({
               abortSignal: req.signal,
+              // `ignoreIncompleteToolCalls` drops tool parts that never reached
+              // a terminal state (stream aborted mid-input, pending approval
+              // that the UI never resolved, etc.). Without it, resumed
+              // conversations can forward a `tool_use` whose `input` is still
+              // the partial value `parsePartialJson` left behind — often a
+              // string or `undefined` — and Anthropic rejects with
+              // `tool_use.input: Input should be a valid dictionary`.
               messages: await convertToModelMessages(
                 body.messages as Parameters<typeof convertToModelMessages>[0],
+                { ignoreIncompleteToolCalls: true },
               ),
               model: resolvedModel,
               onFinish,


### PR DESCRIPTION
## Summary
This fix prevents the chat agent from sending incomplete or malformed tool calls to the AI provider, which was causing request rejections from providers like Anthropic.

## Problem
When a previous assistant turn's tool call was interrupted (e.g., due to a closed tab or network issue), the AI SDK would leave the tool call in a non-terminal state with a partial or invalid `input` value (often a string or `undefined` instead of a dictionary). When these messages were forwarded verbatim to the provider, it would reject the request with errors like:
- `messages.N.content.M.tool_use.input: Input should be a valid dictionary`
- Orphan `tool_use` blocks without matching `tool_result` entries

## Changes
- **index.ts**: Added `ignoreIncompleteToolCalls: true` option when converting messages to the model format, ensuring incomplete tool calls are dropped before being sent to the provider
- **index.test.ts**: Added regression test that verifies interrupted tool calls with non-dictionary inputs are sanitized before reaching the provider

## Implementation Details
The fix leverages the existing `convertToModelMessages` function's capability to filter out incomplete tool calls. This ensures the provider only receives well-formed tool calls with valid dictionary inputs and proper `tool_result` pairings.

https://claude.ai/code/session_013bDyvxUhUfxvhFZRpeY6gR