### PR TITLE
fix(chat-agent): accept numeric IDs in tool schemas

### DIFF
--- a/chat-agent/src/tools.ts
+++ b/chat-agent/src/tools.ts
@@ -303,7 +303,7 @@ export function buildTools(
         })
       },
       inputSchema: z.object({
-        id: z.string(),
+        id: z.union([z.string(), z.number()]),
         collection: z.string(),
         depth,
         draft,
@@ -347,7 +347,7 @@ export function buildTools(
         })
       },
       inputSchema: z.object({
-        id: z.string(),
+        id: z.union([z.string(), z.number()]),
         collection: z.string(),
         data: z.record(z.string(), z.unknown()),
         depth,
@@ -371,7 +371,7 @@ export function buildTools(
         })
       },
       inputSchema: z.object({
-        id: z.string(),
+        id: z.union([z.string(), z.number()]),
         collection: z.string(),
         depth,
         select,


### PR DESCRIPTION
Same approach as #79. `findByID`, `update`, and `delete` tool schemas use `z.string()` for the `id` field, which forces the LLM to send string IDs. On PostgreSQL with serial IDs, this causes downstream failures — `getLatestCollectionVersion` overwrites `version.id` with the string, breaking relationship validation in plugins like `@payloadcms/plugin-nested-docs` and causing false positives in custom `beforeDelete` hooks that compare IDs with strict equality.

Changes `z.string()` to `z.union([z.string(), z.number()])` on all three tool schemas.

Fixes #143