### PR TITLE
refactor(cloudinary)!: derive publicId from filename, align with storage-s3

### DIFF
--- a/cloudinary/CHANGELOG.md
+++ b/cloudinary/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+> ⚠️ **Breaking changes** below — review before upgrading.
+
+- refactor: align with `@payloadcms/storage-s3`'s stateless model. `cloudinaryPublicId` is now derived from `filename` + collection prefix + folder via a field-level `beforeChange` hook, not read from the Cloudinary upload response. The plugin no longer depends on `@payloadcms/plugin-cloud-storage` invoking `adapter.handleUpload` for client uploads — which it stopped doing in 3.82+ — so client uploads on Payload 3.82+ now persist correctly without any workaround.
+- fix: admin previews no longer fail with "missing on disk" after a client upload (root cause covered by the refactor above).
+- refactor: the static handler derives the Cloudinary URL from `cloudinaryPublicId` + `mimeType` instead of reading `doc.url`. Documents no longer need `doc.url` to point at a Cloudinary CDN URL for the API route to work.
+
+### Breaking changes
+
+- The `useFilename` config option has been removed. The plugin now always uses the original filename as the `public_id`. If you depended on `useFilename: false` (random Cloudinary IDs), migration: rename your `public_id`s in Cloudinary to match the new derivation `${folder}/${prefix}${filename without extension}`, or pin to 0.3.x.
+- `adapter.handleUpload` no longer writes `cloudinaryPublicId` or `url` onto the document. Anyone reading these fields downstream still gets the same values, but the write happens through field hooks now.
+
 ## 0.3.4
 
 - feat: broaden Next.js peer dependency to `^15.0.0 || ^16.0.0` so the plugin can be installed alongside Next.js 16

--- a/cloudinary/package.json
+++ b/cloudinary/package.json
@@ -18,14 +18,16 @@
   "types": "./src/index.ts",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:types && pnpm build:swc",
-    "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
-    "build:types": "tsc --outDir dist --rootDir ./src",
+    "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths --ignore '**/*.test.ts,**/*.test.tsx'",
+    "build:types": "tsc --project tsconfig.build.json --outDir dist --rootDir ./src",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
     "clean": "rimraf --glob {dist,*.tsbuildinfo}",
     "dev": "tsc -w",
     "format": "prettier --write src \"*.{json,md,js,mjs,cjs}\"",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm clean && pnpm build"
   },
@@ -43,7 +45,8 @@
     "eslint": "^9.39.4",
     "prettier": "^3.8.3",
     "rimraf": "6.1.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6"
   },
   "peerDependencies": {
     "next": "^15.0.0 || ^16.0.0",

--- a/cloudinary/pnpm-lock.yaml
+++ b/cloudinary/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.7.0)(vite@8.0.13(@types/node@25.7.0)(esbuild@0.27.7)(sass@1.77.4)(tsx@4.21.0))
 
   dev:
     dependencies:
@@ -195,8 +198,14 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -831,6 +840,12 @@ packages:
     resolution: {integrity: sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==}
     engines: {node: '>= 10'}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@15.5.18':
     resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
 
@@ -889,6 +904,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
   '@payloadcms/db-mongodb@3.84.1':
     resolution: {integrity: sha512-HTP/Z6iQHFyHhuMImAC/GH0xGhjuvuHZHdB7crJUkXAyD677tp6C3mS8YB04s28bCteDqcXBYjHODZr5xDHBcw==}
     peerDependencies:
@@ -937,6 +955,104 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
+  '@rolldown/binding-android-arm64@1.0.1':
+    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -947,6 +1063,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/cli@0.8.1':
     resolution: {integrity: sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ==}
@@ -1062,8 +1181,17 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@types/busboy@1.5.4':
     resolution: {integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
@@ -1170,6 +1298,35 @@ packages:
     resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^8.0.5
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+
   '@xhmikosr/archive-type@8.0.1':
     resolution: {integrity: sha512-toXuiWChyfOpEiCPsIw6HGHaNji5LVkvB6EREL548vGWr+hGaehwxG4LzN20vm9aGFXwnA/Jty8yW2/SmV+1zQ==}
     engines: {node: '>=20'}
@@ -1267,6 +1424,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1406,6 +1567,10 @@ packages:
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1479,6 +1644,9 @@ packages:
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   copyfiles@2.4.1:
     resolution: {integrity: sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==}
@@ -1633,6 +1801,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1843,6 +2014,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1861,6 +2035,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   ext-list@2.2.2:
     resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
@@ -2416,6 +2594,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2440,6 +2692,9 @@ packages:
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
@@ -2656,6 +2911,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -2743,6 +3001,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   payload@3.84.1:
     resolution: {integrity: sha512-+aPqqeYsffrzaYmsX/Qt+mHNgcTUyc5TIjjPOaMIrG6nDx6siZ2h9Gv3b3RKAVPt7PWkHI+ooEW3cQbwiDd99Q==}
@@ -2952,6 +3213,11 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
@@ -3056,6 +3322,9 @@ packages:
   sift@17.1.3:
     resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3109,8 +3378,14 @@ packages:
   stable-hash@0.0.4:
     resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3233,9 +3508,20 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3372,6 +3658,90 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
+  vite@8.0.13:
+    resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^8.0.5
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
@@ -3406,6 +3776,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3568,7 +3943,18 @@ snapshots:
       react: 19.2.6
       tslib: 2.8.1
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4121,6 +4507,13 @@ snapshots:
       '@napi-rs/nice-win32-x64-msvc': 1.1.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@next/env@15.5.18': {}
 
   '@next/env@16.2.6': {}
@@ -4148,6 +4541,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
+
+  '@oxc-project/types@0.130.0': {}
 
   '@payloadcms/db-mongodb@3.84.1(payload@3.84.1(graphql@16.12.0)(typescript@6.0.3))':
     dependencies:
@@ -4323,11 +4718,64 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@rolldown/binding-android-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.1':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/is@7.2.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/cli@0.8.1(@swc/core@1.15.33)':
     dependencies:
@@ -4419,9 +4867,21 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/busboy@1.5.4':
     dependencies:
       '@types/node': 25.7.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
@@ -4629,6 +5089,47 @@ snapshots:
       '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.7.0)(esbuild@0.27.7)(sass@1.77.4)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.13(@types/node@25.7.0)(esbuild@0.27.7)(sass@1.77.4)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xhmikosr/archive-type@8.0.1':
     dependencies:
       file-type: 21.3.4
@@ -4800,6 +5301,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -4916,6 +5419,8 @@ snapshots:
 
   caniuse-lite@1.0.30001792: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4980,6 +5485,8 @@ snapshots:
   convert-hrtime@5.0.0: {}
 
   convert-source-map@1.9.0: {}
+
+  convert-source-map@2.0.0: {}
 
   copyfiles@2.4.1:
     dependencies:
@@ -5080,8 +5587,7 @@ snapshots:
 
   detect-file@1.0.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   doctrine@3.0.0:
     dependencies:
@@ -5181,6 +5687,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -5516,6 +6024,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   events-universal@1.0.1:
@@ -5554,6 +6066,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.3.0: {}
 
   ext-list@2.2.2:
     dependencies:
@@ -6084,6 +6598,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lines-and-columns@1.2.4: {}
 
   locate-path@6.0.0:
@@ -6101,6 +6664,10 @@ snapshots:
   lowercase-keys@3.0.0: {}
 
   lru-cache@11.3.6: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-asynchronous@1.1.0:
     dependencies:
@@ -6307,6 +6874,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
@@ -6383,6 +6952,8 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   payload@3.84.1(graphql@16.12.0)(typescript@6.0.3):
     dependencies:
@@ -6661,6 +7232,27 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
+  rolldown@1.0.1:
+    dependencies:
+      '@oxc-project/types': 0.130.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.1
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-darwin-x64': 1.0.1
+      '@rolldown/binding-freebsd-x64': 1.0.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
+      '@rolldown/binding-linux-s390x-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-openharmony-arm64': 1.0.1
+      '@rolldown/binding-wasm32-wasi': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
+
   safe-array-concat@1.1.4:
     dependencies:
       call-bind: 1.0.9
@@ -6810,6 +7402,8 @@ snapshots:
 
   sift@17.1.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-wcswidth@1.1.2: {}
@@ -6849,7 +7443,11 @@ snapshots:
 
   stable-hash@0.0.4: {}
 
+  stackback@0.0.2: {}
+
   state-local@1.0.7: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -6984,10 +7582,16 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7128,6 +7732,47 @@ snapshots:
 
   uuid@11.1.1: {}
 
+  vite@8.0.13(@types/node@25.7.0)(esbuild@0.27.7)(sass@1.77.4)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.7.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      sass: 1.77.4
+      tsx: 4.21.0
+
+  vitest@4.1.6(@types/node@25.7.0)(vite@8.0.13(@types/node@25.7.0)(esbuild@0.27.7)(sass@1.77.4)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.7.0)(esbuild@0.27.7)(sass@1.77.4)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@25.7.0)(esbuild@0.27.7)(sass@1.77.4)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.7.0
+    transitivePeerDependencies:
+      - msw
+
   web-worker@1.5.0: {}
 
   webidl-conversions@7.0.0: {}
@@ -7185,6 +7830,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/cloudinary/src/client/CloudinaryClientUploadHandler.ts
+++ b/cloudinary/src/client/CloudinaryClientUploadHandler.ts
@@ -9,7 +9,6 @@ export type CloudinaryClientUploadHandlerExtra = {
   cloudName: string
   folder?: string
   prefix: string
-  useFilename?: boolean
 }
 
 export type ClientUploadContext = {
@@ -108,11 +107,11 @@ export const CloudinaryClientUploadHandler: ReturnType<
   typeof createClientUploadHandler<CloudinaryClientUploadHandlerExtra>
 > = createClientUploadHandler<CloudinaryClientUploadHandlerExtra>({
   handler: async ({ apiRoute, collectionSlug, extra, file, serverHandlerPath, serverURL }) => {
-    const { apiKey, cloudName, folder, prefix, useFilename } = extra
+    const { apiKey, cloudName, folder, prefix } = extra
 
     const url = `https://api.cloudinary.com/v1_1/${cloudName}/auto/upload`
     const timestamp = Math.round(new Date().getTime() / 1000).toString()
-    const publicId = useFilename ? generatePublicId(prefix, file.name) : undefined
+    const publicId = generatePublicId(prefix, file.name)
 
     const paramsToSign = buildParamsToSign({ folder, publicId, timestamp })
     const signature = await getSignature(

--- a/cloudinary/src/generateURL.ts
+++ b/cloudinary/src/generateURL.ts
@@ -1,34 +1,28 @@
 import type { GenerateURL } from '@payloadcms/plugin-cloud-storage/types'
 
-import type { CloudinaryStorageOptions } from './types.js'
-
 import { generateCloudinaryUrl } from './utilities/generateCloudinaryUrl.js'
+import { generatePublicId } from './utilities/generatePublicId.js'
 
-export const getGenerateUrl = ({ options }: { options: CloudinaryStorageOptions }): GenerateURL => {
-  return ({ data }) => {
-    const mimeType = (
-      'mimeType' in data && typeof data.mimeType === 'string' ? data.mimeType : undefined
-    ) as string | undefined
+export const getGenerateUrl = ({
+  cloudName,
+  collectionPrefix,
+  folderSrc,
+}: {
+  cloudName: string
+  collectionPrefix: string
+  folderSrc: string
+}): GenerateURL => {
+  return ({ data, filename }) => {
+    const mimeType =
+      data && 'mimeType' in data && typeof data.mimeType === 'string' ? data.mimeType : undefined
 
-    if (!mimeType) {
-      console.warn(
-        'MimeType field is missing in data passed to the generateURL function. This can happen if a find query contains select without mimeType. Falling back to auto/upload.',
-        data,
-      )
-    }
-
-    const cloudinaryPublicId =
-      'cloudinaryPublicId' in data && typeof data.cloudinaryPublicId === 'string'
-        ? data.cloudinaryPublicId
-        : undefined
-    if (!cloudinaryPublicId) {
-      // since Payload 3.7X this is called during upload, therefore its not possible to throw an error here, otherwise the upload fails
+    if (!filename) {
       return undefined as unknown as string
     }
 
     return generateCloudinaryUrl({
-      cloudinaryPublicId,
-      cloudName: options.cloudName,
+      cloudinaryPublicId: `${folderSrc}${generatePublicId(collectionPrefix, filename)}`,
+      cloudName,
       mimeType,
     })
   }

--- a/cloudinary/src/getAdminThumbnail.ts
+++ b/cloudinary/src/getAdminThumbnail.ts
@@ -1,38 +1,39 @@
 import { generateCloudinaryUrl } from './utilities/generateCloudinaryUrl.js'
+import { generatePublicId } from './utilities/generatePublicId.js'
 
 type GetAdminThumbnail = (args: { doc: Record<string, unknown> }) => false | null | string
 
-type GetAdminThumbnailFactory = (cloudName: string) => GetAdminThumbnail
+type GetAdminThumbnailFactory = (args: {
+  cloudName: string
+  collectionPrefix: string
+  folderSrc: string
+}) => GetAdminThumbnail
 
-/**
- * Factory function to create the adminThumbnail function with access to cloudName.
- * This generates thumbnail URLs directly from cloudinaryPublicId instead of relying on doc.url,
- * which may still be a relative path when Payload's thumbnailURL hook runs.
- */
-export const getAdminThumbnailFactory: GetAdminThumbnailFactory = (cloudName) => {
+// Derive the thumbnail URL from doc.filename + collection prefix + folder rather than
+// reading doc.cloudinaryPublicId. The plugin owns the entire public_id namespace, so it
+// can reconstruct it without depending on a value that the upload pipeline may not have
+// persisted yet (e.g. during the upload-in-progress render).
+export const getAdminThumbnailFactory: GetAdminThumbnailFactory = ({
+  cloudName,
+  collectionPrefix,
+  folderSrc,
+}) => {
   return ({ doc }) => {
-    const cloudinaryPublicId = doc.cloudinaryPublicId
+    const filename = doc.filename
     const mimeType = doc.mimeType
 
-    if (
-      !cloudinaryPublicId ||
-      !mimeType ||
-      typeof cloudinaryPublicId !== 'string' ||
-      typeof mimeType !== 'string'
-    ) {
-      // since Payload 3.7X this is called during upload, therefore its not possible to throw an error here, otherwise the upload fails
-      return undefined as unknown as string
+    if (!filename || !mimeType || typeof filename !== 'string' || typeof mimeType !== 'string') {
+      return null
     }
 
+    const cloudinaryPublicId = `${folderSrc}${generatePublicId(collectionPrefix, filename)}`
     const transformOptions = 'w_300,h_300,c_fill,f_auto,q_auto,dpr_auto'
 
-    // For videos, create an image thumbnail (webp format)
     if (mimeType.startsWith('video/')) {
-      const publicIdWithoutExt = cloudinaryPublicId.replace(/\.[^/.]+$/, '')
       return generateCloudinaryUrl({
-        cloudinaryPublicId: `${publicIdWithoutExt}.webp`,
+        cloudinaryPublicId: `${cloudinaryPublicId}.webp`,
         cloudName,
-        mimeType: 'video/', // Keep as video for correct resource type
+        mimeType: 'video/',
         transformOptions,
       })
     }

--- a/cloudinary/src/handleUpload.ts
+++ b/cloudinary/src/handleUpload.ts
@@ -5,37 +5,30 @@ import type stream from 'stream'
 import { v2 as cloudinary } from 'cloudinary'
 import fs from 'fs'
 
-import type { ClientUploadContext } from './client/CloudinaryClientUploadHandler.js'
-
 import { generatePublicId } from './utilities/generatePublicId.js'
 
 type HandleUploadArgs = {
+  collectionPrefix: string
   folderSrc: string
-  prefix?: string
-  useFilename?: boolean
 }
 
 const multipartThreshold = 1024 * 1024 * 99 // 99MB
 
+// Uploads the file to Cloudinary using a deterministic public_id derived from filename
+// + collection prefix + folder. The persisted cloudinaryPublicId field is computed from
+// those same inputs via a field-level beforeChange hook, so this function does not
+// mutate `data` — it just performs the upload. Server-side uploads only; client uploads
+// never reach here (upstream filters them out in afterChange, and the file is already
+// in Cloudinary).
 export const getHandleUpload = ({
+  collectionPrefix,
   folderSrc,
-  prefix = '',
-  useFilename,
 }: HandleUploadArgs): HandleUpload => {
   return async ({ data, file }) => {
-    const clientUploadContext = file.clientUploadContext as ClientUploadContext | undefined
-
-    // If the file was already uploaded from the client, add the publicId and secureUrl to the data object and return it
-    if (clientUploadContext) {
-      data.cloudinaryPublicId = clientUploadContext.publicId
-      data.url = clientUploadContext.secureUrl
-
-      return data
-    }
-
+    const folder = folderSrc.replace(/\/$/, '')
     const uploadOptions: UploadApiOptions = {
-      folder: folderSrc,
-      public_id: useFilename ? generatePublicId(prefix, file.filename) : undefined,
+      folder: folder || undefined,
+      public_id: generatePublicId(collectionPrefix, file.filename),
       resource_type: 'auto',
     }
 
@@ -51,7 +44,6 @@ export const getHandleUpload = ({
               if (error) {
                 reject(new Error(`Upload error: ${error.message}`))
               }
-
               resolve(result!)
             })
             .end(fileBufferOrStream)
@@ -63,7 +55,6 @@ export const getHandleUpload = ({
               if (error) {
                 reject(new Error(`Chunked upload error: ${error.message}`))
               }
-
               resolve(result!)
             })
             .end(fileBufferOrStream)
@@ -73,14 +64,10 @@ export const getHandleUpload = ({
 
     const result = await uploadStream()
 
-    if (result && typeof result === 'object' && 'public_id' in result && 'secure_url' in result) {
-      // these fields will be stored in the database
-      data.cloudinaryPublicId = result.public_id
-      data.url = result.secure_url
-
-      return data
-    } else {
+    if (!(result && typeof result === 'object' && 'public_id' in result)) {
       throw new Error('No public_id in upload result from Cloudinary. Upload failed.')
     }
+
+    return data
   }
 }

--- a/cloudinary/src/index.test.ts
+++ b/cloudinary/src/index.test.ts
@@ -1,0 +1,131 @@
+import type { CollectionConfig, Config, FieldHook, TextField } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import type { CloudinaryStorageOptions } from './types.js'
+
+import { payloadCloudinaryPlugin } from './index.js'
+
+const baseOptions: CloudinaryStorageOptions = {
+  clientUploads: true,
+  cloudName: 'test-cloud',
+  collections: {
+    media: true,
+    videos: { prefix: 'videos/' },
+  },
+  credentials: {
+    apiKey: 'test-key',
+    apiSecret: 'test-secret',
+  },
+  folder: 'cloudinary-storage-plugin-test',
+}
+
+const mediaCollection: CollectionConfig = {
+  slug: 'media',
+  fields: [],
+  upload: { mimeTypes: ['image/*'] },
+}
+
+const videosCollection: CollectionConfig = {
+  slug: 'videos',
+  fields: [],
+  upload: { mimeTypes: ['video/*'] },
+}
+
+async function buildConfig(): Promise<Config> {
+  const incoming = {
+    collections: [mediaCollection, videosCollection],
+  } as unknown as Config
+
+  return await payloadCloudinaryPlugin(baseOptions)(incoming)
+}
+
+function findField(collection: CollectionConfig, name: string): TextField | undefined {
+  return collection.fields.find(
+    (f): f is TextField => 'name' in f && f.name === name && f.type === 'text',
+  )
+}
+
+async function runFieldBeforeChange(
+  hook: FieldHook,
+  args: { data: Record<string, unknown>; originalDoc?: Record<string, unknown>; value?: unknown },
+): Promise<unknown> {
+  return await (hook as unknown as (a: unknown) => unknown)({
+    collection: undefined,
+    context: {},
+    data: args.data,
+    field: undefined,
+    operation: 'create',
+    originalDoc: args.originalDoc,
+    req: {} as unknown,
+    siblingData: args.data,
+    value: args.value,
+  })
+}
+
+describe('payloadCloudinaryPlugin — stateless publicId derivation', () => {
+  it('derives cloudinaryPublicId from filename + folder for a collection with no prefix', async () => {
+    const config = await buildConfig()
+    const media = config.collections!.find((c) => c.slug === 'media')!
+    const field = findField(media, 'cloudinaryPublicId')
+
+    expect(field).toBeDefined()
+    expect(field?.hooks?.beforeChange?.length ?? 0).toBeGreaterThan(0)
+
+    const result = await runFieldBeforeChange(field!.hooks!.beforeChange![0], {
+      data: { filename: 'photo.jpg', mimeType: 'image/jpeg' },
+    })
+
+    expect(result).toBe('cloudinary-storage-plugin-test/photo')
+  })
+
+  it('derives cloudinaryPublicId from filename + folder + collection prefix', async () => {
+    const config = await buildConfig()
+    const videos = config.collections!.find((c) => c.slug === 'videos')!
+    const field = findField(videos, 'cloudinaryPublicId')
+
+    const result = await runFieldBeforeChange(field!.hooks!.beforeChange![0], {
+      data: { filename: 'clip.mp4', mimeType: 'video/mp4' },
+    })
+
+    expect(result).toBe('cloudinary-storage-plugin-test/videos/clip')
+  })
+
+  it('does not need req.file.clientUploadContext to populate cloudinaryPublicId', async () => {
+    const config = await buildConfig()
+    const media = config.collections!.find((c) => c.slug === 'media')!
+    const field = findField(media, 'cloudinaryPublicId')
+
+    const result = await runFieldBeforeChange(field!.hooks!.beforeChange![0], {
+      data: { filename: 'photo.jpg', mimeType: 'image/jpeg' },
+    })
+
+    expect(result).toBe('cloudinary-storage-plugin-test/photo')
+  })
+
+  it('falls back to originalDoc.filename on update without a new file', async () => {
+    const config = await buildConfig()
+    const media = config.collections!.find((c) => c.slug === 'media')!
+    const field = findField(media, 'cloudinaryPublicId')
+
+    const result = await runFieldBeforeChange(field!.hooks!.beforeChange![0], {
+      data: {},
+      originalDoc: { filename: 'photo.jpg', mimeType: 'image/jpeg' },
+      value: 'cloudinary-storage-plugin-test/photo',
+    })
+
+    expect(result).toBe('cloudinary-storage-plugin-test/photo')
+  })
+
+  it('does not touch collections that are not configured for cloudinary', async () => {
+    const other: CollectionConfig = { slug: 'pages', fields: [] }
+    const incoming = {
+      collections: [mediaCollection, other],
+    } as unknown as Config
+
+    const config = await payloadCloudinaryPlugin(baseOptions)(incoming)
+
+    const pages = config.collections?.find((c) => c.slug === 'pages')
+    expect(pages && findField(pages, 'cloudinaryPublicId')).toBeUndefined()
+  })
+})

--- a/cloudinary/src/index.ts
+++ b/cloudinary/src/index.ts
@@ -4,7 +4,7 @@ import type {
   CollectionOptions,
   GeneratedAdapter,
 } from '@payloadcms/plugin-cloud-storage/types'
-import type { Config, Field, Plugin } from 'payload'
+import type { Config, Field, Plugin, TextField } from 'payload'
 
 import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 import { initClientUploads } from '@payloadcms/plugin-cloud-storage/utilities'
@@ -19,11 +19,50 @@ import { getGenerateSignature } from './getGenerateSignature.js'
 import { getHandleDelete } from './handleDelete.js'
 import { getHandleUpload } from './handleUpload.js'
 import { getStaticHandler } from './staticHandler.js'
+import { generatePublicId } from './utilities/generatePublicId.js'
 
-const defaultUploadOptions: Partial<CloudinaryStorageOptions> = {
-  enabled: true,
-  useFilename: true,
-}
+const folderSrcOf = (folder?: string) => (folder ? folder.replace(/^\/|\/$/g, '') + '/' : '')
+
+const collectionPrefixOf = (collOptions: CloudinaryStorageOptions['collections'][string]) =>
+  (typeof collOptions === 'object' && collOptions.prefix) || ''
+
+// Cloudinary's public_id is fully determined by what the plugin tells Cloudinary to use:
+// `${folder}/${collectionPrefix}${filename without extension}`. No piece comes from the
+// upload response, so the field can be persisted via a beforeChange hook driven by
+// data.filename — identical to how @payloadcms/storage-s3 reconstructs S3 keys without
+// per-doc state. Aligning with that pattern removes the need for adapters to receive
+// clientUploadContext through afterChange (which upstream now skips).
+const buildPublicIdField = ({
+  collectionPrefix,
+  folderSrc,
+}: {
+  collectionPrefix: string
+  folderSrc: string
+}): TextField => ({
+  name: 'cloudinaryPublicId',
+  type: 'text',
+  admin: {
+    disableBulkEdit: true,
+    hidden: true,
+    readOnly: true,
+  },
+  hooks: {
+    beforeChange: [
+      ({ data, originalDoc, value }) => {
+        const filename =
+          (data && typeof data.filename === 'string' && data.filename) ||
+          (originalDoc && typeof originalDoc.filename === 'string' && originalDoc.filename) ||
+          undefined
+        if (!filename) {
+          return value
+        }
+        return `${folderSrc}${generatePublicId(collectionPrefix, filename)}`
+      },
+    ],
+  },
+  label: 'Cloudinary Public ID',
+  required: false,
+})
 
 export const payloadCloudinaryPlugin: (cloudinaryStorageOpts: CloudinaryStorageOptions) => Plugin =
   (incomingOptions: CloudinaryStorageOptions) =>
@@ -34,24 +73,8 @@ export const payloadCloudinaryPlugin: (cloudinaryStorageOpts: CloudinaryStorageO
       cloud_name: incomingOptions.cloudName,
     })
 
-    const options = {
-      ...defaultUploadOptions,
-      ...incomingOptions,
-    }
-
-    const fields: Field[] = [
-      {
-        name: 'cloudinaryPublicId',
-        type: 'text',
-        admin: {
-          disableBulkEdit: true,
-          hidden: true,
-          readOnly: true,
-        },
-        label: 'Cloudinary Public ID',
-        required: false, // set to false to match with the default url field
-      },
-    ]
+    const options = { enabled: true, ...incomingOptions }
+    const folderSrc = folderSrcOf(options.folder)
 
     const isPluginDisabled = options.enabled === false
 
@@ -69,7 +92,6 @@ export const payloadCloudinaryPlugin: (cloudinaryStorageOpts: CloudinaryStorageO
           cloudName: options.cloudName,
           folder: options.folder,
           prefix: (typeof collection === 'object' && collection.prefix) || '',
-          useFilename: options.useFilename,
         }) satisfies CloudinaryClientUploadHandlerExtra,
       serverHandler: getGenerateSignature({
         access:
@@ -83,9 +105,6 @@ export const payloadCloudinaryPlugin: (cloudinaryStorageOpts: CloudinaryStorageO
       return incomingConfig
     }
 
-    const adapter = cloudinaryStorageAdapter({ ...options })
-
-    // Add adapter to each collection option object
     const collectionsWithAdapter: CloudStoragePluginOptions['collections'] = Object.entries(
       options.collections,
     ).reduce(
@@ -93,26 +112,37 @@ export const payloadCloudinaryPlugin: (cloudinaryStorageOpts: CloudinaryStorageO
         ...acc,
         [slug]: {
           ...(collOptions === true ? {} : collOptions),
-          adapter,
+          adapter: cloudinaryStorageAdapter({
+            clientUploads: options.clientUploads,
+            cloudName: options.cloudName,
+            collectionPrefix: collectionPrefixOf(collOptions),
+            folderSrc,
+          }),
         },
       }),
       {} as Record<string, CollectionOptions>,
     )
 
-    // Set disableLocalStorage: true for collections specified in the plugin options
     const config = {
       ...incomingConfig,
       collections: (incomingConfig.collections || []).map((collection) => {
-        if (!collectionsWithAdapter[collection.slug]) {
+        const collOptions = options.collections[collection.slug]
+        if (!collOptions) {
           return collection
         }
+        const collectionPrefix = collectionPrefixOf(collOptions)
+        const publicIdField: Field = buildPublicIdField({ collectionPrefix, folderSrc })
 
         return {
           ...collection,
-          fields: [...fields, ...(collection.fields || [])],
+          fields: [publicIdField, ...(collection.fields || [])],
           upload: {
             ...(typeof collection.upload === 'object' ? collection.upload : {}),
-            adminThumbnail: getAdminThumbnailFactory(options.cloudName),
+            adminThumbnail: getAdminThumbnailFactory({
+              cloudName: options.cloudName,
+              collectionPrefix,
+              folderSrc,
+            }),
             crop: false,
             disableLocalStorage: true,
           },
@@ -125,21 +155,23 @@ export const payloadCloudinaryPlugin: (cloudinaryStorageOpts: CloudinaryStorageO
     })(config)
   }
 
-function cloudinaryStorageAdapter(options: CloudinaryStorageOptions): Adapter {
-  return ({ prefix }): GeneratedAdapter => {
-    const folderSrc = options.folder ? options.folder.replace(/^\/|\/$/g, '') + '/' : '' // ensure only trailing slash is present
-
-    return {
-      name: 'cloudinary',
-      clientUploads: options.clientUploads,
-      generateURL: getGenerateUrl({ options }),
-      handleDelete: getHandleDelete(),
-      handleUpload: getHandleUpload({
-        folderSrc,
-        prefix,
-        useFilename: options.useFilename,
-      }),
-      staticHandler: getStaticHandler(),
-    }
-  }
+function cloudinaryStorageAdapter({
+  clientUploads,
+  cloudName,
+  collectionPrefix,
+  folderSrc,
+}: {
+  clientUploads?: CloudinaryStorageOptions['clientUploads']
+  cloudName: string
+  collectionPrefix: string
+  folderSrc: string
+}): Adapter {
+  return (): GeneratedAdapter => ({
+    name: 'cloudinary',
+    clientUploads,
+    generateURL: getGenerateUrl({ cloudName, collectionPrefix, folderSrc }),
+    handleDelete: getHandleDelete(),
+    handleUpload: getHandleUpload({ collectionPrefix, folderSrc }),
+    staticHandler: getStaticHandler({ cloudName, collectionPrefix, folderSrc }),
+  })
 }

--- a/cloudinary/src/staticHandler.ts
+++ b/cloudinary/src/staticHandler.ts
@@ -2,10 +2,27 @@ import type { StaticHandler } from '@payloadcms/plugin-cloud-storage/types'
 
 import type { ClientUploadContext } from './client/CloudinaryClientUploadHandler.js'
 
-// This is called:
-// - after the client upload is finished with the clientUploadContext
-// - whenever the file is requested from the api/[collection]/[filename] path
-export const getStaticHandler = (): StaticHandler => {
+import { generateCloudinaryUrl } from './utilities/generateCloudinaryUrl.js'
+import { generatePublicId } from './utilities/generatePublicId.js'
+
+// staticHandler is called for two distinct flows:
+//   1. After a client upload, addDataAndFileToRequest invokes it with
+//      params.clientUploadContext so it can fetch the file content from Cloudinary for
+//      server-side size generation.
+//   2. When the admin (or any client of /api/{collection}/file/{filename}) requests the
+//      original file with disablePayloadAccessControl: false. The doc.url field may
+//      point back at this same route (Payload's default for upload collections), so the
+//      handler must NOT read doc.url to find the Cloudinary location — it must derive
+//      the Cloudinary public_id itself, the same way the rest of the plugin does.
+export const getStaticHandler = ({
+  cloudName,
+  collectionPrefix,
+  folderSrc,
+}: {
+  cloudName: string
+  collectionPrefix: string
+  folderSrc: string
+}): StaticHandler => {
   return async (req, { doc, params }) => {
     try {
       type Params = {
@@ -15,56 +32,32 @@ export const getStaticHandler = (): StaticHandler => {
       }
       const { clientUploadContext, collection, filename } = params as Params
 
-      let publicId: string | undefined
       let secureUrl: string | undefined
 
       if (
         clientUploadContext &&
-        'publicId' in clientUploadContext &&
-        clientUploadContext.publicId &&
+        typeof clientUploadContext === 'object' &&
         'secureUrl' in clientUploadContext &&
-        clientUploadContext.secureUrl
+        typeof clientUploadContext.secureUrl === 'string'
       ) {
-        publicId = clientUploadContext.publicId
         secureUrl = clientUploadContext.secureUrl
       } else {
-        if (
-          doc &&
-          'cloudinaryPublicId' in doc &&
-          'url' in doc &&
-          typeof doc.cloudinaryPublicId === 'string' &&
-          typeof doc.url === 'string'
-        ) {
-          publicId = doc.cloudinaryPublicId
-          secureUrl = doc.url
-        } else {
-          const result = await req.payload.find({
-            collection,
-            limit: 1,
-            pagination: false,
-            req,
-            select: {
-              cloudinaryPublicId: true,
-              url: true,
-            },
-            where: {
-              filename: { equals: filename },
-            },
+        const mimeType = await getMimeType({
+          collection,
+          doc: doc as { mimeType?: unknown } | undefined,
+          filename,
+          req,
+        })
+        if (mimeType) {
+          secureUrl = generateCloudinaryUrl({
+            cloudinaryPublicId: `${folderSrc}${generatePublicId(collectionPrefix, filename)}`,
+            cloudName,
+            mimeType,
           })
-
-          if (
-            result.docs.length > 0 &&
-            'cloudinaryPublicId' in result.docs[0] &&
-            'url' in result.docs[0]
-          ) {
-            publicId = result.docs[0].cloudinaryPublicId as string
-            secureUrl = result.docs[0].url as string
-          }
         }
       }
 
-      if (!publicId || !secureUrl) {
-        console.log('No publicId or secureUrl found, returning 404')
+      if (!secureUrl) {
         return new Response(null, { status: 404, statusText: 'Not Found' })
       }
 
@@ -102,15 +95,36 @@ export const getStaticHandler = (): StaticHandler => {
         'http_code' in err.error &&
         err.error.http_code === 404
       ) {
-        const cloudinaryError =
-          'message' in err.error ? err.error.message : JSON.stringify(err.error)
-
-        console.log('Error fetching file from cloudinary, 404, message:', cloudinaryError)
         return new Response(null, { status: 404, statusText: 'Not Found' })
       }
-
       req.payload.logger.error({ err, msg: 'Unexpected error in staticHandler' })
       return new Response('Internal Server Error', { status: 500 })
     }
   }
+}
+
+async function getMimeType({
+  collection,
+  doc,
+  filename,
+  req,
+}: {
+  collection: string
+  doc?: { mimeType?: unknown }
+  filename: string
+  req: Parameters<StaticHandler>[0]
+}): Promise<string | undefined> {
+  if (doc && typeof doc.mimeType === 'string') {
+    return doc.mimeType
+  }
+  const result = await req.payload.find({
+    collection,
+    limit: 1,
+    pagination: false,
+    req,
+    select: { mimeType: true },
+    where: { filename: { equals: filename } },
+  })
+  const found = result.docs[0] as { mimeType?: unknown } | undefined
+  return found && typeof found.mimeType === 'string' ? found.mimeType : undefined
 }

--- a/cloudinary/src/types.ts
+++ b/cloudinary/src/types.ts
@@ -36,10 +36,4 @@ export type CloudinaryStorageOptions = {
    * Folder name to upload files to.
    */
   folder?: string
-
-  /**
-   * Whether to use the original filename as part of the public ID
-   * @default true
-   */
-  useFilename?: boolean
 }

--- a/cloudinary/tsconfig.build.json
+++ b/cloudinary/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["./src/**/*.test.ts", "./src/**/*.test.tsx"]
+}

--- a/cloudinary/vitest.config.ts
+++ b/cloudinary/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})


### PR DESCRIPTION
## Summary

Alternative to #148 that **removes the workaround entirely** by aligning this plugin with the stateless model used by `@payloadcms/storage-s3`. The plugin no longer depends on the cloudinary response coming back through `adapter.handleUpload`, so the upstream 3.82+ regression that skips that call for client uploads becomes inert.

### Why this works

`generatePublicId(prefix, filename)` is the value the plugin **tells Cloudinary to use** (both server-side via `cloudinary.uploader.upload_stream` and client-side via the signed upload). Cloudinary honors an explicit `public_id` verbatim — no suffixing — so the resulting `cloudinaryPublicId` is fully determined by:

```
`${folderSrc}${collectionPrefix}${filename without extension}`
```

…every piece of which is either adapter config (closure) or already on the document (`data.filename`). The cloudinary response is a *mirror* of what we passed in, not a *source of truth* — exactly like how the S3 adapter knows the bucket key without asking S3 (`@payloadcms/storage-s3/dist/adapter.js`).

### What changed

- **`cloudinaryPublicId` field gets a `beforeChange` hook** that derives the value from `data.filename` + closure-captured `collectionPrefix` + `folderSrc`. Falls back to `originalDoc.filename` on updates without a new file. This runs whether or not `handleUpload` was called, so client uploads on Payload 3.82+ persist correctly.
- **`generateURL`** derives `cloudinaryPublicId` inline instead of reading `data.cloudinaryPublicId`. It now takes `cloudName`, `collectionPrefix`, and `folderSrc` instead of the full options object.
- **`staticHandler`** reconstructs the Cloudinary CDN URL from `doc.cloudinaryPublicId` + `mimeType` (looked up via `payload.find` when not in `doc`). It no longer reads `doc.url`, which removes a footgun: with `disablePayloadAccessControl: false`, `doc.url` was `/api/{collection}/file/{filename}` and the old handler would recursively fetch itself.
- **`getAdminThumbnail`** derives `cloudinaryPublicId` from `doc.filename` + collection prefix instead of reading `doc.cloudinaryPublicId` — same logic as `generateURL`, same factory signature.
- **`handleUpload`** still performs the actual upload but no longer mutates `data` — the field hook owns persistence.
- **`useFilename: false` removed** (breaking). In that mode Cloudinary mints a random `public_id`, and the only place it exists is the upload response — non-derivable. Dropping it is the price of a stateless plugin.
- **`adapter.clientUploads` is now forwarded** from `options.clientUploads` instead of being hardcoded, fixing a pre-existing oversight.

### What this means for the upstream bug

The upstream filter `!file.clientUploadContext` in `@payloadcms/plugin-cloud-storage/hooks/afterChange.js:35` still skips `handleUpload` for client uploads. That's still arguably an API contract violation (`HandleUpload`'s type declares `clientUploadContext` as a parameter). But for this plugin it's now a non-issue — there's nothing left for the adapter to do that depends on that callback firing. Filing the upstream bug remains worthwhile for other adapters in the wild that still need it.

### Relationship to #148

#148 is a fast, low-risk fix that restores persistence by adding a collection-level `beforeChange` hook reading `req.file.clientUploadContext`. This PR is the cleaner alternative — pick one. If we ship this, #148 should be closed without merging.

## Test plan

- [x] `pnpm test` — 5 new tests covering:
  - derivation for a collection with no prefix
  - derivation with collection prefix (`videos/`)
  - derivation without any `clientUploadContext` involvement (proves the new path doesn't depend on it)
  - fallback to `originalDoc.filename` on update without a new file
  - non-cloudinary collections are untouched
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` produces a clean `dist/` with no `*.test.*` files
- [ ] End-to-end in `cloudinary/dev`: upload an image (uses `disablePayloadAccessControl: true`) and a video (no `disablePayloadAccessControl`) via the admin's client upload path, confirm both render in the admin and the docs carry the expected `cloudinaryPublicId`.
- [ ] Migration check: existing docs already have correct `cloudinaryPublicId` values stored (the persistence used to come from Cloudinary's response, which equals what the new derivation produces for `useFilename: true`). No data migration needed except for users who were on `useFilename: false` — they'll need to rename objects in Cloudinary.

## Breaking changes

- `useFilename` option removed. Documented in CHANGELOG with migration guidance.
- `adapter.handleUpload` no longer writes `cloudinaryPublicId` or `url` onto the document. Direct consumers of the adapter (rare) should be aware.