### PR TITLE
feat(chat-agent): pass resolved modelId to tools resolver

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: pass the resolved `modelId` to the `tools` plugin option so a multi-provider setup can conditionally include provider-native tools (e.g. drop `anthropic.tools.webSearch_*` when the user selects an OpenAI model) instead of sending a tool shape the selected provider would reject at runtime.
+
 ## 0.1.0-beta.4
 
 BREAKING CHANGES:

--- a/chat-agent/README.md
+++ b/chat-agent/README.md
@@ -34,18 +34,18 @@ Provider API keys are never read from `process.env` by the plugin — pass them 
 
 ## Configuration
 
-| Option            | Type                                 | Required | Description                                                                                             |
-| ----------------- | ------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------- |
-| `model`           | `(modelId: string) => LanguageModel` | Yes      | Resolves a model id to a Vercel AI SDK `LanguageModel`. Called once per request with the selected model |
-| `defaultModel`    | `string`                             | Yes      | Model id used when no per-request override is provided                                                  |
-| `availableModels` | `ModelOption[]`                      | No       | Models the user can choose from in the chat UI (selector shown when 2+ entries)                         |
-| `systemPrompt`    | `string`                             | No       | Custom text prepended to the auto-generated system prompt                                               |
-| `access`          | `(req) => boolean`                   | No       | Override the default auth check (default: requires authenticated user)                                  |
-| `maxSteps`        | `number`                             | No       | Maximum tool-use loop steps per request (default: 20)                                                   |
-| `modes`           | `ModesConfig`                        | No       | Agent modes configuration (see below)                                                                   |
-| `adminView`       | `{ path, Component }`                | No       | Customize the admin chat view route or component                                                        |
-| `navLink`         | `boolean`                            | No       | Show a "Chat" link at the top of the admin nav sidebar (default: `true`)                                |
-| `budget`          | `BudgetConfig`                       | No       | Optional token budget (see below)                                                                       |
+| Option            | Type                                          | Required | Description                                                                                             |
+| ----------------- | --------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `model`           | `(modelId: string) => LanguageModel`          | Yes      | Resolves a model id to a Vercel AI SDK `LanguageModel`. Called once per request with the selected model |
+| `defaultModel`    | `string`                                      | Yes      | Model id used when no per-request override is provided                                                  |
+| `availableModels` | `ModelOption[]`                               | No       | Models the user can choose from in the chat UI (selector shown when 2+ entries)                         |
+| `systemPrompt`    | `string`                                      | No       | Custom text prepended to the auto-generated system prompt                                               |
+| `access`          | `(req) => boolean`                            | No       | Override the default auth check (default: requires authenticated user)                                  |
+| `maxSteps`        | `number`                                      | No       | Maximum tool-use loop steps per request (default: 20)                                                   |
+| `modes`           | `ModesConfig`                                 | No       | Agent modes configuration (see below)                                                                   |
+| `adminView`       | `{ path, Component }`                         | No       | Customize the admin chat view route or component                                                        |
+| `navLink`         | `boolean`                                     | No       | Show a "Chat" link at the top of the admin nav sidebar (default: `true`)                                |
+| `budget`          | `BudgetConfig`                                | No       | Optional token budget (see below)                                                                       |
 | `tools`           | `({ req, defaultTools, modelId }) => ToolMap` | No       | Compose the final toolset — add user or provider-native tools, drop defaults, etc. (see below)          |
 
 ### Mixing providers

--- a/chat-agent/README.md
+++ b/chat-agent/README.md
@@ -46,7 +46,7 @@ Provider API keys are never read from `process.env` by the plugin — pass them 
 | `adminView`       | `{ path, Component }`                | No       | Customize the admin chat view route or component                                                        |
 | `navLink`         | `boolean`                            | No       | Show a "Chat" link at the top of the admin nav sidebar (default: `true`)                                |
 | `budget`          | `BudgetConfig`                       | No       | Optional token budget (see below)                                                                       |
-| `tools`           | `({ req, defaultTools }) => ToolMap` | No       | Compose the final toolset — add user or provider-native tools, drop defaults, etc. (see below)          |
+| `tools`           | `({ req, defaultTools, modelId }) => ToolMap` | No       | Compose the final toolset — add user or provider-native tools, drop defaults, etc. (see below)          |
 
 ### Mixing providers
 
@@ -121,7 +121,7 @@ endpoints: [
 
 ### Extending or customizing tools
 
-One `tools` factory composes the full toolset the agent sees. It receives the plugin's default tools (the Payload Local API bindings below) and the authenticated `req`, and returns the final `name -> Tool` map. Modeled on Payload's `lexicalEditor({ features: ({ defaultFeatures }) => ... })`: spread `defaultTools` to keep them, omit to drop, and add your own under any name.
+One `tools` factory composes the full toolset the agent sees. It receives the plugin's default tools (the Payload Local API bindings below), the authenticated `req`, and the selected `modelId` for this request, and returns the final `name -> Tool` map. Modeled on Payload's `lexicalEditor({ features: ({ defaultFeatures }) => ... })`: spread `defaultTools` to keep them, omit to drop, and add your own under any name.
 
 ```ts
 import { anthropic } from '@ai-sdk/anthropic'
@@ -152,6 +152,28 @@ chatAgentPlugin({
         return { ok: res.ok, status: res.status }
       },
     }),
+  }),
+})
+```
+
+In a multi-provider setup, gate provider-native tools on `modelId` so they're only sent to a compatible provider — otherwise e.g. OpenAI will reject an Anthropic-native `webSearch_*` tool the moment someone picks `gpt-5-mini`:
+
+```ts
+import { anthropic } from '@ai-sdk/anthropic'
+import { openai } from '@ai-sdk/openai'
+
+chatAgentPlugin({
+  defaultModel: 'claude-sonnet-4-20250514',
+  availableModels: [
+    { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
+    { id: 'gpt-5-mini', label: 'GPT-5 mini' },
+  ],
+  model: (id) => (id.startsWith('claude-') ? anthropic(id) : openai(id)),
+  tools: ({ defaultTools, modelId }) => ({
+    ...defaultTools,
+    ...(modelId.startsWith('claude-')
+      ? { webSearch: anthropic.tools.webSearch_20250305({ maxUses: 5 }) }
+      : { webSearch: openai.tools.webSearch() }),
   }),
 })
 ```

--- a/chat-agent/dev/src/payload.config.ts
+++ b/chat-agent/dev/src/payload.config.ts
@@ -437,14 +437,22 @@ export default buildConfig({
       // user-defined tools and provider-native ones (executed server-side by
       // the provider, billed separately ~$10 / 1k searches).
       //
+      // The Anthropic-native web tools are gated on `modelId` so we don't
+      // send Anthropic-shaped tools to OpenAI when the user picks a `gpt-*`
+      // model — OpenAI would reject the unknown tool shape at runtime.
+      //
       // Using `webFetch_20250910` (pre-dynamic-filtering) so this works with
-      // all models. The newer `webFetch_20260209` adds code-execution-based
-      // filtering but requires Opus 4.6+/Sonnet 4.6.
-      tools: ({ defaultTools, req }) => ({
+      // all Claude models. The newer `webFetch_20260209` adds
+      // code-execution-based filtering but requires Opus 4.6+/Sonnet 4.6.
+      tools: ({ defaultTools, modelId, req }) => ({
         ...defaultTools,
         ...customTools({ req }),
-        webFetch: anthropic.tools.webFetch_20250910(),
-        webSearch: anthropic.tools.webSearch_20250305({ maxUses: 5 }),
+        ...(modelId.startsWith('claude-')
+          ? {
+              webFetch: anthropic.tools.webFetch_20250910(),
+              webSearch: anthropic.tools.webSearch_20250305({ maxUses: 5 }),
+            }
+          : {}),
       }),
       modes: {
         default: 'ask',

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -1514,8 +1514,7 @@ describe('chatAgentPlugin tools', () => {
     expect(lastStreamTextHandle()._streamTextOpts.tools!.webSearch).toBeUndefined()
 
     await handler({
-      json: () =>
-        Promise.resolve({ ...validChatBody, model: 'claude-sonnet-4-20250514' }),
+      json: () => Promise.resolve({ ...validChatBody, model: 'claude-sonnet-4-20250514' }),
       payload: { config: { collections: [], globals: [] } },
       user: { id: 1 },
     })

--- a/chat-agent/src/index.test.ts
+++ b/chat-agent/src/index.test.ts
@@ -1476,6 +1476,77 @@ describe('chatAgentPlugin tools', () => {
     expect(_streamTextOpts.tools!.fetchWeather).toBeDefined()
   })
 
+  it('passes the selected modelId to the tools resolver so it can skip provider-incompatible tools', async () => {
+    // Regression guard for the multi-provider setup: if the resolver only
+    // sees `defaultTools` and `req`, an Anthropic-native server tool like
+    // `anthropic.tools.webSearch_20250305` gets sent to OpenAI the moment a
+    // user picks `gpt-5-mini`, and OpenAI rejects the unknown tool shape at
+    // runtime. Surfacing the selected modelId to the resolver is what makes
+    // conditional registration possible.
+    vi.mocked(streamText).mockClear()
+    const plugin = chatAgentPlugin({
+      availableModels: [
+        { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet' },
+        { id: 'gpt-5-mini', label: 'GPT-5 mini' },
+      ],
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+      modes: { default: 'read-write' },
+      tools: ({ defaultTools, modelId }) => {
+        if (modelId.startsWith('claude-')) {
+          return {
+            ...defaultTools,
+            webSearch: fakeProviderTool('anthropic.web_search_20250305'),
+          }
+        }
+        return defaultTools
+      },
+    })
+    const handler = plugin({ endpoints: [] }).endpoints.find(
+      (ep: Endpoint) => ep.path === '/chat-agent/chat',
+    ).handler
+
+    await handler({
+      json: () => Promise.resolve({ ...validChatBody, model: 'gpt-5-mini' }),
+      payload: { config: { collections: [], globals: [] } },
+      user: { id: 1 },
+    })
+    expect(lastStreamTextHandle()._streamTextOpts.tools!.webSearch).toBeUndefined()
+
+    await handler({
+      json: () =>
+        Promise.resolve({ ...validChatBody, model: 'claude-sonnet-4-20250514' }),
+      payload: { config: { collections: [], globals: [] } },
+      user: { id: 1 },
+    })
+    expect(lastStreamTextHandle()._streamTextOpts.tools!.webSearch).toBeDefined()
+  })
+
+  it('falls back to defaultModel when the request omits `model` before calling the tools resolver', async () => {
+    vi.mocked(streamText).mockClear()
+    const receivedModelIds: string[] = []
+    const plugin = chatAgentPlugin({
+      defaultModel: 'claude-sonnet-4-20250514',
+      model: makeModelFactory().factory,
+      modes: { default: 'read-write' },
+      tools: ({ defaultTools, modelId }) => {
+        receivedModelIds.push(modelId)
+        return defaultTools
+      },
+    })
+    const handler = plugin({ endpoints: [] }).endpoints.find(
+      (ep: Endpoint) => ep.path === '/chat-agent/chat',
+    ).handler
+
+    await handler({
+      json: () => Promise.resolve(validChatBody),
+      payload: { config: { collections: [], globals: [] } },
+      user: { id: 1 },
+    })
+
+    expect(receivedModelIds).toEqual(['claude-sonnet-4-20250514'])
+  })
+
   describe('mode filtering for user-defined tools', () => {
     // The plugin can't know a user tool's side effects, so a tool with an
     // `execute` function defaults to "write": excluded in read, gated behind

--- a/chat-agent/src/index.ts
+++ b/chat-agent/src/index.ts
@@ -284,10 +284,16 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
             // Payload's `lexicalEditor({ features: ({ defaultFeatures }) => ... })`:
             // the user composes, the plugin does not merge. If omitted,
             // default tools are used as-is.
+            //
+            // `modelId` is passed in so a multi-provider setup can skip
+            // provider-native tools that the selected provider wouldn't
+            // accept (e.g. Anthropic's `webSearch_*` when the user picked
+            // an OpenAI model).
+            const modelId = body.model ?? options.defaultModel
             let allTools: Record<string, Tool>
             if (options.tools) {
               try {
-                allTools = await options.tools({ defaultTools: builtInTools, req })
+                allTools = await options.tools({ defaultTools: builtInTools, modelId, req })
               } catch (err) {
                 return Response.json(
                   {
@@ -306,7 +312,6 @@ export function chatAgentPlugin(options: ChatAgentPluginOptions) {
               customEndpoints.length > 0,
               mode,
             )
-            const modelId = body.model ?? options.defaultModel
             const maxSteps = options.maxSteps ?? 20
 
             // --- Resolve model from user-provided factory ------------------

--- a/chat-agent/src/types.ts
+++ b/chat-agent/src/types.ts
@@ -204,14 +204,20 @@ export interface ChatAgentPluginOptions {
   systemPrompt?: string
   /**
    * Customize the tools exposed to the agent. Called once per chat request
-   * with the authenticated request and the plugin's default tools (Payload
-   * Local API: `find`, `create`, `getCollectionSchema`, ...). Return the
-   * final `name -> Tool` map — the plugin does not merge; what you return is
-   * what the agent sees.
+   * with the authenticated request, the selected model id, and the plugin's
+   * default tools (Payload Local API: `find`, `create`,
+   * `getCollectionSchema`, ...). Return the final `name -> Tool` map — the
+   * plugin does not merge; what you return is what the agent sees.
    *
    * Modelled on Payload's `lexicalEditor({ features: ({ defaultFeatures }) => ... })`:
    * spread `defaultTools` to keep them, omit/filter to drop, and add your
    * own (user-defined or provider-native) under any name.
+   *
+   * `modelId` is the model the agent will use for this request — either the
+   * value from the request body or `defaultModel`. Use it to skip
+   * provider-native tools that the selected provider wouldn't accept (e.g.
+   * drop Anthropic's `webSearch_*` when the user picked an OpenAI model, or
+   * swap in `openai.tools.webSearch` instead).
    *
    * Tool classification for mode filtering (read / ask):
    * - Provider-native tools (no `execute` — executed server-side by the
@@ -230,9 +236,27 @@ export interface ChatAgentPluginOptions {
    *   }),
    * })
    * ```
+   *
+   * @example Conditional provider-native tools in a multi-provider setup
+   * ```ts
+   * import { anthropic } from '@ai-sdk/anthropic'
+   * chatAgentPlugin({
+   *   tools: ({ defaultTools, modelId }) => {
+   *     if (modelId.startsWith('claude-')) {
+   *       return {
+   *         ...defaultTools,
+   *         webSearch: anthropic.tools.webSearch_20250305({ maxUses: 5 }),
+   *       }
+   *     }
+   *     return defaultTools
+   *   },
+   * })
+   * ```
    */
   tools?: (args: {
     defaultTools: Record<string, Tool>
+    /** The model id resolved for this request (body.model or `defaultModel`). */
+    modelId: string
     req: PayloadRequest
   }) => Promise<Record<string, Tool>> | Record<string, Tool>
 }


### PR DESCRIPTION
Without this, a multi-provider setup cannot conditionally include
provider-native tools: `anthropic.tools.webSearch_*` gets sent to OpenAI
when the user picks `gpt-5-mini`, and OpenAI rejects the unknown tool
shape at runtime.

https://claude.ai/code/session_01WivTMkgouaYE6iiANnTBoZ