### PR TITLE
feat(alt-text): add baseUrl option to openAIResolver

### DIFF
--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: add `baseUrl` option to `openAIResolver` for OpenAI-compatible providers (e.g. Nebius, Azure)
+
 ## 0.6.1
 
 - fix: pass `'max'` as the second `revalidateTag` argument so the health-widget cache invalidation no longer triggers Next 16's deprecation warning

--- a/alt-text/src/resolvers/openAI.ts
+++ b/alt-text/src/resolvers/openAI.ts
@@ -18,6 +18,12 @@ export type OpenAIResolverConfig = {
   /** OpenAI API key for authentication */
   apiKey: string
   /**
+   * Base URL for the OpenAI-compatible API.
+   * Use this to point at alternative providers (e.g. Azure, Nebius, local inference).
+   * @default undefined — the OpenAI SDK defaults to 'https://api.openai.com/v1'
+   */
+  baseUrl?: string
+  /**
    * The OpenAI LLM model to use for alt text generation.
    * @default 'gpt-4.1-nano'
    */
@@ -57,14 +63,23 @@ function zodResponseFormat<ZodInput extends z.ZodType>(
  * ```typescript
  * import { openAIResolver } from '@jhb.software/payload-alt-text-plugin'
  *
+ * // OpenAI
  * openAIResolver({
  *   apiKey: process.env.OPENAI_API_KEY,
  *   model: 'gpt-4.1-mini', // optional, defaults to 'gpt-4.1-nano'
  * })
+ *
+ * // OpenAI-compatible provider (e.g. Nebius)
+ * openAIResolver({
+ *   apiKey: process.env.NEBIUS_API_KEY,
+ *   baseUrl: 'https://api.tokenfactory.us-central1.nebius.com/v1',
+ *   model: 'Qwen/Qwen2.5-VL-72B-Instruct',
+ * })
  * ```
  */
 export const openAIResolver = (config: OpenAIResolverConfig): AltTextResolver => {
-  const { apiKey, model = 'gpt-4.1-nano' } = config
+  const { apiKey, baseUrl, model = 'gpt-4.1-nano' } = config
+  const openai = new OpenAI({ apiKey, baseURL: baseUrl })
 
   return {
     key: 'openai',
@@ -74,8 +89,6 @@ export const openAIResolver = (config: OpenAIResolverConfig): AltTextResolver =>
       locale,
     }: AltTextResolverArgs): Promise<AltTextResolverResponse> => {
       try {
-        const openai = new OpenAI({ apiKey })
-
         const modelResponseSchema = z.object({
           altText: z.string().describe('A concise, descriptive alt text for the image'),
           keywords: z.array(z.string()).describe('Keywords that describe the content of the image'),
@@ -144,8 +157,6 @@ export const openAIResolver = (config: OpenAIResolverConfig): AltTextResolver =>
       locales,
     }: AltTextBulkResolverArgs): Promise<AltTextBulkResolverResponse> => {
       try {
-        const openai = new OpenAI({ apiKey })
-
         const modelResponseSchema = z.object(
           Object.fromEntries(
             locales.map((locale) => [


### PR DESCRIPTION
The content-translator plugin's `openAIResolver` already accepts a `baseUrl` option, but the alt-text plugin's resolver does not. This makes it impossible to use OpenAI-compatible vision providers (e.g. Nebius Token Factory) without writing a custom resolver.

This PR adds an optional `baseUrl` parameter to `openAIResolver` for pointing at OpenAI-compatible providers.