### PR TITLE
feat(chat-agent): clarify draft flag vs _status field in system prompt

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat!: rename the `chat-conversations` collection to `agent-conversations` and the default `chat-token-usage` budget collection to `agent-token-usage`. Existing projects must migrate data or override `createPayloadBudget({ slug: 'chat-token-usage' })` to keep the previous slug.
 - feat: note in the system prompt that Payload uses Lexical for rich text so the agent reads/writes rich-text field values as Lexical editor JSON state instead of HTML or Markdown
+- feat: explain Payload's draft / `_status` model in the system prompt so the agent stops confusing the `draft: true` query arg (returns the latest, possibly unpublished version) with filtering for documents currently in draft state (`where: { _status: { equals: 'draft' } }`)
 - fix: redirect unauthenticated visitors of `/admin/chat` to the login page instead of rendering the admin chrome around a "Not authorized" message
 
 ## 0.1.0-beta.3

--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - feat!: rename the `chat-conversations` collection to `agent-conversations` and the default `chat-token-usage` budget collection to `agent-token-usage`. Existing projects must migrate data or override `createPayloadBudget({ slug: 'chat-token-usage' })` to keep the previous slug.
 - feat: note in the system prompt that Payload uses Lexical for rich text so the agent reads/writes rich-text field values as Lexical editor JSON state instead of HTML or Markdown
-- feat: explain Payload's draft / `_status` model in the system prompt so the agent stops confusing the `draft: true` query arg (returns the latest, possibly unpublished version) with filtering for documents currently in draft state (`where: { _status: { equals: 'draft' } }`)
+- feat: note in the system prompt how Payload's `draft` query flag (versions vs main table, a "latest" flag) differs from the `_status` field (the document's actual `'draft'` / `'published'` state) so the agent stops conflating the two
 - fix: redirect unauthenticated visitors of `/admin/chat` to the login page instead of rendering the admin chrome around a "Not authorized" message
 
 ## 0.1.0-beta.3

--- a/chat-agent/src/system-prompt.test.ts
+++ b/chat-agent/src/system-prompt.test.ts
@@ -81,15 +81,13 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('Lexical')
   })
 
-  it('explains that draft status lives in `_status`, distinct from the `draft` query arg', () => {
-    // Without this, the agent confuses `draft: true` (return the latest
-    // version, which may be an unpublished draft) with filtering for docs
-    // currently in draft state — the latter requires
-    // `where: { _status: { equals: 'draft' } }`.
+  it('distinguishes the `draft` query flag from the `_status` field', () => {
+    // The agent was conflating the two: `draft` selects the versions vs main
+    // table (a "latest" flag); `_status` holds the actual draft/published
+    // state of the document.
     const prompt = buildSystemPrompt({ collections: [], globals: [] })
-    expect(prompt).toContain('_status')
-    expect(prompt).toContain("equals: 'draft'")
-    expect(prompt).toContain('draft: true')
+    expect(prompt).toContain('`draft`')
+    expect(prompt).toContain('`_status`')
   })
 
   it('mentions listEndpoints only when custom endpoints exist', () => {

--- a/chat-agent/src/system-prompt.test.ts
+++ b/chat-agent/src/system-prompt.test.ts
@@ -81,6 +81,17 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('Lexical')
   })
 
+  it('explains that draft status lives in `_status`, distinct from the `draft` query arg', () => {
+    // Without this, the agent confuses `draft: true` (return the latest
+    // version, which may be an unpublished draft) with filtering for docs
+    // currently in draft state — the latter requires
+    // `where: { _status: { equals: 'draft' } }`.
+    const prompt = buildSystemPrompt({ collections: [], globals: [] })
+    expect(prompt).toContain('_status')
+    expect(prompt).toContain("equals: 'draft'")
+    expect(prompt).toContain('draft: true')
+  })
+
   it('mentions listEndpoints only when custom endpoints exist', () => {
     const withEndpoints = buildSystemPrompt({ collections: [], globals: [] }, undefined, true)
     expect(withEndpoints).toContain('listEndpoints')

--- a/chat-agent/src/system-prompt.ts
+++ b/chat-agent/src/system-prompt.ts
@@ -73,6 +73,7 @@ export function buildSystemPrompt(
     "- Respect that your actions are limited by the current user's permissions.",
     '- If a tool call fails with a permission error, tell the user they lack access.',
     '- Payload uses [Lexical](https://lexical.dev) for rich text fields — their values are Lexical editor JSON state, not HTML or Markdown.',
+    "- Drafts: when a collection or global has drafts enabled, the status of its latest version lives in the `_status` field (note the leading underscore) with values `'draft'` or `'published'`. To list documents currently in draft state, filter `where: { _status: { equals: 'draft' } }`. The separate `draft: true` query argument tells Payload to return the latest version (which may be an unpublished draft) instead of the latest published version — it does **not** filter results to drafts only.",
     '',
     '## Token efficiency',
     '- Always use `select` to request only the fields you need. Never fetch all fields when you only need a few.',

--- a/chat-agent/src/system-prompt.ts
+++ b/chat-agent/src/system-prompt.ts
@@ -73,7 +73,7 @@ export function buildSystemPrompt(
     "- Respect that your actions are limited by the current user's permissions.",
     '- If a tool call fails with a permission error, tell the user they lack access.',
     '- Payload uses [Lexical](https://lexical.dev) for rich text fields — their values are Lexical editor JSON state, not HTML or Markdown.',
-    "- Drafts: when a collection or global has drafts enabled, the status of its latest version lives in the `_status` field (note the leading underscore) with values `'draft'` or `'published'`. To list documents currently in draft state, filter `where: { _status: { equals: 'draft' } }`. The separate `draft: true` query argument tells Payload to return the latest version (which may be an unpublished draft) instead of the latest published version — it does **not** filter results to drafts only.",
+    "- Drafts: for versioned collections, the `draft` flag selects which table is read from or written to — the versions table (drafts) or the main collection table (published); it acts as a \"latest version\" flag and relaxes required-field validation on writes. The document's actual status lives in the `_status` field, with values `'draft'` or `'published'`.",
     '',
     '## Token efficiency',
     '- Always use `select` to request only the fields you need. Never fetch all fields when you only need a few.',


### PR DESCRIPTION
## Summary
Updated the system prompt to clarify the distinction between Payload's `draft` query flag and the `_status` field, preventing the agent from conflating these two separate concepts.

## Changes
- Added documentation to the system prompt explaining that:
  - The `draft` flag is a "latest version" selector for versioned collections (chooses between versions table for drafts vs main table for published)
  - It also relaxes required-field validation on writes
  - The `_status` field holds the actual document status (`'draft'` or `'published'`)
- Added test case to verify both concepts are mentioned in the generated prompt

## Details
The agent was previously treating the `draft` query parameter and `_status` field as interchangeable, when they actually serve different purposes. The `draft` flag is a query-time routing mechanism for versioned collections, while `_status` is a document property that tracks the actual publication state. This clarification helps the agent correctly construct queries and understand document state.

https://claude.ai/code/session_017u242Q15nSMHVrt1GF1dj8