### PR TITLE
feat(chat-agent): surface endpoint custom.schema to the agent

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: surface `endpoint.custom.schema` (query / body / response shapes, as declared by the CLI plugin's `EndpointCustom` type) through `listEndpoints` so the agent sees each custom endpoint's request/response contract and can construct valid `callEndpoint` calls without trial-and-error.
 - feat: add `listBlocks` and `getBlockSchema` tools so the agent can enumerate and inspect globally-declared blocks (`config.blocks`) on demand instead of only seeing them through the collections/globals that reference them.
 - feat!: rename the `chat-conversations` collection to `agent-conversations` and the default `chat-token-usage` budget collection to `agent-token-usage`. Existing projects must migrate data or override `createPayloadBudget({ slug: 'chat-token-usage' })` to keep the previous slug.
 - feat: add a `tools` plugin option that composes the final toolset the agent sees. The factory receives `{ defaultTools, req }` and returns the full `name -> Tool` map — modeled on Payload's `lexicalEditor({ features: ({ defaultFeatures }) => ... })`. Supports user-defined tools (Slack webhooks, Axiom/Vercel log queries, ...) and provider-native ones (`anthropic.tools.webSearch_*`, `openai.tools.webSearch`, `google.tools.googleSearch`, ...) under the same surface. Classification: tools without an `execute` function (provider-native, server-executed) are treated as reads; everything else defaults to write (excluded in `read`, `needsApproval: true` in `ask`).

--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: surface `endpoint.custom.schema` (query / body / response shapes, as declared by the CLI plugin's `EndpointCustom` type) through `listEndpoints` so the agent sees each custom endpoint's request/response contract and can construct valid `callEndpoint` calls without trial-and-error.
+- feat: surface `endpoint.custom.schema` (query / body / response shapes) through `listEndpoints` so the agent sees each custom endpoint's request/response contract and can construct valid `callEndpoint` calls without trial-and-error.
 - feat: add `listBlocks` and `getBlockSchema` tools so the agent can enumerate and inspect globally-declared blocks (`config.blocks`) on demand instead of only seeing them through the collections/globals that reference them.
 - feat!: rename the `chat-conversations` collection to `agent-conversations` and the default `chat-token-usage` budget collection to `agent-token-usage`. Existing projects must migrate data or override `createPayloadBudget({ slug: 'chat-token-usage' })` to keep the previous slug.
 - feat: add a `tools` plugin option that composes the final toolset the agent sees. The factory receives `{ defaultTools, req }` and returns the full `name -> Tool` map — modeled on Payload's `lexicalEditor({ features: ({ defaultFeatures }) => ... })`. Supports user-defined tools (Slack webhooks, Axiom/Vercel log queries, ...) and provider-native ones (`anthropic.tools.webSearch_*`, `openai.tools.webSearch`, `google.tools.googleSearch`, ...) under the same surface. Classification: tools without an `execute` function (provider-native, server-executed) are treated as reads; everything else defaults to write (excluded in `read`, `needsApproval: true` in `ask`).

--- a/chat-agent/README.md
+++ b/chat-agent/README.md
@@ -96,20 +96,28 @@ chatAgentPlugin({
 
 ### Custom endpoints
 
-Any endpoint with a `custom.description` is discoverable by the agent via the `callEndpoint` tool:
+Any endpoint with a `custom.description` is discoverable by the agent via the `callEndpoint` tool. Optionally attach a `custom.schema` describing the request/response contract (`query`, `body`, `response`) — when present, it's handed to the agent alongside the description so it can construct valid calls without trial-and-error:
 
 ```ts
 endpoints: [
   {
     path: '/publish/:id',
     method: 'post',
-    custom: { description: 'Publish a document by ID' },
+    custom: {
+      description: 'Publish a document by ID',
+      schema: {
+        body: { notify: { type: 'boolean' } },
+        response: { id: { type: 'string' }, status: { type: 'string' } },
+      },
+    },
     handler: async (req) => {
       /* ... */
     },
   },
 ]
 ```
+
+`custom.schema` leaves are passed through verbatim — use whatever shape your team already documents endpoints with (plain descriptors, JSON Schema, etc.). Route params like `:id` belong in the path, not the schema.
 
 ### Extending or customizing tools
 

--- a/chat-agent/dev/src/endpoints.ts
+++ b/chat-agent/dev/src/endpoints.ts
@@ -8,6 +8,12 @@ export const rootEndpoints: Endpoint[] = [
     custom: {
       description:
         'Health check. Returns `{ ok: true, time }` with the server timestamp. Takes no input.',
+      schema: {
+        response: {
+          ok: { type: 'boolean' },
+          time: { type: 'string', format: 'date-time' },
+        },
+      },
     },
     handler: () => {
       return Response.json({ ok: true, time: new Date().toISOString() })
@@ -19,6 +25,9 @@ export const rootEndpoints: Endpoint[] = [
     custom: {
       description:
         'Echo a message back from a URL path param. Route param `:message` is returned verbatim.',
+      schema: {
+        response: { message: { type: 'string', nullable: true } },
+      },
     },
     handler: (req: PayloadRequest) => {
       return Response.json({ message: req.routeParams?.message ?? null })
@@ -30,6 +39,10 @@ export const rootEndpoints: Endpoint[] = [
     custom: {
       description:
         'Echo a JSON body back. Accepts any object and returns `{ received: <body> }`. Useful for verifying body serialization.',
+      schema: {
+        body: { type: 'object', description: 'Arbitrary JSON object' },
+        response: { received: { type: 'object', nullable: true } },
+      },
     },
     handler: async (req: PayloadRequest) => {
       const body = await req.json?.()
@@ -42,6 +55,16 @@ export const rootEndpoints: Endpoint[] = [
     custom: {
       description:
         'Demonstrates query-string parsing. Accepts query params `q` (string) and `limit` (number), echoes both back.',
+      schema: {
+        query: {
+          q: { type: 'string', description: 'Search query' },
+          limit: { type: 'number', description: 'Max results to return' },
+        },
+        response: {
+          q: { type: 'string', nullable: true },
+          limit: { type: 'number', nullable: true },
+        },
+      },
     },
     handler: (req: PayloadRequest) => {
       const q = req.searchParams?.get('q') ?? null
@@ -56,6 +79,13 @@ export const rootEndpoints: Endpoint[] = [
     custom: {
       description:
         'Returns document counts across the seeded collections (`posts`, `categories`, `users`). No input.',
+      schema: {
+        response: {
+          posts: { type: 'number' },
+          categories: { type: 'number' },
+          users: { type: 'number' },
+        },
+      },
     },
     handler: async (req: PayloadRequest) => {
       const [posts, categories, users] = await Promise.all([
@@ -80,6 +110,12 @@ export const postsEndpoints: Endpoint[] = [
     custom: {
       description:
         "Publish a post by id. Sets its `_status` to `'published'` and returns the updated document. Route param `:id` is the post id.",
+      schema: {
+        response: {
+          id: { type: 'string' },
+          _status: { type: 'string', enum: ['draft', 'published'] },
+        },
+      },
     },
     handler: async (req: PayloadRequest) => {
       const id = req.routeParams?.id as string | undefined

--- a/chat-agent/src/tools.test.ts
+++ b/chat-agent/src/tools.test.ts
@@ -430,6 +430,49 @@ describe('discoverEndpoints', () => {
     const eps = discoverEndpoints(asConfig(config))
     expect(eps).toHaveLength(0)
   })
+
+  it('surfaces custom.schema (query/body/response) when declared', () => {
+    // The CLI plugin's `EndpointCustom` type exposes a schema contract alongside
+    // the description; if an endpoint declares it, the agent should see it so
+    // it can construct valid calls without trial-and-error.
+    const schema = {
+      body: { draft: { type: 'boolean' } },
+      query: { locale: { type: 'string' } },
+      response: { id: { type: 'string' }, published: { type: 'boolean' } },
+    }
+    const config = {
+      collections: [],
+      endpoints: [
+        {
+          custom: { description: 'Publish content', schema },
+          handler: () => {},
+          method: 'post',
+          path: '/publish',
+        },
+      ],
+      globals: [],
+    }
+    const eps = discoverEndpoints(asConfig(config))
+    expect(eps).toHaveLength(1)
+    expect(eps[0].schema).toEqual(schema)
+  })
+
+  it('leaves schema undefined when custom.schema is absent', () => {
+    const config = {
+      collections: [],
+      endpoints: [
+        {
+          custom: { description: 'Publish content' },
+          handler: () => {},
+          method: 'post',
+          path: '/publish',
+        },
+      ],
+      globals: [],
+    }
+    const eps = discoverEndpoints(asConfig(config))
+    expect(eps[0].schema).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1222,5 +1265,36 @@ describe('listEndpoints', () => {
       { description: 'Publish a post', method: 'POST', path: '/api/posts/publish/:id' },
       { description: 'Archive a post', method: 'DELETE', path: '/api/posts/archive/:id' },
     ])
+  })
+
+  it("includes each endpoint's schema when present so the agent knows the contract", async () => {
+    const schema = {
+      body: { draft: { type: 'boolean' } },
+      query: { locale: { type: 'string' } },
+      response: { id: { type: 'string' } },
+    }
+    const endpoints = [
+      {
+        description: 'Publish a post',
+        handler: () => Response.json({}),
+        method: 'post',
+        path: '/api/posts/publish/:id',
+        schema,
+      },
+      {
+        description: 'Archive a post',
+        handler: () => Response.json({}),
+        method: 'delete',
+        path: '/api/posts/archive/:id',
+      },
+    ]
+    const tools = buildTools(mockPayload, mockUser, false, asReq({}), endpoints)
+
+    const result = (await tools.listEndpoints.execute({}, ctx)) as {
+      endpoints: { schema?: unknown }[]
+    }
+    expect(result.endpoints[0].schema).toEqual(schema)
+    // Endpoints without a declared schema stay lean — no empty schema key.
+    expect(result.endpoints[1]).not.toHaveProperty('schema')
   })
 })

--- a/chat-agent/src/tools.test.ts
+++ b/chat-agent/src/tools.test.ts
@@ -432,7 +432,7 @@ describe('discoverEndpoints', () => {
   })
 
   it('surfaces custom.schema (query/body/response) when declared', () => {
-    // The CLI plugin's `EndpointCustom` type exposes a schema contract alongside
+    // `endpoint.custom.schema` exposes a request/response contract alongside
     // the description; if an endpoint declares it, the agent should see it so
     // it can construct valid calls without trial-and-error.
     const schema = {

--- a/chat-agent/src/tools.ts
+++ b/chat-agent/src/tools.ts
@@ -142,8 +142,8 @@ type ExecutableTool = Required<Pick<Tool<Record<string, unknown>, unknown>, 'exe
   Tool<Record<string, unknown>, unknown>
 
 /**
- * Request/response contract for a custom endpoint, mirrored from the CLI
- * plugin's `EndpointCustom` type. Each leaf is intentionally `unknown` — it's
+ * Request/response contract for a custom endpoint, read from
+ * `endpoint.custom.schema`. Each leaf is intentionally `unknown` — it's
  * surfaced to the agent verbatim, not validated here.
  */
 export interface EndpointSchema {

--- a/chat-agent/src/tools.ts
+++ b/chat-agent/src/tools.ts
@@ -141,12 +141,28 @@ interface PayloadLocalAPI {
 type ExecutableTool = Required<Pick<Tool<Record<string, unknown>, unknown>, 'execute'>> &
   Tool<Record<string, unknown>, unknown>
 
+/**
+ * Request/response contract for a custom endpoint, mirrored from the CLI
+ * plugin's `EndpointCustom` type. Each leaf is intentionally `unknown` — it's
+ * surfaced to the agent verbatim, not validated here.
+ */
+export interface EndpointSchema {
+  /** Request body shape */
+  body?: Record<string, unknown>
+  /** Query string parameters */
+  query?: Record<string, unknown>
+  /** Response shape */
+  response?: Record<string, unknown>
+}
+
 /** Minimal representation of a custom endpoint for the agent. */
 export interface DiscoverableEndpoint {
   description?: string
   handler: (req: PayloadRequest) => Promise<Response> | Response
   method: string
   path: string
+  /** Optional request/response contract declared via `endpoint.custom.schema`. */
+  schema?: EndpointSchema
 }
 
 /**
@@ -167,6 +183,7 @@ export function discoverEndpoints(config: SanitizedConfig): DiscoverableEndpoint
         handler: ep.handler,
         method: ep.method,
         path: `/api${ep.path}`,
+        ...(ep.custom.schema && { schema: ep.custom.schema as EndpointSchema }),
       })
     }
   }
@@ -182,6 +199,7 @@ export function discoverEndpoints(config: SanitizedConfig): DiscoverableEndpoint
           handler: ep.handler,
           method: ep.method,
           path: `/api/${col.slug}${ep.path}`,
+          ...(ep.custom.schema && { schema: ep.custom.schema as EndpointSchema }),
         })
       }
     }
@@ -198,6 +216,7 @@ export function discoverEndpoints(config: SanitizedConfig): DiscoverableEndpoint
           handler: ep.handler,
           method: ep.method,
           path: `/api/globals/${global.slug}${ep.path}`,
+          ...(ep.custom.schema && { schema: ep.custom.schema as EndpointSchema }),
         })
       }
     }
@@ -540,13 +559,14 @@ export function buildTools(
       ? {
           listEndpoints: {
             description:
-              'List plugin-provided custom API endpoints that can be invoked via `callEndpoint`. Returns method, path, and description for each.',
+              'List plugin-provided custom API endpoints that can be invoked via `callEndpoint`. Returns method, path, and description for each, plus an optional `schema` describing the request/response contract (query/body/response shapes) when the endpoint declares one.',
             execute: () => {
               return {
                 endpoints: customEndpoints.map((ep) => ({
                   description: ep.description,
                   method: ep.method.toUpperCase(),
                   path: ep.path,
+                  ...(ep.schema && { schema: ep.schema }),
                 })),
               }
             },


### PR DESCRIPTION
Surface `endpoint.custom.schema` (query / body / response shapes) through `discoverEndpoints` and `listEndpoints` so the agent sees each custom endpoint's request/response contract and can construct valid `callEndpoint` calls without trial-and-error.