### PR TITLE
fix(content-translator): write back group and named-tab translations in emptyOnly mode

### DIFF
--- a/content-translator/CHANGELOG.md
+++ b/content-translator/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - style: standardize icons to use Geist icon set (16x16 filled)
 - feat: add configurable `access` option for the translate endpoint (defaults to requiring authentication)
+- fix: "translate empty fields" now populates localized fields nested inside groups and named tabs when the target locale has no value yet
 
 ## 0.1.2
 

--- a/content-translator/dev/src/collections/pages.ts
+++ b/content-translator/dev/src/collections/pages.ts
@@ -22,5 +22,41 @@ export const pagesSchema: CollectionConfig = {
       required: false,
       localized: true,
     },
+    {
+      name: 'meta',
+      type: 'group',
+      fields: [
+        {
+          name: 'title',
+          type: 'text',
+          localized: true,
+        },
+        {
+          name: 'description',
+          type: 'textarea',
+          localized: true,
+        },
+      ],
+    },
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          name: 'seo',
+          fields: [
+            {
+              name: 'ogTitle',
+              type: 'text',
+              localized: true,
+            },
+            {
+              name: 'ogDescription',
+              type: 'textarea',
+              localized: true,
+            },
+          ],
+        },
+      ],
+    },
   ],
 }

--- a/content-translator/package.json
+++ b/content-translator/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "node --experimental-strip-types --test test/*.test.ts",
+    "test": "tsx --test test/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -52,6 +52,7 @@
     "eslint": "^9.0.0",
     "prettier": "^3.8.3",
     "rimraf": "^6.1.3",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
   "files": [

--- a/content-translator/pnpm-lock.yaml
+++ b/content-translator/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/content-translator/src/translate/traverseFields.ts
+++ b/content-translator/src/translate/traverseFields.ts
@@ -204,6 +204,8 @@ export const traverseFields = ({
           valuesToTranslate,
         })
 
+        siblingDataTranslated[field.name] = groupDataTranslated
+
         break
       }
       case 'richText': {
@@ -286,6 +288,10 @@ export const traverseFields = ({
             translatedData,
             valuesToTranslate,
           })
+
+          if (hasName) {
+            siblingDataTranslated[tab.name] = tabDataTranslated
+          }
         }
 
         break

--- a/content-translator/test/traverseFields.test.ts
+++ b/content-translator/test/traverseFields.test.ts
@@ -1,18 +1,38 @@
+import type { Field, SanitizedConfig } from 'payload'
+
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
 
-/**
- * These tests verify that traverseFields correctly types array and block IDs
- * as string | number, supporting both MongoDB (string ObjectIds) and
- * PostgreSQL (numeric IDs).
- *
- * See https://github.com/jhb-software/payload-plugins/issues/70
- */
+import type { ValueToTranslate } from '../src/translate/types.ts'
+
+import { traverseFields } from '../src/translate/traverseFields.ts'
+
+const payloadConfig = {} as SanitizedConfig
+
+const runTraverse = (fields: Field[], dataFrom: Record<string, unknown>, emptyOnly: boolean) => {
+  const translatedData: Record<string, unknown> = {}
+  const valuesToTranslate: ValueToTranslate[] = []
+
+  traverseFields({
+    dataFrom,
+    emptyOnly,
+    fields,
+    payloadConfig,
+    translatedData,
+    valuesToTranslate,
+  })
+
+  for (const v of valuesToTranslate) {
+    v.onTranslate(`TRANSLATED:${v.value}`)
+  }
+
+  return translatedData
+}
 
 describe('traverseFields ID types', () => {
   describe('array field IDs', () => {
     test('accepts string IDs (MongoDB)', () => {
-      const arrayData: { id: string | number }[] = [
+      const arrayData: { id: number | string }[] = [
         { id: '507f1f77bcf86cd799439011' },
         { id: '507f1f77bcf86cd799439012' },
       ]
@@ -20,24 +40,124 @@ describe('traverseFields ID types', () => {
     })
 
     test('accepts numeric IDs (PostgreSQL)', () => {
-      const arrayData: { id: string | number }[] = [{ id: 1 }, { id: 2 }]
+      const arrayData: { id: number | string }[] = [{ id: 1 }, { id: 2 }]
       assert.equal(typeof arrayData[0].id, 'number')
     })
   })
 
   describe('block field IDs', () => {
     test('accepts string IDs (MongoDB)', () => {
-      const blockData: { blockType: string; id: string | number }[] = [
+      const blockData: { blockType: string; id: number | string }[] = [
         { id: '507f1f77bcf86cd799439011', blockType: 'hero' },
       ]
       assert.equal(typeof blockData[0].id, 'string')
     })
 
     test('accepts numeric IDs (PostgreSQL)', () => {
-      const blockData: { blockType: string; id: string | number }[] = [
+      const blockData: { blockType: string; id: number | string }[] = [
         { id: 42, blockType: 'hero' },
       ]
       assert.equal(typeof blockData[0].id, 'number')
+    })
+  })
+})
+
+/**
+ * Regression tests for https://github.com/jhb-software/payload-plugins/issues/137
+ *
+ * "Translate empty fields" silently dropped translations for localized fields
+ * inside groups and named tabs because the translated sub-object was created
+ * via a `?? {}` fallback but never written back to its parent.
+ */
+describe('traverseFields - emptyOnly with missing target sub-objects (#137)', () => {
+  test('populates a localized field inside a group when target locale data is missing', () => {
+    const fields: Field[] = [
+      {
+        name: 'meta',
+        type: 'group',
+        fields: [{ name: 'title', type: 'text', localized: true }],
+      },
+    ]
+
+    const translated = runTraverse(fields, { meta: { title: 'Hello' } }, true)
+
+    assert.deepEqual(translated, { meta: { title: 'TRANSLATED:Hello' } })
+  })
+
+  test('populates a localized field inside a named tab when target locale data is missing', () => {
+    const fields: Field[] = [
+      {
+        type: 'tabs',
+        tabs: [
+          {
+            name: 'seo',
+            fields: [{ name: 'description', type: 'text', localized: true }],
+          },
+        ],
+      },
+    ]
+
+    const translated = runTraverse(fields, { seo: { description: 'World' } }, true)
+
+    assert.deepEqual(translated, { seo: { description: 'TRANSLATED:World' } })
+  })
+
+  test('populates a localized field inside a group nested in a named tab', () => {
+    const fields: Field[] = [
+      {
+        type: 'tabs',
+        tabs: [
+          {
+            name: 'seo',
+            fields: [
+              {
+                name: 'social',
+                type: 'group',
+                fields: [{ name: 'title', type: 'text', localized: true }],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const translated = runTraverse(fields, { seo: { social: { title: 'Nested' } } }, true)
+
+    assert.deepEqual(translated, { seo: { social: { title: 'TRANSLATED:Nested' } } })
+  })
+
+  test('preserves existing translated values in a group when emptyOnly is true', () => {
+    const fields: Field[] = [
+      {
+        name: 'meta',
+        type: 'group',
+        fields: [
+          { name: 'title', type: 'text', localized: true },
+          { name: 'description', type: 'text', localized: true },
+        ],
+      },
+    ]
+
+    const translatedData: Record<string, unknown> = {
+      meta: { title: 'Already translated' },
+    }
+    const valuesToTranslate: ValueToTranslate[] = []
+
+    traverseFields({
+      dataFrom: { meta: { title: 'Hello', description: 'World' } },
+      emptyOnly: true,
+      fields,
+      payloadConfig,
+      translatedData,
+      valuesToTranslate,
+    })
+
+    for (const v of valuesToTranslate) {
+      v.onTranslate(`TRANSLATED:${v.value}`)
+    }
+
+    assert.deepEqual(translatedData, {
+      meta: { title: 'Already translated', description: 'TRANSLATED:World' },
     })
   })
 })


### PR DESCRIPTION
## Summary
Fixes an issue where the "translate empty fields" feature silently dropped translations for localized fields inside groups and named tabs. The translated sub-objects were created but never written back to their parent containers.

## Key Changes
- **traverseFields.ts**: Added missing assignments to persist translated data:
  - For group fields: assign `groupDataTranslated` back to `siblingDataTranslated[field.name]`
  - For named tabs: assign `tabDataTranslated` back to `siblingDataTranslated[tab.name]`
- **Test coverage**: Added comprehensive regression tests covering:
  - Localized fields in groups
  - Localized fields in named tabs
  - Nested groups within tabs
  - Preservation of existing translations when `emptyOnly` is true
- **Dev schema**: Enhanced the pages collection with group and tab field examples for testing
- **Test runner**: Updated from `node --experimental-strip-types` to `tsx` for better TypeScript support

## Implementation Details
The bug occurred because when traversing nested structures (groups and tabs), the code would create a temporary translated object (`groupDataTranslated` or `tabDataTranslated`) and recursively populate it, but failed to assign it back to the parent's translated data object. This caused all translations within these containers to be lost.

The fix ensures that after recursively processing nested fields, the populated sub-object is explicitly assigned to its parent, maintaining the complete translation hierarchy.

closes #137 