### PR TITLE
feat(chat-agent): allow restricting read mode via access

### DIFF
--- a/chat-agent/README.md
+++ b/chat-agent/README.md
@@ -91,10 +91,10 @@ chatAgentPlugin({
 })
 ```
 
-- `read` is always available and cannot be restricted
-- Modes without an access function are available to all authenticated users
+- Modes without an access function are available to all authenticated users (including `read`)
 - `superuser` requires an explicit access function to be enabled
 - Users only see modes they have access to
+- When only one mode remains after access filtering, the mode selector is hidden
 
 ### Empty chat screen
 

--- a/chat-agent/src/modes.test.ts
+++ b/chat-agent/src/modes.test.ts
@@ -22,9 +22,9 @@ describe('resolveAvailableModes', () => {
     expect(modes).toEqual(['read', 'ask', 'read-write'])
   })
 
-  it('always includes read even if access function returns false', async () => {
+  it('excludes read when access function returns false', async () => {
     const modes = await resolveAvailableModes({ access: { read: () => false } }, mockReq)
-    expect(modes).toContain('read')
+    expect(modes).not.toContain('read')
   })
 
   it('excludes superuser when no access function configured', async () => {

--- a/chat-agent/src/modes.ts
+++ b/chat-agent/src/modes.ts
@@ -34,7 +34,6 @@ export function resolveModeConfig(options: ChatAgentPluginOptions | undefined): 
  * the list of modes available to the user.
  *
  * Rules:
- * - `read` is always available (cannot be restricted).
  * - `superuser` is only available if an explicit access function is configured
  *   and returns true.
  * - Other modes are available to all authenticated users unless an access
@@ -47,12 +46,6 @@ export async function resolveAvailableModes(
   const available: AgentMode[] = []
 
   for (const mode of AGENT_MODES) {
-    // read is always available
-    if (mode === 'read') {
-      available.push(mode)
-      continue
-    }
-
     // superuser requires explicit access configuration
     if (mode === 'superuser' && !modesConfig.access?.superuser) {
       continue


### PR DESCRIPTION
Currently read mode is hardcoded as always available in resolveAvailableModes, so the mode selector dropdown always appears — even when ask is the only desired mode. No user voluntarily downgrades to read-only, so the dropdown just adds confusion.

This removes the special-casing for read and lets it go through the same access function check as ask and read-write. Since ModeSelector already returns null when availableModes.length <= 1, this effectively hides the dropdown when only one mode remains.

Backward-compatible — existing configs without modes.access.read still get read mode by default.

Closes #144