### PR TITLE
feat(chat-agent): add virtual path field to dev app posts collection

### DIFF
--- a/chat-agent/dev/payload-types.ts
+++ b/chat-agent/dev/payload-types.ts
@@ -209,7 +209,7 @@ export interface Post {
   id: string;
   title: string;
   slug: string;
-  url?: string | null;
+  path?: string | null;
   content?: {
     root: {
       type: string;
@@ -419,7 +419,7 @@ export interface UsersSelect<T extends boolean = true> {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   slug?: T;
-  url?: T;
+  path?: T;
   content?: T;
   author?: T;
   featuredImage?: T;

--- a/chat-agent/dev/payload-types.ts
+++ b/chat-agent/dev/payload-types.ts
@@ -209,6 +209,7 @@ export interface Post {
   id: string;
   title: string;
   slug: string;
+  url?: string | null;
   content?: {
     root: {
       type: string;
@@ -418,6 +419,7 @@ export interface UsersSelect<T extends boolean = true> {
 export interface PostsSelect<T extends boolean = true> {
   title?: T;
   slug?: T;
+  url?: T;
   content?: T;
   author?: T;
   featuredImage?: T;

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -130,6 +130,14 @@ export default buildConfig({
       fields: [
         { name: 'title', type: 'text', required: true },
         { name: 'slug', type: 'text', required: true, unique: true },
+        {
+          name: 'url',
+          type: 'text',
+          virtual: true,
+          hooks: {
+            afterRead: [({ data }) => (data?.slug ? `/posts/${data.slug}` : undefined)],
+          },
+        },
         { name: 'content', type: 'richText' },
         { name: 'author', type: 'relationship', relationTo: 'users' },
         { name: 'featuredImage', type: 'relationship', relationTo: 'media' },

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -131,7 +131,7 @@ export default buildConfig({
         { name: 'title', type: 'text', required: true },
         { name: 'slug', type: 'text', required: true, unique: true },
         {
-          name: 'url',
+          name: 'path',
           type: 'text',
           virtual: true,
           hooks: {


### PR DESCRIPTION
## Summary
Added a virtual `path` field to the Post collection that automatically generates post URLs based on the slug.

## Key Changes
- Added a new virtual `path` field to the Post collection in `payload.config.ts` that:
  - Automatically constructs the post path as `/posts/{slug}` using an `afterRead` hook
  - Returns `undefined` if no slug is present
- Updated TypeScript types in `payload-types.ts` to reflect the new optional `path` field in:
  - The `Post` interface
  - The `PostsSelect` interface for query selection

## Implementation Details
The `path` field is implemented as a virtual field with an `afterRead` hook, meaning it's computed on-the-fly during read operations rather than stored in the database. This ensures the path is always consistent with the slug and reduces data duplication.

https://claude.ai/code/session_01BEWEg9q5o3cEYDx1vdPRs1