### PR TITLE
feat(chat-agent): add listBlocks and getBlockSchema tools

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: add `listBlocks` and `getBlockSchema` tools so the agent can enumerate and inspect globally-declared blocks (`config.blocks`) on demand instead of only seeing them through the collections/globals that reference them.
 - feat!: rename the `chat-conversations` collection to `agent-conversations` and the default `chat-token-usage` budget collection to `agent-token-usage`. Existing projects must migrate data or override `createPayloadBudget({ slug: 'chat-token-usage' })` to keep the previous slug.
 - feat: add a `tools` plugin option that composes the final toolset the agent sees. The factory receives `{ defaultTools, req }` and returns the full `name -> Tool` map — modeled on Payload's `lexicalEditor({ features: ({ defaultFeatures }) => ... })`. Supports user-defined tools (Slack webhooks, Axiom/Vercel log queries, ...) and provider-native ones (`anthropic.tools.webSearch_*`, `openai.tools.webSearch`, `google.tools.googleSearch`, ...) under the same surface. Classification: tools without an `execute` function (provider-native, server-executed) are treated as reads; everything else defaults to write (excluded in `read`, `needsApproval: true` in `ask`).
 - feat: show a "Responding…" indicator in the message list while the agent is working on a response but hasn't streamed any output yet, and a shimmer skeleton while conversation history is loading (initial hydration and sidebar switches) instead of a blank area

--- a/chat-agent/dev/payload-types.ts
+++ b/chat-agent/dev/payload-types.ts
@@ -65,7 +65,10 @@ export interface Config {
   auth: {
     users: UserAuthOperations;
   };
-  blocks: {};
+  blocks: {
+    cta: CtaBlock;
+    hero: Hero;
+  };
   collections: {
     users: User;
     posts: Post;
@@ -131,6 +134,49 @@ export interface UserAuthOperations {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "CtaBlock".
+ */
+export interface CtaBlock {
+  heading: string;
+  buttonLabel: string;
+  buttonHref: string;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'cta';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "hero".
+ */
+export interface Hero {
+  headline: string;
+  subheadline?: string | null;
+  image?: (string | null) | Media;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'hero';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "media".
+ */
+export interface Media {
+  id: string;
+  alt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  url?: string | null;
+  thumbnailURL?: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  filesize?: number | null;
+  width?: number | null;
+  height?: number | null;
+  focalX?: number | null;
+  focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users".
  */
 export interface User {
@@ -181,27 +227,27 @@ export interface Post {
   } | null;
   author?: (string | null) | User;
   featuredImage?: (string | null) | Media;
+  layout?: (CtaBlock | Hero)[] | null;
+  sidebar?:
+    | (
+        | {
+            quote: string;
+            attribution?: string | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'pullQuote';
+          }
+        | {
+            twitter?: string | null;
+            github?: string | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'socialLinks';
+          }
+      )[]
+    | null;
   updatedAt: string;
   createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "media".
- */
-export interface Media {
-  id: string;
-  alt?: string | null;
-  updatedAt: string;
-  createdAt: string;
-  url?: string | null;
-  thumbnailURL?: string | null;
-  filename?: string | null;
-  mimeType?: string | null;
-  filesize?: number | null;
-  width?: number | null;
-  height?: number | null;
-  focalX?: number | null;
-  focalY?: number | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -376,6 +422,27 @@ export interface PostsSelect<T extends boolean = true> {
   content?: T;
   author?: T;
   featuredImage?: T;
+  layout?: T | {};
+  sidebar?:
+    | T
+    | {
+        pullQuote?:
+          | T
+          | {
+              quote?: T;
+              attribution?: T;
+              id?: T;
+              blockName?: T;
+            };
+        socialLinks?:
+          | T
+          | {
+              twitter?: T;
+              github?: T;
+              id?: T;
+              blockName?: T;
+            };
+      };
   updatedAt?: T;
   createdAt?: T;
 }

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -104,13 +104,24 @@ export default buildConfig({
         { name: 'content', type: 'richText' },
         { name: 'author', type: 'relationship', relationTo: 'users' },
         { name: 'featuredImage', type: 'relationship', relationTo: 'media' },
-        // Merged case: global `cta` + `hero` via blockReferences alongside an
-        // inline `pullQuote` block. `getCollectionSchema({ slug: 'posts' })`
-        // should surface all three in `layout.blocks`.
+        // Reference case: `layout` uses globally-declared blocks by slug.
+        // `getCollectionSchema({ slug: 'posts' })` resolves each slug against
+        // `config.blocks` so the agent sees cta + hero fields inlined.
+        //
+        // Payload rejects mixing `blockReferences` and inline `blocks` on the
+        // same field ("You cannot have both blockReferences and blocks in the
+        // same blocks field"), so inline blocks live on `sidebar` below.
         {
           name: 'layout',
           type: 'blocks',
           blockReferences: ['cta', 'hero'],
+          blocks: [],
+        },
+        // Inline case: `pullQuote` and `socialLinks` are scoped to this field
+        // and do not appear in `listBlocks`.
+        {
+          name: 'sidebar',
+          type: 'blocks',
           blocks: [
             {
               slug: 'pullQuote',
@@ -119,14 +130,6 @@ export default buildConfig({
                 { name: 'attribution', type: 'text' },
               ],
             },
-          ],
-        },
-        // Pure-inline case: `socialLinks` is not declared globally and never
-        // appears in `listBlocks`; it only shows up under `sidebar.blocks`.
-        {
-          name: 'sidebar',
-          type: 'blocks',
-          blocks: [
             {
               slug: 'socialLinks',
               fields: [

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -54,6 +54,27 @@ export default buildConfig({
     meta: { titleSuffix: '- Chat Agent Dev' },
     user: 'users',
   },
+  blocks: [
+    {
+      slug: 'cta',
+      interfaceName: 'CtaBlock',
+      labels: { singular: 'Call to Action', plural: 'Calls to Action' },
+      fields: [
+        { name: 'heading', type: 'text', required: true },
+        { name: 'buttonLabel', type: 'text', required: true },
+        { name: 'buttonHref', type: 'text', required: true },
+      ],
+    },
+    {
+      slug: 'hero',
+      labels: { singular: 'Hero', plural: 'Heroes' },
+      fields: [
+        { name: 'headline', type: 'text', required: true },
+        { name: 'subheadline', type: 'text' },
+        { name: 'image', type: 'relationship', relationTo: 'media' },
+      ],
+    },
+  ],
   collections: [
     {
       slug: 'users',
@@ -83,6 +104,38 @@ export default buildConfig({
         { name: 'content', type: 'richText' },
         { name: 'author', type: 'relationship', relationTo: 'users' },
         { name: 'featuredImage', type: 'relationship', relationTo: 'media' },
+        // Merged case: global `cta` + `hero` via blockReferences alongside an
+        // inline `pullQuote` block. `getCollectionSchema({ slug: 'posts' })`
+        // should surface all three in `layout.blocks`.
+        {
+          name: 'layout',
+          type: 'blocks',
+          blockReferences: ['cta', 'hero'],
+          blocks: [
+            {
+              slug: 'pullQuote',
+              fields: [
+                { name: 'quote', type: 'textarea', required: true },
+                { name: 'attribution', type: 'text' },
+              ],
+            },
+          ],
+        },
+        // Pure-inline case: `socialLinks` is not declared globally and never
+        // appears in `listBlocks`; it only shows up under `sidebar.blocks`.
+        {
+          name: 'sidebar',
+          type: 'blocks',
+          blocks: [
+            {
+              slug: 'socialLinks',
+              fields: [
+                { name: 'twitter', type: 'text' },
+                { name: 'github', type: 'text' },
+              ],
+            },
+          ],
+        },
       ],
     },
     {

--- a/chat-agent/src/schema.ts
+++ b/chat-agent/src/schema.ts
@@ -51,6 +51,8 @@ type RawField = { [key: string]: unknown; type: string }
 /** Loose structural representation of a Payload block. */
 export interface RawBlock {
   fields?: readonly unknown[]
+  interfaceName?: string
+  labels?: { plural?: unknown; singular?: unknown }
   slug: string
 }
 

--- a/chat-agent/src/system-prompt.test.ts
+++ b/chat-agent/src/system-prompt.test.ts
@@ -74,6 +74,24 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('getGlobalSchema')
   })
 
+  it('mentions listBlocks / getBlockSchema only when config.blocks is non-empty', () => {
+    const withBlocks = buildSystemPrompt({
+      blocks: [{ slug: 'hero', fields: [] }],
+      collections: [],
+      globals: [],
+    })
+    expect(withBlocks).toContain('listBlocks')
+    expect(withBlocks).toContain('getBlockSchema')
+
+    const emptyBlocks = buildSystemPrompt({ blocks: [], collections: [], globals: [] })
+    expect(emptyBlocks).not.toContain('listBlocks')
+    expect(emptyBlocks).not.toContain('getBlockSchema')
+
+    const noBlocks = buildSystemPrompt({ collections: [], globals: [] })
+    expect(noBlocks).not.toContain('listBlocks')
+    expect(noBlocks).not.toContain('getBlockSchema')
+  })
+
   it('notes that Payload uses Lexical for rich text', () => {
     // The agent needs to know rich-text field values are Lexical editor state
     // (JSON tree), not HTML or Markdown, so it writes/reads them correctly.

--- a/chat-agent/src/system-prompt.ts
+++ b/chat-agent/src/system-prompt.ts
@@ -65,7 +65,7 @@ export function buildSystemPrompt(
     '- Call `getCollectionSchema({ slug })` or `getGlobalSchema({ slug })` to inspect field details before querying, filtering, or writing. Only the slugs are listed below — field names and types are fetched on demand.',
     ...((payloadConfig.blocks?.length ?? 0) > 0
       ? [
-          '- Call `listBlocks` to see globally-declared blocks, and `getBlockSchema({ slug })` to inspect a block\'s fields before inserting it into a `blocks` field.',
+          "- Call `listBlocks` to see globally-declared blocks, and `getBlockSchema({ slug })` to inspect a block's fields before inserting it into a `blocks` field.",
         ]
       : []),
     ...(hasCustomEndpoints

--- a/chat-agent/src/system-prompt.ts
+++ b/chat-agent/src/system-prompt.ts
@@ -63,6 +63,11 @@ export function buildSystemPrompt(
               '- Use `find` or `findByID` to look up data before making changes.',
             ]),
     '- Call `getCollectionSchema({ slug })` or `getGlobalSchema({ slug })` to inspect field details before querying, filtering, or writing. Only the slugs are listed below — field names and types are fetched on demand.',
+    ...((payloadConfig.blocks?.length ?? 0) > 0
+      ? [
+          '- Call `listBlocks` to see globally-declared blocks, and `getBlockSchema({ slug })` to inspect a block\'s fields before inserting it into a `blocks` field.',
+        ]
+      : []),
     ...(hasCustomEndpoints
       ? [
           '- Call `listEndpoints` to see plugin-provided custom endpoints that can be invoked via `callEndpoint`.',

--- a/chat-agent/src/tools.test.ts
+++ b/chat-agent/src/tools.test.ts
@@ -867,6 +867,82 @@ describe('schema inspection tools', () => {
     expect(JSON.stringify(result.fields)).toContain('buttonText')
   })
 
+  it('getCollectionSchema surfaces inline blocks declared on the field', async () => {
+    // Inline blocks live on `field.blocks` — they never appear in
+    // config.blocks, so the only way the agent can learn their shape is
+    // through the parent collection's schema.
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      collections: [
+        {
+          slug: 'pages',
+          fields: [
+            {
+              name: 'layout',
+              type: 'blocks',
+              blocks: [
+                {
+                  slug: 'inlineHero',
+                  fields: [{ name: 'headline', type: 'text', required: true }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      globals: [],
+    })
+
+    const result = (await tools.getCollectionSchema.execute({ slug: 'pages' }, ctx)) as {
+      fields: { blocks?: { fields: { name: string }[]; slug: string }[]; name: string }[]
+    }
+    const layout = result.fields.find((f) => f.name === 'layout')!
+    expect(layout.blocks).toEqual([
+      {
+        slug: 'inlineHero',
+        fields: [{ name: 'headline', required: true, type: 'text' }],
+      },
+    ])
+  })
+
+  it('getCollectionSchema merges inline blocks and blockReferences on the same field', async () => {
+    // Payload allows a single `blocks` field to declare inline blocks AND
+    // reference globally-registered blocks by slug. Both should appear in
+    // the extracted schema so the agent knows every block it may insert.
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [
+        {
+          slug: 'globalCta',
+          fields: [{ name: 'buttonText', type: 'text' }],
+        },
+      ],
+      collections: [
+        {
+          slug: 'pages',
+          fields: [
+            {
+              name: 'layout',
+              type: 'blocks',
+              blockReferences: ['globalCta'],
+              blocks: [
+                {
+                  slug: 'inlineHero',
+                  fields: [{ name: 'headline', type: 'text' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      globals: [],
+    })
+
+    const result = (await tools.getCollectionSchema.execute({ slug: 'pages' }, ctx)) as {
+      fields: { blocks?: { slug: string }[]; name: string }[]
+    }
+    const layout = result.fields.find((f) => f.name === 'layout')!
+    expect(layout.blocks?.map((b) => b.slug)).toEqual(['inlineHero', 'globalCta'])
+  })
+
   it('getGlobalSchema returns extracted fields for a known slug', async () => {
     const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
       collections: [],

--- a/chat-agent/src/tools.test.ts
+++ b/chat-agent/src/tools.test.ts
@@ -904,45 +904,6 @@ describe('schema inspection tools', () => {
     ])
   })
 
-  it('getCollectionSchema merges inline blocks and blockReferences on the same field', async () => {
-    // Payload allows a single `blocks` field to declare inline blocks AND
-    // reference globally-registered blocks by slug. Both should appear in
-    // the extracted schema so the agent knows every block it may insert.
-    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
-      blocks: [
-        {
-          slug: 'globalCta',
-          fields: [{ name: 'buttonText', type: 'text' }],
-        },
-      ],
-      collections: [
-        {
-          slug: 'pages',
-          fields: [
-            {
-              name: 'layout',
-              type: 'blocks',
-              blockReferences: ['globalCta'],
-              blocks: [
-                {
-                  slug: 'inlineHero',
-                  fields: [{ name: 'headline', type: 'text' }],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      globals: [],
-    })
-
-    const result = (await tools.getCollectionSchema.execute({ slug: 'pages' }, ctx)) as {
-      fields: { blocks?: { slug: string }[]; name: string }[]
-    }
-    const layout = result.fields.find((f) => f.name === 'layout')!
-    expect(layout.blocks?.map((b) => b.slug)).toEqual(['inlineHero', 'globalCta'])
-  })
-
   it('getGlobalSchema returns extracted fields for a known slug', async () => {
     const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
       collections: [],

--- a/chat-agent/src/tools.test.ts
+++ b/chat-agent/src/tools.test.ts
@@ -55,6 +55,31 @@ describe('buildTools', () => {
     ])
   })
 
+  it('exposes listBlocks and getBlockSchema when config is passed', () => {
+    // Same contract-lock as the base set, but for the config-gated surface.
+    // The schema inspection tools register together; if any of them is
+    // dropped or renamed, lock it here so the agent doesn't silently lose a
+    // discovery path.
+    const tools = buildTools(createMockPayload(), mockUser, false, undefined, undefined, {
+      collections: [],
+      globals: [],
+    })
+    expect(Object.keys(tools).sort()).toEqual([
+      'count',
+      'create',
+      'delete',
+      'find',
+      'findByID',
+      'findGlobal',
+      'getBlockSchema',
+      'getCollectionSchema',
+      'getGlobalSchema',
+      'listBlocks',
+      'update',
+      'updateGlobal',
+    ])
+  })
+
   it('find calls payload.find with correct arguments', async () => {
     const payload = createMockPayload()
     const tools = buildTools(payload, mockUser)
@@ -813,8 +838,6 @@ describe('schema inspection tools', () => {
   })
 
   it('getCollectionSchema resolves blockReferences from config.blocks', async () => {
-    // Block field details come along when inspecting a collection, so a
-    // separate getBlockSchema tool isn't needed.
     const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
       blocks: [
         {
@@ -902,6 +925,212 @@ describe('schema inspection tools', () => {
       error: string
     }
     expect(result.error).toMatch(/unknown global slug/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Block schema tools (listBlocks, getBlockSchema)
+// ---------------------------------------------------------------------------
+
+describe('block schema tools', () => {
+  const mockPayload = {
+    count: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    find: vi.fn(),
+    findByID: vi.fn(),
+    findGlobal: vi.fn(),
+    update: vi.fn(),
+    updateGlobal: vi.fn(),
+  }
+  const mockUser = { id: 'u1' }
+  const ctx = { abortSignal: undefined, messages: [], toolCallId: '1' }
+
+  it('are not registered when config is not passed', () => {
+    const tools = buildTools(mockPayload, mockUser)
+    expect(tools.listBlocks).toBeUndefined()
+    expect(tools.getBlockSchema).toBeUndefined()
+  })
+
+  it('listBlocks returns slugs from config.blocks in declared order', async () => {
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [
+        { slug: 'hero', fields: [] },
+        { slug: 'callToAction', fields: [] },
+      ],
+      collections: [],
+      globals: [],
+    })
+
+    const result = (await tools.listBlocks.execute({}, ctx)) as {
+      blocks: { slug: string }[]
+    }
+    expect(result.blocks.map((b) => b.slug)).toEqual(['hero', 'callToAction'])
+  })
+
+  it('listBlocks surfaces normalized labels and interfaceName when set', async () => {
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [
+        {
+          slug: 'hero',
+          fields: [],
+          interfaceName: 'HeroBlock',
+          labels: { plural: 'Heroes', singular: 'Hero' },
+        },
+      ],
+      collections: [],
+      globals: [],
+    })
+
+    const result = (await tools.listBlocks.execute({}, ctx)) as {
+      blocks: { interfaceName?: string; labels?: { plural?: unknown; singular?: unknown }; slug: string }[]
+    }
+    expect(result.blocks).toEqual([
+      {
+        slug: 'hero',
+        interfaceName: 'HeroBlock',
+        labels: { plural: 'Heroes', singular: 'Hero' },
+      },
+    ])
+  })
+
+  it('listBlocks omits labels when both leaves normalize to undefined', async () => {
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [{ slug: 'hero', fields: [], labels: { singular: () => 'X' } }],
+      collections: [],
+      globals: [],
+    })
+
+    const result = (await tools.listBlocks.execute({}, ctx)) as {
+      blocks: Record<string, unknown>[]
+    }
+    expect(result.blocks).toEqual([{ slug: 'hero' }])
+    expect(result.blocks[0]).not.toHaveProperty('labels')
+  })
+
+  it('listBlocks returns an empty array when config.blocks is absent or empty', async () => {
+    const noBlocks = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      collections: [],
+      globals: [],
+    })
+    expect(((await noBlocks.listBlocks.execute({}, ctx)) as { blocks: unknown[] }).blocks).toEqual(
+      [],
+    )
+
+    const emptyBlocks = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [],
+      collections: [],
+      globals: [],
+    })
+    expect(
+      ((await emptyBlocks.listBlocks.execute({}, ctx)) as { blocks: unknown[] }).blocks,
+    ).toEqual([])
+  })
+
+  it('getBlockSchema returns fields for a known slug', async () => {
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [
+        {
+          slug: 'hero',
+          fields: [
+            { name: 'heading', type: 'text', required: true },
+            { name: 'subheading', type: 'text' },
+          ],
+        },
+      ],
+      collections: [],
+      globals: [],
+    })
+
+    const result = (await tools.getBlockSchema.execute({ slug: 'hero' }, ctx)) as {
+      fields: { name: string }[]
+      slug: string
+    }
+    expect(result.slug).toBe('hero')
+    expect(result.fields.map((f) => f.name)).toEqual(['heading', 'subheading'])
+  })
+
+  it('getBlockSchema returns { error } for an unknown slug', async () => {
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [{ slug: 'hero', fields: [] }],
+      collections: [],
+      globals: [],
+    })
+
+    const result = (await tools.getBlockSchema.execute({ slug: 'nope' }, ctx)) as {
+      error: string
+    }
+    expect(result.error).toBe('Unknown block slug "nope"')
+  })
+
+  it('getBlockSchema resolves nested blockReferences', async () => {
+    // Block A contains a `blocks` field that references block B by slug.
+    // The shared blocksBySlug map must let extractFields follow that ref
+    // transparently — same mechanism getCollectionSchema uses.
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [
+        {
+          slug: 'parent',
+          fields: [
+            {
+              name: 'children',
+              type: 'blocks',
+              blockReferences: ['child'],
+              blocks: [],
+            },
+          ],
+        },
+        { slug: 'child', fields: [{ name: 'label', type: 'text' }] },
+      ],
+      collections: [],
+      globals: [],
+    })
+
+    const result = (await tools.getBlockSchema.execute({ slug: 'parent' }, ctx)) as {
+      fields: unknown[]
+    }
+    expect(JSON.stringify(result.fields)).toContain('label')
+  })
+
+  it('getBlockSchema surfaces labels and interfaceName when set', async () => {
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [
+        {
+          slug: 'hero',
+          fields: [],
+          interfaceName: 'HeroBlock',
+          labels: { plural: 'Heroes', singular: 'Hero' },
+        },
+      ],
+      collections: [],
+      globals: [],
+    })
+
+    const result = (await tools.getBlockSchema.execute({ slug: 'hero' }, ctx)) as {
+      interfaceName?: string
+      labels?: { plural?: unknown; singular?: unknown }
+    }
+    expect(result.interfaceName).toBe('HeroBlock')
+    expect(result.labels).toEqual({ plural: 'Heroes', singular: 'Hero' })
+  })
+
+  it('read and ask mode filters keep both block tools', () => {
+    const tools = buildTools(mockPayload, mockUser, false, undefined, undefined, {
+      blocks: [{ slug: 'hero', fields: [] }],
+      collections: [],
+      globals: [],
+    })
+
+    const readTools = filterToolsByMode(tools, 'read')
+    expect(readTools).toHaveProperty('listBlocks')
+    expect(readTools).toHaveProperty('getBlockSchema')
+
+    const askTools = filterToolsByMode(tools, 'ask')
+    expect(askTools).toHaveProperty('listBlocks')
+    expect(askTools).toHaveProperty('getBlockSchema')
+    // Read tools stay plain in ask mode — no needsApproval gate.
+    expect(askTools.listBlocks).not.toHaveProperty('needsApproval')
+    expect(askTools.getBlockSchema).not.toHaveProperty('needsApproval')
   })
 })
 

--- a/chat-agent/src/tools.test.ts
+++ b/chat-agent/src/tools.test.ts
@@ -899,7 +899,7 @@ describe('schema inspection tools', () => {
     expect(layout.blocks).toEqual([
       {
         slug: 'inlineHero',
-        fields: [{ name: 'headline', required: true, type: 'text' }],
+        fields: [{ name: 'headline', type: 'text', required: true }],
       },
     ])
   })
@@ -1059,7 +1059,11 @@ describe('block schema tools', () => {
     })
 
     const result = (await tools.listBlocks.execute({}, ctx)) as {
-      blocks: { interfaceName?: string; labels?: { plural?: unknown; singular?: unknown }; slug: string }[]
+      blocks: {
+        interfaceName?: string
+        labels?: { plural?: unknown; singular?: unknown }
+        slug: string
+      }[]
     }
     expect(result.blocks).toEqual([
       {

--- a/chat-agent/src/tools.ts
+++ b/chat-agent/src/tools.ts
@@ -21,7 +21,7 @@ import { z } from 'zod'
 import type { PayloadConfigForPrompt, RawBlock } from './schema.js'
 import type { AgentMode } from './types.js'
 
-import { extractFields } from './schema.js'
+import { extractFields, normalizeLabel } from './schema.js'
 
 // ---------------------------------------------------------------------------
 // Tool classification
@@ -35,6 +35,8 @@ export const READ_TOOL_NAMES = [
   'findGlobal',
   'getCollectionSchema',
   'getGlobalSchema',
+  'listBlocks',
+  'getBlockSchema',
   'listEndpoints',
 ] as const
 
@@ -470,6 +472,64 @@ export function buildTools(
             },
             inputSchema: z.object({
               slug: z.string().describe('Global slug (see the slug catalog in the system prompt)'),
+            }),
+          } satisfies ExecutableTool,
+
+          listBlocks: {
+            description:
+              'List all globally-declared blocks (config.blocks). These blocks can be referenced from `blocks` fields and inserted into lexical fields configured with BlocksFeature.',
+            execute: () => ({
+              blocks: (config.blocks ?? []).map((block) => {
+                const singular = normalizeLabel(block.labels?.singular)
+                const plural = normalizeLabel(block.labels?.plural)
+                const labels =
+                  singular !== undefined || plural !== undefined
+                    ? {
+                        ...(singular !== undefined && { singular }),
+                        ...(plural !== undefined && { plural }),
+                      }
+                    : undefined
+                return {
+                  slug: block.slug,
+                  ...(labels && { labels }),
+                  ...(typeof block.interfaceName === 'string' && {
+                    interfaceName: block.interfaceName,
+                  }),
+                }
+              }),
+            }),
+            inputSchema: z.object({}),
+          } satisfies ExecutableTool,
+
+          getBlockSchema: {
+            description:
+              'Get the field schema for a globally-declared block by slug. Call listBlocks first to discover slugs. Returns { error } if the slug is unknown.',
+            execute: (input: Record<string, unknown>) => {
+              const slug = input.slug as string
+              const block = blocksBySlug[slug]
+              if (!block) {
+                return { error: `Unknown block slug "${slug}"` }
+              }
+              const singular = normalizeLabel(block.labels?.singular)
+              const plural = normalizeLabel(block.labels?.plural)
+              const labels =
+                singular !== undefined || plural !== undefined
+                  ? {
+                      ...(singular !== undefined && { singular }),
+                      ...(plural !== undefined && { plural }),
+                    }
+                  : undefined
+              return {
+                slug,
+                fields: extractFields(block.fields ?? [], blocksBySlug),
+                ...(labels && { labels }),
+                ...(typeof block.interfaceName === 'string' && {
+                  interfaceName: block.interfaceName,
+                }),
+              }
+            },
+            inputSchema: z.object({
+              slug: z.string().describe('Block slug from listBlocks'),
             }),
           } satisfies ExecutableTool,
         }


### PR DESCRIPTION
Exposes globally-declared blocks (config.blocks) to the agent as
first-class, discoverable schema entities. Previously the agent could
only reach a block by inspecting a collection/global whose fields
referenced it; the new read tools let it enumerate the block catalog
and resolve a single block's field schema on demand.

The system prompt gains a single bullet when config.blocks is non-empty
pointing the agent at the two tools.