### PR TITLE
docs(chat-agent): mark block & lexical schema plans ready

### DIFF
--- a/chat-agent/plans/012-block-schema-tools.md
+++ b/chat-agent/plans/012-block-schema-tools.md
@@ -1,17 +1,17 @@
 ---
 title: Block schema tools
-description: Expose globally-declared Payload blocks to the chat agent so it can discover which blocks exist and inspect each block's field shape before composing `blocks` content (or resolving slugs surfaced by other schema tools).
+description: Expose globally-declared Payload blocks to the chat agent via two new read tools (`listBlocks`, `getBlockSchema`) so it can discover which blocks exist and inspect each block's field shape before composing `blocks` content.
 type: tool
-readiness: draft
+readiness: ready
 ---
 
-> **Related:** plan [`013-rich-text-feature-discovery.md`](./013-rich-text-feature-discovery.md) surfaces _per-field_ lexical features (including which block slugs a `richText` field accepts). That plan depends on the `getBlockSchema` tool defined here to resolve those slugs to fields. Keep the two scopes disjoint — this plan owns the **block catalog**, plan 013 owns **field-level lexical surfacing**.
+> **Scope & sequencing.** This plan ships as its own PR. Plan [`013-rich-text-feature-discovery.md`](./013-rich-text-feature-discovery.md) is an independent follow-up that surfaces per-`richText`-field lexical features and emits block slugs under `lexical.options.blocks.slugs`; those slugs are resolved via the `getBlockSchema` tool added here. **Plan 012 does not add any lexical keys to `FieldSchema`.** That surface is entirely 013's concern.
 
 ## Problem
 
 The agent can inspect collections and globals via `getCollectionSchema` / `getGlobalSchema`, but it cannot reason about **blocks** as first-class, reusable schema entities.
 
-Blocks declared at the root `config.blocks` (Payload's global block registry, referenced from fields via `blockReferences`) are only visible to the agent when it happens to inspect a collection/global whose field tree references them. If the user asks _"what blocks can I put on a page?"_ or _"show me the `callToAction` block schema"_, there's no direct tool.
+Blocks declared at the root `config.blocks` (Payload's global block registry, referenced from fields via `blockReferences`) are only visible to the agent when it happens to inspect a collection/global whose field tree references them. If the user asks _"what blocks can I put on a page?"_ or _"show me the `callToAction` block schema"_, there is no direct tool.
 
 Goal: two new read tools so the agent can enumerate and resolve block schemas on demand.
 
@@ -19,116 +19,153 @@ Goal: two new read tools so the agent can enumerate and resolve block schemas on
 
 ### Tool 1: `listBlocks`
 
-Returns the full slug catalog of globally-declared blocks.
+Returns the slug catalog of globally-declared blocks.
 
 - **Input**: none.
-- **Output**: `{ blocks: Array<{ slug: string; labels?: { singular?: string; plural?: string }; interfaceName?: string }> }`.
+- **Output**: `{ blocks: Array<{ slug: string; labels?: { singular?: StaticLabel; plural?: StaticLabel }; interfaceName?: string }> }`.
 - **Source**: `config.blocks` (the sanitized `PayloadConfigForPrompt.blocks`).
-- Only registered when `config` is available (same gate as `getCollectionSchema`).
-- Only returns slugs/labels — **not** fields, to keep the response small. Fields are fetched via `getBlockSchema`.
+- **Registration gate**: only registered when `config` is available (same gate as `getCollectionSchema` / `getGlobalSchema`). When `config.blocks` is `undefined` or an empty array, the tool is still registered if `config` exists — it just returns `{ blocks: [] }`. (Rationale: gate mirrors the other schema tools. The system-prompt bullet uses the stricter `config.blocks?.length > 0` gate so the agent is not told to call a tool that returns nothing.)
+- **Labels**: normalize each label value via the existing `normalizeLabel` helper in `schema.ts:25`. Labels on blocks are Payload's standard `{ singular?, plural? }` shape where each leaf is `string | Record<string, string> | LabelFunction | false`; `normalizeLabel` collapses function/`false` to `undefined`. Omit the `labels` key from the output entry if both singular and plural normalize to `undefined`.
+- Returns slugs/labels/interfaceName only — **not** fields, to keep the response small. Fields are fetched via `getBlockSchema`.
 
 ### Tool 2: `getBlockSchema`
 
 Returns the field schema for a single block.
 
 - **Input**: `{ slug: string }`.
-- **Output**: `{ slug, fields: FieldSchema[], labels?, interfaceName? }` or `{ error: "Unknown block slug \"...\"" }`.
-- **Source**: `config.blocks` registry, resolved via the existing `blocksBySlug` map in `tools.ts:224-228`.
-- Reuses `extractFields` so nested `blockReferences` inside the block's own fields continue to resolve transparently — the agent can drill into composite blocks the same way it drills into collection fields today.
+- **Output** on success: `{ slug: string; fields: FieldSchema[]; labels?: { singular?: StaticLabel; plural?: StaticLabel }; interfaceName?: string }`.
+- **Output** on miss: `{ error: string }` with message `Unknown block slug "<slug>"`.
+- **Source**: `config.blocks` registry, resolved via the existing `blocksBySlug` map built in `tools.ts` before the tool definitions.
+- **Fields**: reuses `extractFields(block.fields ?? [], blocksBySlug)` so nested `blockReferences` inside the block's own fields continue to resolve transparently — the agent can drill into composite blocks the same way it drills into collection fields today.
 
-### System prompt update
+### System-prompt update
 
-Add a single line to the rules block in `system-prompt.ts`:
+Add one rule bullet to `system-prompt.ts`, gated on `config.blocks?.length > 0`:
 
-> Call `listBlocks` to see globally-declared blocks, and `getBlockSchema({ slug })` to inspect a block's fields before inserting it into a `blocks` field (or a lexical `blocks` / `inlineBlocks` slot — see plan 013 for how those slugs are surfaced per field).
+> Call `listBlocks` to see globally-declared blocks, and `getBlockSchema({ slug })` to inspect a block's fields before inserting it into a `blocks` field.
 
-No slug catalog for blocks in the prompt itself — the list could be long and the agent can fetch it on demand.
+No slug catalog for blocks in the prompt itself — the list could be long, and the agent can fetch it on demand.
 
 ## Implementation
 
 ### 1. `schema.ts`
 
-- Add `lexicalBlocks?: { slug: string }[]` and `lexicalInlineBlocks?: { slug: string }[]` to `FieldSchema`.
-- In `extractFields`, after the `field.name` guard, add a branch for `field.type === 'richText'` that:
-  - Walks `field.editor?.features` (array) or `resolvedFeatureMap` (Map) looking for the `blocks` feature.
-  - Normalizes each entry to `{ slug }`.
-  - Registers full inline `Block` objects into the caller-provided `blocksBySlug` — note this requires `blocksBySlug` to be mutable, which it already is in the `tools.ts` call site (plain object literal).
-- Export a small helper `collectLexicalBlocks(field, blocksBySlug)` that returns `{ blocks, inlineBlocks }` for reuse/testability.
-
-### 2. `tools.ts`
-
-- Add `listBlocks` and `getBlockSchema` inside the existing `config ?` conditional so they share the same gate as the other schema tools.
-- Append `'listBlocks'` and `'getBlockSchema'` to `READ_TOOL_NAMES` so read/ask modes include them.
+Extend `RawBlock` (currently at `schema.ts:52-55`) with optional fields that `listBlocks` / `getBlockSchema` expose:
 
 ```ts
-listBlocks: {
-  description: 'List all globally-declared blocks (config.blocks). These blocks can be referenced from `blocks` fields and inserted into lexical fields configured with BlocksFeature.',
-  execute: () => ({
-    blocks: (config.blocks ?? []).map((b) => ({
-      slug: b.slug,
-      // labels / interfaceName are optional on the loose RawBlock shape
-      ...(b as { labels?: unknown; interfaceName?: string }).labels !== undefined && { labels: (b as any).labels },
-      ...typeof (b as any).interfaceName === 'string' && { interfaceName: (b as any).interfaceName },
-    })),
-  }),
-  inputSchema: z.object({}),
-}
-
-getBlockSchema: {
-  description: 'Get the field schema for a globally-declared block by slug. Call listBlocks first to discover slugs.',
-  execute: (input) => {
-    const slug = input.slug as string
-    const block = blocksBySlug[slug]
-    if (!block) return { error: `Unknown block slug "${slug}"` }
-    return {
-      slug,
-      fields: extractFields(block.fields ?? [], blocksBySlug),
-    }
-  },
-  inputSchema: z.object({ slug: z.string().describe('Block slug from listBlocks') }),
+export interface RawBlock {
+  fields?: readonly unknown[]
+  slug: string
+  labels?: { singular?: unknown; plural?: unknown }
+  interfaceName?: string
 }
 ```
 
+No other changes to `schema.ts`. `FieldSchema` stays as-is. `extractFields` is unchanged.
+
+### 2. `tools.ts`
+
+Register `listBlocks` and `getBlockSchema` inside the existing `config ?` conditional (the same block that already defines `getCollectionSchema` / `getGlobalSchema` / `listEndpoints`). Append `'listBlocks'` and `'getBlockSchema'` to `READ_TOOL_NAMES` at `tools.ts:31-39`.
+
+Reference implementation (use this shape; no `as any` casts):
+
+```ts
+listBlocks: {
+  description:
+    'List all globally-declared blocks (config.blocks). These blocks can be referenced from `blocks` fields and inserted into lexical fields configured with BlocksFeature.',
+  inputSchema: z.object({}),
+  execute: () => ({
+    blocks: (config.blocks ?? []).map((block) => {
+      const singular = normalizeLabel(block.labels?.singular)
+      const plural = normalizeLabel(block.labels?.plural)
+      const labels =
+        singular !== undefined || plural !== undefined
+          ? { ...(singular !== undefined && { singular }), ...(plural !== undefined && { plural }) }
+          : undefined
+      return {
+        slug: block.slug,
+        ...(labels && { labels }),
+        ...(typeof block.interfaceName === 'string' && { interfaceName: block.interfaceName }),
+      }
+    }),
+  }),
+},
+
+getBlockSchema: {
+  description:
+    "Get the field schema for a globally-declared block by slug. Call listBlocks first to discover slugs. Returns { error } if the slug is unknown.",
+  inputSchema: z.object({ slug: z.string().describe('Block slug from listBlocks') }),
+  execute: ({ slug }) => {
+    const block = blocksBySlug[slug]
+    if (!block) return { error: `Unknown block slug "${slug}"` }
+    const singular = normalizeLabel(block.labels?.singular)
+    const plural = normalizeLabel(block.labels?.plural)
+    const labels =
+      singular !== undefined || plural !== undefined
+        ? { ...(singular !== undefined && { singular }), ...(plural !== undefined && { plural }) }
+        : undefined
+    return {
+      slug,
+      fields: extractFields((block.fields as RawField[] | undefined) ?? [], blocksBySlug),
+      ...(labels && { labels }),
+      ...(typeof block.interfaceName === 'string' && { interfaceName: block.interfaceName }),
+    }
+  },
+},
+```
+
+Import `normalizeLabel` from `./schema.js` alongside `extractFields`. The `RawField` cast on `block.fields` mirrors how `extractFields` already narrows untyped field arrays elsewhere in the file.
+
 ### 3. `system-prompt.ts`
 
-- Add one rule bullet as described above, gated on `config.blocks?.length` being non-zero (so configs without any global blocks don't get noise).
+Add the bullet described above, next to the existing schema-related rules (current version lives around `system-prompt.ts:65`). Gate on `config.blocks?.length > 0`.
 
-### 4. `RawBlock` shape
+### 4. Contract test + stale comment
 
-- Extend `RawBlock` in `schema.ts` with optional `labels?: { singular?: string; plural?: string }` and `interfaceName?: string` so `listBlocks` can expose them without casts (keep them optional — many blocks won't have them).
+- `tools.test.ts` has a contract test around lines 41-56 that locks the full set of tool names. Add `'listBlocks'` and `'getBlockSchema'` to it.
+- `tools.test.ts` has a stale comment around lines 784-786 that asserts these tools do not yet exist. Update or delete it.
 
 ## Tests
 
-Test-driven per CLAUDE.md — write failing tests first.
+Test-driven per `CLAUDE.md` — write failing tests first.
 
 ### `tools.test.ts`
 
-- **listBlocks returns slugs from config.blocks**: build a config with two global blocks (`hero`, `callToAction`), invoke tool, assert both slugs present.
-- **listBlocks is absent when config has no blocks**: config with `blocks: []` → tool is not registered (keeps parity with current gating pattern for no-custom-endpoints).
-- **getBlockSchema returns fields for a known block**: invoke with `slug: 'hero'`, assert returned `fields` includes the block's fields (by name).
-- **getBlockSchema returns `{ error }` for an unknown slug**: invoke with `slug: 'nope'`, assert error payload.
-- **getBlockSchema resolves nested blockReferences**: block A contains a `blocks` field whose `blockReferences: ['child']` points at block B; assert the resolved schema contains block B's fields under the nested block.
-- **Both tools are filtered in on read mode**: `filterToolsByMode(tools, 'read')` keeps them (they're reads).
-
-### `schema.test.ts` (new or existing)
-
-- **extractFields surfaces lexical BlocksFeature slugs**: field of `type: 'richText'` with an `editor.features` entry of `key: 'blocks'` and `serverFeatureProps.blocks: [{ slug: 'hero', fields: [...] }, 'callToAction']` produces `{ type: 'richText', lexicalBlocks: [{ slug: 'hero' }, { slug: 'callToAction' }] }`.
-- **Inline lexical blocks are registered into the shared blocksBySlug**: passing the same inline `Block` object in a lexical `BlocksFeature` and later calling `getBlockSchema('hero')` succeeds.
-- **richText without BlocksFeature emits neither key**: assert `lexicalBlocks` and `lexicalInlineBlocks` are undefined (not `[]`).
+- **`listBlocks` returns slugs from `config.blocks`.** Build a config with two global blocks (`hero`, `callToAction`), invoke the tool, assert both slugs present, order preserved.
+- **`listBlocks` surfaces normalized labels and `interfaceName` when set.** One block with `labels: { singular: 'Hero', plural: 'Heroes' }, interfaceName: 'HeroBlock'`; assert they round-trip as plain strings, `interfaceName === 'HeroBlock'`.
+- **`listBlocks` omits `labels` when both leaves normalize to undefined.** Block with `labels: { singular: () => 'X' }` (function form) → output entry has no `labels` key (not `labels: {}`).
+- **`listBlocks` returns `{ blocks: [] }` when `config.blocks` is empty or absent.** Tool is still registered as long as `config` is present.
+- **Tools are absent when `config` is not passed.** Matches the existing `config ?` gate for `getCollectionSchema` / `getGlobalSchema`.
+- **`getBlockSchema` returns fields for a known slug.** Invoke with `slug: 'hero'`; assert returned `fields` includes the block's declared fields by name.
+- **`getBlockSchema` returns `{ error }` for an unknown slug.** Invoke with `slug: 'nope'`; assert exact error string.
+- **`getBlockSchema` resolves nested `blockReferences`.** Block A contains a `blocks` field whose `blockReferences: ['child']` points at block B; assert the resolved schema contains block B's fields under the nested block (exercises the shared `blocksBySlug` and `extractFields`).
+- **Read/ask-mode filter keeps both tools.** `filterToolsByMode(tools, 'read')` and `filterToolsByMode(tools, 'ask')` include `listBlocks` and `getBlockSchema`.
+- **Contract test at `tools.test.ts:41-56` is extended.** The locked tool-name set includes `'listBlocks'` and `'getBlockSchema'`.
 
 ### `system-prompt.test.ts`
 
-- New bullet appears only when `config.blocks` has entries.
+- **New bullet is included when `config.blocks` has entries.**
+- **New bullet is absent when `config.blocks` is `[]` or `undefined`.**
 
 ## Non-goals
 
 - **Not a block authoring/editing tool.** The agent uses `create` / `update` with `data` that includes blocks — no separate `addBlock` tool. These schema tools exist so the agent knows _what_ to put into that `data`.
-- **No runtime validation of block data.** Payload's own validation is authoritative; the agent should not try to precheck.
-- **No dedicated tool for a single lexical field's allowed blocks.** That's already covered by `getCollectionSchema` + the new `lexicalBlocks` keys on the field schema.
+- **No runtime validation of block data.** Payload's own validation is authoritative; the agent must not try to precheck.
+- **No per-field lexical surfacing.** Covered by plan 013. Do not add `lexicalBlocks` / `lexicalInlineBlocks` / `lexical` keys on `FieldSchema` in this plan.
+- **No i18n label resolution.** `normalizeLabel` collapses `LabelFunction` / `false` to `undefined`; agent treats the remaining `string | Record<string,string>` as opaque.
 - **No caching.** `config.blocks` is in memory already; resolution is trivial.
 
-## Open questions / decisions
+## Resolved decisions
 
-- **Label translation.** `labels` can be a function or an i18n record. `listBlocks` should surface the raw value and let the agent treat it as opaque — do not try to resolve `t()` server-side. Confirm by reading one real config.
-- **Inline blocks on `FieldSchema.lexicalInlineBlocks`.** Naming: `lexicalInlineBlocks` is verbose but unambiguous. Alternative: fold into a single `lexicalBlocks: { slug, inline?: true }[]` to keep the shape flat. Decision: keep them separate — they're addressed by different lexical nodes (`BlocksNode` vs `InlineBlocksNode`) and the agent needs to know which is which when composing content.
-- **Tool naming.** `listBlocks` / `getBlockSchema` mirror `listEndpoints` / `getCollectionSchema`. Confirmed to match existing convention.
+- **Labels.** Normalize via the existing `normalizeLabel` helper in `schema.ts`. Each `{ singular, plural }` leaf is normalized independently; if both collapse to `undefined`, the `labels` key is omitted from the tool output entry.
+- **Tool naming.** `listBlocks` / `getBlockSchema` — mirrors `listEndpoints` / `getCollectionSchema`.
+- **`RawBlock` extension.** Add optional `labels?: { singular?: unknown; plural?: unknown }` and `interfaceName?: string`. Both stay optional — many blocks omit them.
+- **Empty-catalog behavior.** `listBlocks` returns `{ blocks: [] }` when there are no global blocks; tool stays registered as long as `config` is present. The system-prompt bullet uses the stricter `config.blocks?.length > 0` gate to avoid telling the agent to call a tool that returns nothing.
+- **Per-field lexical surfacing.** Out of scope — owned by plan 013. This plan does **not** touch `FieldSchema`.
+- **Sequencing.** Ships first; plan 013 builds on the tools added here.
+
+## Changelog
+
+Add one `## Unreleased` → `### Added` (or `feat:` bullet) entry to `chat-agent/CHANGELOG.md`:
+
+> `listBlocks` and `getBlockSchema` tools to let the agent enumerate and inspect globally-declared blocks.

--- a/chat-agent/plans/013-rich-text-feature-discovery.md
+++ b/chat-agent/plans/013-rich-text-feature-discovery.md
@@ -2,31 +2,31 @@
 title: Rich-text feature discovery in schema tools
 description: Surface the enabled lexical features of every `richText` field in the extracted schema so the agent knows which node types (headings, lists, links, blocks, …) it may emit when generating rich-text content.
 type: tool
-readiness: discussion
+readiness: ready
 ---
+
+> **Scope & sequencing.** Ships as a follow-up PR after [`012-block-schema-tools.md`](./012-block-schema-tools.md) lands. Depends on `getBlockSchema` existing (it resolves the block slugs this plan surfaces under `lexical.options.blocks.slugs`). This plan does **not** require any changes to plan 012's code — it only extends `FieldSchema` and updates `extractFields` + `system-prompt.ts`.
 
 ## Problem
 
-Lexical rich-text fields in Payload are configured per-field with a `features` array (`HeadingFeature`, `BoldFeature`, `LinkFeature`, `BlocksFeature`, `UploadFeature`, etc.). The set of allowed nodes/marks is **not** uniform across the project: one field may allow `h1`–`h6` + lists + links, another may only allow inline marks, a third may allow blocks of a specific subset of slugs.
+Lexical rich-text fields in Payload are configured per-field with a `features` array (`HeadingFeature`, `BoldFeature`, `LinkFeature`, `BlocksFeature`, `UploadFeature`, etc.). The allowed node/mark set is **not** uniform across a project: one field may allow `h1`–`h6` + lists + links, another may only allow inline marks, a third may allow blocks of a specific subset of slugs.
 
-Today `extractFields` (`schema.ts:44-145`) emits `{ name, type: 'richText' }` and stops. The agent therefore has no way to know:
+Today `extractFields` in `schema.ts` emits `{ name, type: 'richText' }` and stops. The agent therefore has no way to know:
 
 - whether headings are allowed, and which levels (`HeadingFeature({ enabledHeadingSizes })`)
 - whether lists, links, uploads, horizontal rules, indents, blockquotes, code, alignment, etc. are enabled
-- what the allowed `headingSizes`, `link.fields`, `upload.collections`, `blocks` / `inlineBlocks` slugs are
+- what the allowed `headingSizes`, `link.fields`, `upload.collections`, `blocks` / `inlineBlocks` slugs, `relationship` collections are
 
 Without this, the model is forced to guess. It will either:
 
-1. produce lexical JSON that contains nodes the editor's validators reject, or
-2. play it safe and only emit paragraphs + text, losing fidelity the schema actually permits.
-
-Plan **012** (`012-block-schema-tools.md`) addresses **only** the `BlocksFeature` slice of this problem (it surfaces `lexicalBlocks` / `lexicalInlineBlocks` slugs). This plan generalises that idea to _every_ lexical feature so the agent can compose any allowed node, not just blocks.
+1. produce lexical JSON that the editor's validators reject, or
+2. play it safe and emit only paragraphs + text, losing fidelity the schema actually permits.
 
 ## Proposal
 
 ### Per-field `lexical` summary on `FieldSchema`
 
-Extend `FieldSchema` with an optional `lexical` object emitted only for `field.type === 'richText'`:
+Extend `FieldSchema` in `schema.ts` with an optional `lexical` object emitted only for `field.type === 'richText'`:
 
 ```ts
 interface FieldSchema {
@@ -36,17 +36,17 @@ interface FieldSchema {
     features: string[]
     /** Per-feature constraints worth telling the agent about. Keys are feature keys. */
     options?: {
-      heading?: { enabledHeadingSizes: ('h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6')[] }
+      heading?: { enabledHeadingSizes?: ('h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6')[] }
       link?: {
         enabledCollections?: string[]
         disabledCollections?: string[]
-        fields?: FieldSchema[] // custom link fields, run through extractFields
+        fields?: FieldSchema[] // custom link fields, run through extractFields when the sanitized shape is an array
       }
       upload?: { collections: string[] }
-      blocks?: { slugs: string[] } // replaces lexicalBlocks from plan 012
-      inlineBlocks?: { slugs: string[] } // replaces lexicalInlineBlocks from plan 012
+      blocks?: { slugs: string[] }
+      inlineBlocks?: { slugs: string[] }
       relationship?: { enabledCollections?: string[]; disabledCollections?: string[] }
-      // …add others as we encounter them; keep the map open-ended
+      // open-ended — additional feature-specific options can be added in follow-ups
     }
   }
 }
@@ -54,45 +54,35 @@ interface FieldSchema {
 
 Design notes:
 
-- **One key per field, not many top-level keys.** Avoids polluting `FieldSchema` with a long list of `lexical*` siblings (cf. plan 012's `lexicalBlocks` / `lexicalInlineBlocks`).
-- **Slugs only, no nested field trees** for blocks/inlineBlocks — the agent calls `getBlockSchema` (plan 012) to drill in.
-- **Open-ended `options`** — we don't try to model every feature exhaustively up front. We surface what we know, ignore what we don't, and grow the map over time.
-- **Omit `lexical` entirely** if the field is not a lexical editor or the editor exposes no recognisable features (e.g. a custom editor). Do not emit `{ features: [] }`.
+- **One `lexical` key per field**, not several top-level `lexical*` siblings.
+- **Slugs only for blocks / inlineBlocks**, no nested field trees — the agent resolves slugs via `getBlockSchema` (from plan 012).
+- **Open-ended `options` map.** Only the allow-list of known keys gets a typed projection. Unknown keys still appear in `features` (so the agent knows they exist) but get no `options` entry.
+- **Omit `lexical` entirely** if the field is not a lexical editor or no feature keys are detected. Do not emit `{ features: [] }`.
 
 ### Detection strategy
 
-Lexical's sanitized config exposes features under several shapes depending on Payload version:
+Lexical's sanitized config exposes features under one of two shapes depending on Payload internals:
 
 1. `field.editor.features` — array of `{ key, serverFeatureProps?, clientFeatureProps? }`.
-2. `field.editor.resolvedFeatureMap` — `Map<key, ResolvedServerFeature>` with `.serverFeatureProps`.
-3. Older configs may put props directly on the feature entry.
+2. `field.editor.resolvedFeatureMap` — `Map<key, ResolvedServerFeature>` where each value carries `serverFeatureProps` / similar.
 
-The extractor should:
+The extractor normalizes these to a single iterable of `{ key, props }` entries:
 
-1. Build a normalized iterable of `{ key, props }` from whichever shape is present.
-2. Collect all keys → `features: string[]` (sorted, deduped).
-3. For a small allow-list of "interesting" keys, project `props` into the typed `options[key]` shape above.
-4. Unknown keys still appear in `features` (so the agent knows they exist) but get no `options` entry — that's fine.
+1. If `field.editor?.features` is an array → walk it, taking `serverFeatureProps ?? props ?? {}` as `props`.
+2. Else if `field.editor?.resolvedFeatureMap` is a `Map` → walk its entries, same projection.
+3. Else → return `undefined` (no `lexical` key).
 
-Keep the detection loose / structural to avoid a hard dependency on `@payloadcms/richtext-lexical`, mirroring the approach in plan 012.
+Detection is **structural** (duck-typed) to avoid a hard dependency on `@payloadcms/richtext-lexical`. Do not throw on unrecognised shapes — return `undefined` and let the caller omit the key.
 
-### Folding plan 012 into this plan
-
-Plan 012 introduces `lexicalBlocks` / `lexicalInlineBlocks` as siblings on `FieldSchema`. If both plans land, prefer this plan's nested shape:
-
-```ts
-lexical: { features: ['blocks'], options: { blocks: { slugs: [...] }, inlineBlocks: { slugs: [...] } } }
-```
-
-…and drop the flat `lexicalBlocks` keys before plan 012 ships. The block-registry tools (`listBlocks`, `getBlockSchema`) from plan 012 are unchanged — they're still how the agent resolves a block slug to its fields.
+Only emit feature keys that are **actually present** on the editor. Do not emit implicit/default keys like `paragraph` or `text`.
 
 ### System-prompt update
 
-Replace the existing/proposed line about lexical blocks with a more general one:
+Replace the existing lexical-blocks bullet (added by plan 012) with a more general one:
 
-> For every `richText` field in a schema, inspect `lexical.features` and `lexical.options` to see which node types you may emit. Only produce nodes whose feature key appears in `features`. For `blocks` / `inlineBlocks`, the slugs in `options.blocks.slugs` / `options.inlineBlocks.slugs` are exhaustive — call `getBlockSchema(slug)` to inspect a block's fields before composing it.
+> For every `richText` field in a schema, inspect `lexical.features` and `lexical.options` to see which node types you may emit. Only produce nodes whose feature key appears in `features`. For `blocks` / `inlineBlocks`, the slugs in `options.blocks.slugs` / `options.inlineBlocks.slugs` are exhaustive — call `getBlockSchema({ slug })` to inspect a block's fields before composing it.
 
-Gate this bullet on at least one collection/global having a `richText` field with a non-empty `features` list (avoid noise in configs without lexical).
+Gate on at least one schema already produced for the prompt having a `richText` field with a non-empty `lexical.features`. Compute from the generated schemas; don't re-traverse `config`.
 
 ## Implementation
 
@@ -100,67 +90,88 @@ Gate this bullet on at least one collection/global having a `richText` field wit
 
 - Extend `FieldSchema` with the `lexical` shape above.
 - Add a helper `extractLexicalSummary(field, blocksBySlug): FieldSchema['lexical'] | undefined`:
-  - Normalize `field.editor.features` / `resolvedFeatureMap` into `{ key, props }[]`.
-  - Build `features` (sorted unique keys).
-  - For each known key, project `props` into `options[key]`. Start with: `heading`, `link`, `upload`, `blocks`, `inlineBlocks`, `relationship`. Add others in follow-ups.
-  - For `blocks` / `inlineBlocks`, also fold any inline `Block` objects into `blocksBySlug` so `getBlockSchema` can resolve them (same trick plan 012 uses).
+  - Normalize `field.editor.features` / `resolvedFeatureMap` into `{ key, props }[]` (see Detection strategy).
+  - Build `features` = sorted, deduped list of keys.
+  - For each known key, project `props` into `options[key]` per the rules below. Unknown keys produce no `options` entry.
   - Return `undefined` if no features were detected.
-- In `extractFields`, when `field.type === 'richText'`, call the helper and assign to `schema.lexical`.
+- In `extractFields` (currently at `schema.ts:73` onward), when `field.type === 'richText'`, call the helper with the same `blocksBySlug` map and assign the result to `schema.lexical` (only if defined).
+
+Per-feature projection rules (locked):
+
+- **`heading`** → `{ enabledHeadingSizes }` copied from `props.enabledHeadingSizes` if it's an array of strings; omitted otherwise. Do not infer a default set.
+- **`link`** →
+  - `enabledCollections` / `disabledCollections`: copy through when each is `string[]`.
+  - `fields`: if the sanitized config exposes `props.fields` as a plain array of Payload fields, run it through `extractFields(props.fields, blocksBySlug)` and assign. If `fields` is still a callback or absent, omit the `fields` key. Trust the sanitized output; guard with `Array.isArray` before extracting.
+- **`upload`** → `{ collections: Object.keys(props.collections ?? {}) }`. Omit per-collection nested fields; the agent can call `getCollectionSchema(slug)` if it needs them. If `collections` is missing/non-object, omit `upload` entirely.
+- **`blocks`** / **`inlineBlocks`** →
+  - `{ slugs: string[] }` collected from `props.blocks` (an array where entries may be a `Block` object or a slug string).
+  - For each entry that is a `Block` object (has its own `fields`), register it into the caller-provided `blocksBySlug` map so `getBlockSchema` (plan 012) can resolve it later. Do not recurse into the block's fields here.
+  - String entries contribute their slug directly.
+- **`relationship`** → copy `enabledCollections` / `disabledCollections` through when each is `string[]`.
 
 ### 2. `tools.ts`
 
-- No new tools required — the data rides along on existing `getCollectionSchema` / `getGlobalSchema` payloads.
-- `getBlockSchema` (plan 012) remains the resolver for slugs surfaced in `lexical.options.blocks.slugs`.
+No new tools. The `lexical` summary rides along on existing `getCollectionSchema` / `getGlobalSchema` payloads. `getBlockSchema` (from plan 012) resolves the slugs surfaced under `lexical.options.blocks.slugs` / `lexical.options.inlineBlocks.slugs`.
 
 ### 3. `system-prompt.ts`
 
-- Update the rules block as described above.
-- Compute the gate by walking the schemas already produced for the prompt — no extra config traversal.
+- Replace the bullet added in plan 012 with the generalized bullet above.
+- Gate: walk the schemas already produced for the prompt and include the bullet if any `richText` field has `lexical.features.length > 0`. Do not re-traverse `config`.
+- If plan 012's narrower bullet is still present when this ships, it is removed in the same change — the generalized bullet subsumes it.
 
 ## Tests
 
-Test-driven per CLAUDE.md.
+Test-driven per `CLAUDE.md`.
 
 ### `schema.test.ts`
 
-- **Surfaces enabled feature keys**: a richText field configured with `[BoldFeature, ItalicFeature, HeadingFeature, LinkFeature]` produces `lexical.features` containing all four keys, sorted.
-- **Surfaces `heading` options**: `HeadingFeature({ enabledHeadingSizes: ['h2','h3'] })` → `lexical.options.heading.enabledHeadingSizes === ['h2','h3']`.
-- **Surfaces `link` options including custom fields**: `LinkFeature({ fields: [{ name: 'rel', type: 'text' }] })` → `lexical.options.link.fields` includes a `{ name: 'rel', type: 'text' }` entry produced by `extractFields`.
-- **Surfaces `upload.collections`**: `UploadFeature({ collections: { media: {...} } })` → `lexical.options.upload.collections === ['media']`.
-- **Surfaces `blocks` slugs and registers inline blocks**: `BlocksFeature({ blocks: [{ slug: 'hero', fields: [...] }] })` → `lexical.options.blocks.slugs` contains `'hero'`, and the block is reachable through the shared `blocksBySlug`.
-- **Unknown feature keys appear in `features` without `options`**: a custom feature with `key: 'myThing'` appears in `features` but no `options.myThing` is emitted.
-- **No lexical key when editor is absent**: a `richText` field with no recognisable editor produces no `lexical` key (not `{ features: [] }`).
-- **Non-richText fields are unchanged**: `text`, `array`, `blocks`, `tabs` produce no `lexical` key.
+- **Surfaces enabled feature keys (sorted, deduped).** A richText field configured with `[BoldFeature, ItalicFeature, HeadingFeature, LinkFeature]` produces `lexical.features` containing all four keys in sorted order.
+- **Surfaces `heading.enabledHeadingSizes`.** `HeadingFeature({ enabledHeadingSizes: ['h2','h3'] })` → `lexical.options.heading.enabledHeadingSizes` deep-equals `['h2','h3']`.
+- **Omits `heading.enabledHeadingSizes` when not provided.** `HeadingFeature()` with no props → `lexical.features` contains `'heading'`, `lexical.options.heading` is either absent or `{}`; test the user-visible contract (the key exists in `features`, no inferred default list).
+- **Surfaces `link.fields` when sanitized to an array.** `LinkFeature({ fields: [{ name: 'rel', type: 'text' }] })` after sanitization → `lexical.options.link.fields` contains a `{ name: 'rel', type: 'text' }` entry produced by `extractFields`.
+- **Omits `link.fields` when still a callback.** If `props.fields` is a function, `lexical.options.link` has no `fields` key (not a serialized function).
+- **Surfaces `link.enabledCollections` / `disabledCollections`** when the props carry them.
+- **Surfaces `upload.collections` as a slug array.** `UploadFeature({ collections: { media: {...}, docs: {...} } })` → `lexical.options.upload.collections` deep-equals `['media','docs']` (order by `Object.keys`).
+- **Surfaces `blocks.slugs` and registers inline `Block` objects into `blocksBySlug`.** `BlocksFeature({ blocks: [{ slug: 'hero', fields: [...] }, 'callToAction'] })` → `lexical.options.blocks.slugs` deep-equals `['hero','callToAction']`; calling `getBlockSchema({ slug: 'hero' })` afterwards resolves successfully via the shared `blocksBySlug`.
+- **Surfaces `inlineBlocks.slugs`.** Same behavior as `blocks` for the inline variant.
+- **Surfaces `relationship.enabledCollections` / `disabledCollections`** when present.
+- **Unknown feature keys appear in `features` without an `options` entry.** A custom feature with `key: 'myThing'` appears in `features` but `lexical.options` has no `myThing` key.
+- **No `lexical` key when `editor` is absent.** A `richText` field with no recognisable editor → `schema.lexical` is `undefined` (the key is not emitted).
+- **No `lexical` key when no features are detected.** Editor object present but neither `features` array nor `resolvedFeatureMap` Map → no `lexical` key (not `{ features: [] }`).
+- **Non-richText fields unchanged.** `text`, `array`, `blocks`, `tabs` produce no `lexical` key.
+- **`resolvedFeatureMap` fallback.** A richText field whose editor exposes features only through a `resolvedFeatureMap: Map<...>` (no `features` array) produces the same `lexical.features` list as the equivalent array-form editor.
 
 ### `system-prompt.test.ts`
 
-- The new bullet is included only when at least one schema in the prompt has a `richText` field with `lexical.features.length > 0`.
+- **New bullet appears when at least one schema has a richText field with `lexical.features.length > 0`.**
+- **New bullet is absent when no schema has a richText field, or all richText fields have `lexical === undefined`.**
+- **Narrower plan-012 bullet is no longer emitted** once this plan ships (the generalized bullet replaces it).
 
 ### `tools.test.ts`
 
-- `getCollectionSchema` for a collection containing a `richText` field returns the `lexical` summary on that field (round-trip integration test against a real Payload config used elsewhere in the suite).
-
-## Migration / sequencing vs. plan 012
-
-- Plan 012 and this plan touch the same code path (`schema.ts` lexical detection, `system-prompt.ts` rule bullet).
-- Recommendation: merge plan 012 into this plan and ship as a single change. The block-registry tools (`listBlocks`, `getBlockSchema`) from plan 012 stay; the per-field surfacing collapses into the `lexical.options.blocks` / `lexical.options.inlineBlocks` shape proposed here.
-- If 012 ships first, this plan becomes a follow-up that:
-  1. renames `lexicalBlocks` / `lexicalInlineBlocks` → `lexical.options.blocks.slugs` / `lexical.options.inlineBlocks.slugs`,
-  2. adds the other feature projections,
-  3. updates the system-prompt bullet.
-
-## Open questions / decisions to discuss
-
-- **How chatty should `features` be?** Do we emit _every_ key (including `paragraph`, `text`, structural defaults), or only the ones that gate optional node types? Suggest: only the feature keys actually present on the editor — let lexical's own defaults (paragraph, text) be implicit.
-- **`link.fields` shape.** Lexical link feature accepts a `fields` callback `({ defaultFields }) => Field[]`. Sanitization usually resolves it to the final array — confirm by reading a real config before relying on it.
-- **`upload.collections`.** In current Payload, the shape is `{ collections: { [slug]: { fields?: Field[] } } }`. Surface only the slugs; if the agent needs the per-collection extra fields it can call `getCollectionSchema(slug)`.
-- **Versions / stability.** Lexical's internal feature-prop shape has changed across Payload minors. Decide on a minimum supported Payload version and add a structural guard that no-ops on older shapes rather than throwing.
-- **Naming.** `lexical` (the key) is the most descriptive name but ties the schema to one editor. Alternative: `richText` (mirrors `field.type`). Decision: `lexical` — slate is gone, and any future editor would justify a new key anyway.
-- **Should we resolve `BlocksFeature.blocks` recursively here, or rely on `getBlockSchema`?** Recursively expanding risks blowing up the prompt for deeply-nested block trees. Decision: surface slugs only (consistent with plan 012), defer field resolution to `getBlockSchema`.
-- **Custom features written by users.** They appear in `features` but we have no schema for their props. That's the right outcome — agent at least knows the feature exists; we don't pretend to understand it.
+- **`getCollectionSchema` round-trip.** For a real Payload config with a collection containing a richText field, the tool's output surfaces `lexical` on that field with the expected `features` and `options`.
 
 ## Non-goals
 
-- Not a runtime validator. Payload's own validation is authoritative; the agent should not pre-check.
+- Not a runtime validator. Payload's own validation is authoritative; the agent must not pre-check.
 - Not a lexical-JSON builder/helper. The agent constructs lexical content from this schema knowledge plus its training.
 - Not editor-agnostic. Slate / custom editors are out of scope; the `lexical` key is omitted for them.
+- Not a recursive block expander. Block field trees are fetched via `getBlockSchema`.
+
+## Resolved decisions
+
+- **Key name.** `lexical` (not `richText`). The schema ties to one editor; a future non-lexical editor would justify its own key.
+- **Feature chattiness.** Emit only keys actually present on `editor.features` / `resolvedFeatureMap`. Do not emit implicit defaults like `paragraph` or `text`.
+- **`link.fields` shape.** Trust the sanitized config. If `props.fields` is an array, run it through `extractFields`; if it is a callback or absent, omit the `fields` key. Guard with `Array.isArray`.
+- **`upload.collections`.** Slug array only, via `Object.keys(props.collections ?? {})`. Nested per-collection fields belong to `getCollectionSchema`.
+- **Minimum Payload version.** `^3.83` (matches `chat-agent/package.json`). Detection walks `editor.features` (array) first, falls back to `editor.resolvedFeatureMap` (Map), returns `undefined` otherwise. Do not throw on unrecognised shapes.
+- **Recursive block resolution.** No. Surface slugs only; agent calls `getBlockSchema` to drill in.
+- **Custom / user-authored features.** Appear in `features[]` without an `options` entry. Correct outcome — agent knows the feature exists; we don't pretend to understand its props.
+- **Inline `Block` registration.** `extractLexicalSummary` mutates the caller-provided `blocksBySlug` to fold inline blocks into the shared map (same trick `extractFields` already uses for `blockReferences`). This lets `getBlockSchema` resolve inline-only slugs.
+- **Sequencing.** Ships after plan 012. Requires no changes to plan 012's tools; only extends `FieldSchema` and the extractor.
+
+## Changelog
+
+Add one `## Unreleased` → `### Added` (or `feat:` bullet) entry to `chat-agent/CHANGELOG.md`:
+
+> Per-field `lexical` summary on `FieldSchema` (returned by `getCollectionSchema` / `getGlobalSchema`) surfacing enabled rich-text features and their options (heading sizes, link fields, upload collections, block slugs, relationship collections).


### PR DESCRIPTION
## Summary

Rewrites plans `012-block-schema-tools.md` and `013-rich-text-feature-discovery.md` with every open question resolved and `readiness: ready`. Splits the scope cleanly so each ships as its own PR:

- **Plan 012** — adds `listBlocks` / `getBlockSchema` tools and extends `RawBlock` with optional `labels` / `interfaceName`. No `FieldSchema` changes.
- **Plan 013** — adds a per-field `lexical` summary to `FieldSchema` (features + typed options for `heading`, `link`, `upload`, `blocks`, `inlineBlocks`, `relationship`). Depends on 012's tools at runtime (to resolve surfaced block slugs) but not on its code.

Locked decisions encoded in the plans:
- Labels normalized via the existing `normalizeLabel` helper.
- Feature detection probes `editor.features` → `editor.resolvedFeatureMap` → `undefined`; targets Payload ^3.83.
- Only emit feature keys actually present on the editor; unknown keys appear in `features` without an `options` entry.
- Inline `Block` objects under `BlocksFeature` / `InlineBlocksFeature` are folded into the shared `blocksBySlug` so `getBlockSchema` can resolve them.
- Key name is `lexical` (not `richText`); no recursive block expansion.

No code or behavior changes — docs only.

## Test plan

- [ ] n/a — docs-only change; both plans are self-contained specs for follow-up implementation PRs.

https://claude.ai/code/session_01DxyixPTAJUNwQZsVuSzsX4