### PR TITLE
feat(chat-agent): add updateMany and deleteMany tools for bulk operations

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: add `updateMany` and `deleteMany` tools for bulk-updating/deleting documents matching a `where` query in a single call.
+
 ## 0.1.0-beta.7
 
 - feat: `emptyState` accepts a per-request callback `({ req }) => EmptyStateConfig | Promise<EmptyStateConfig>` in addition to a static object, so the empty chat screen can be loaded from a Payload global or varied per tenant.

--- a/chat-agent/src/system-prompt.ts
+++ b/chat-agent/src/system-prompt.ts
@@ -123,6 +123,7 @@ export function buildSystemPrompt(
     '- Use `limit` to fetch only as many documents as needed.',
     '- For listing/browsing, select only summary fields (e.g. id, title, slug, status) first, then fetch full details with findByID only when needed.',
     "- Don't re-fetch a document already loaded in this conversation unless its data may have changed. A write tool (`update`, `create`, `updateGlobal`) returns the saved document — use that response directly instead of following it with a `findByID`.",
+    '- Use `updateMany` / `deleteMany` to apply the same change to multiple documents in one call instead of looping `update` / `delete` per document.',
     '- When an expected field is missing from a response, the most likely causes (in order) are: a localized field unset in the requested locale (try another locale), an unpublished doc requiring `draft: true`, or a `select` that excluded the field. Check those before broadening `depth` or removing `select`.',
     '',
     '## Admin Panel Links',

--- a/chat-agent/src/tools.test.ts
+++ b/chat-agent/src/tools.test.ts
@@ -50,11 +50,13 @@ describe('buildTools', () => {
       'count',
       'create',
       'delete',
+      'deleteMany',
       'find',
       'findByID',
       'findGlobal',
       'update',
       'updateGlobal',
+      'updateMany',
     ])
   })
 
@@ -71,6 +73,7 @@ describe('buildTools', () => {
       'count',
       'create',
       'delete',
+      'deleteMany',
       'find',
       'findByID',
       'findGlobal',
@@ -80,6 +83,7 @@ describe('buildTools', () => {
       'listBlocks',
       'update',
       'updateGlobal',
+      'updateMany',
     ])
   })
 
@@ -208,6 +212,77 @@ describe('buildTools', () => {
     )
   })
 
+  it('updateMany calls payload.update with where (no id)', async () => {
+    const payload = createMockPayload()
+    const tools = buildTools(payload, mockUser)
+
+    await tools.updateMany.execute(
+      {
+        collection: 'posts',
+        data: { status: 'published' },
+        where: { status: { equals: 'draft' } },
+      },
+      { abortSignal: undefined, messages: [], toolCallId: '1' },
+    )
+
+    expect(payload.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'posts',
+        data: { status: 'published' },
+        depth: 0,
+        overrideAccess: false,
+        user: mockUser,
+        where: { status: { equals: 'draft' } },
+      }),
+    )
+    expect(payload.update).toHaveBeenCalledWith(
+      expect.not.objectContaining({ id: expect.anything() }),
+    )
+  })
+
+  it('updateMany forwards limit', async () => {
+    const payload = createMockPayload()
+    const tools = buildTools(payload, mockUser)
+
+    await tools.updateMany.execute(
+      {
+        collection: 'posts',
+        data: { status: 'published' },
+        limit: 10,
+        where: { status: { equals: 'draft' } },
+      },
+      { abortSignal: undefined, messages: [], toolCallId: '1' },
+    )
+
+    expect(payload.update).toHaveBeenCalledWith(expect.objectContaining({ limit: 10 }))
+  })
+
+  it('deleteMany calls payload.delete with where (no id)', async () => {
+    const payload = createMockPayload()
+    const tools = buildTools(payload, mockUser)
+
+    await tools.deleteMany.execute(
+      {
+        collection: 'posts',
+        where: { status: { equals: 'draft' } },
+      },
+      { abortSignal: undefined, messages: [], toolCallId: '1' },
+    )
+
+    expect(payload.delete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'posts',
+        depth: 0,
+        overrideAccess: false,
+        user: mockUser,
+        where: { status: { equals: 'draft' } },
+      }),
+    )
+    expect(payload.delete).toHaveBeenCalledWith(
+      expect.not.objectContaining({ id: expect.anything() }),
+    )
+  })
+
   it('count calls payload.count correctly', async () => {
     const payload = createMockPayload()
     const tools = buildTools(payload, mockUser)
@@ -323,11 +398,15 @@ describe('buildTools', () => {
     await tools.findByID.execute({ id: '1', collection: 'posts' }, ctx)
     await tools.create.execute({ collection: 'posts', data: {} }, ctx)
     await tools.update.execute({ id: '1', collection: 'posts', data: {} }, ctx)
+    await tools.updateMany.execute({ collection: 'posts', data: {}, where: { x: {} } }, ctx)
     await tools.delete.execute({ id: '1', collection: 'posts' }, ctx)
+    await tools.deleteMany.execute({ collection: 'posts', where: { x: {} } }, ctx)
     await tools.count.execute({ collection: 'posts' }, ctx)
     await tools.findGlobal.execute({ slug: 'settings' }, ctx)
     await tools.updateGlobal.execute({ slug: 'settings', data: {} }, ctx)
 
+    // updateMany and deleteMany share payload.update / payload.delete with
+    // their single-document counterparts — the loop below covers both.
     for (const method of [
       'find',
       'findByID',
@@ -673,7 +752,9 @@ describe('filterToolsByMode', () => {
       expect(names).toEqual(expect.arrayContaining(['find', 'findByID', 'count', 'findGlobal']))
       expect(names).not.toContain('create')
       expect(names).not.toContain('update')
+      expect(names).not.toContain('updateMany')
       expect(names).not.toContain('delete')
+      expect(names).not.toContain('deleteMany')
       expect(names).not.toContain('updateGlobal')
     })
 
@@ -696,7 +777,7 @@ describe('filterToolsByMode', () => {
     it('includes all tools', () => {
       const tools = getAllTools()
       const filtered = filterToolsByMode(tools, 'ask')
-      expect(Object.keys(filtered)).toHaveLength(8)
+      expect(Object.keys(filtered)).toHaveLength(10)
     })
 
     it('read tools are unchanged (no needsApproval, still have execute)', () => {
@@ -753,11 +834,13 @@ describe('filterToolsByMode', () => {
           'count',
           'create',
           'delete',
+          'deleteMany',
           'find',
           'findByID',
           'findGlobal',
           'update',
           'updateGlobal',
+          'updateMany',
         ])
         for (const tool of Object.values(filtered)) {
           expect(tool).not.toHaveProperty('needsApproval')

--- a/chat-agent/src/tools.ts
+++ b/chat-agent/src/tools.ts
@@ -41,7 +41,14 @@ export const READ_TOOL_NAMES = [
 ] as const
 
 /** Built-in tools that modify data (restricted in read/ask modes). */
-export const WRITE_TOOL_NAMES = ['create', 'update', 'delete', 'updateGlobal'] as const
+export const WRITE_TOOL_NAMES = [
+  'create',
+  'update',
+  'updateMany',
+  'delete',
+  'deleteMany',
+  'updateGlobal',
+] as const
 
 const readToolSet: ReadonlySet<string> = new Set(READ_TOOL_NAMES)
 
@@ -359,6 +366,35 @@ export function buildTools(
       }),
     },
 
+    updateMany: {
+      description:
+        'Update multiple documents matching a where query. Partial — omitted fields are unchanged. Returns { docs, errors }.',
+      execute: async (input: Record<string, unknown>) => {
+        return payload.update({
+          collection: input.collection,
+          data: input.data,
+          where: input.where,
+          ...(input.limit !== undefined && { limit: input.limit }),
+          ...commonParams(input),
+          ...access,
+        })
+      },
+      inputSchema: z.object({
+        collection: z.string(),
+        data: z.record(z.string(), z.unknown()),
+        depth,
+        draft,
+        fallbackLocale,
+        limit: z.number().optional().describe('Max documents to update (default: no limit).'),
+        locale,
+        populate,
+        select,
+        where: z
+          .record(z.string(), z.unknown())
+          .describe("Payload where query, e.g. { status: { equals: 'draft' } }."),
+      }),
+    },
+
     delete: {
       description: 'Delete a document by ID.',
       execute: async (input: Record<string, unknown>) => {
@@ -375,6 +411,27 @@ export function buildTools(
         collection: z.string(),
         depth,
         select,
+      }),
+    },
+
+    deleteMany: {
+      description: 'Delete multiple documents matching a where query. Returns { docs, errors }.',
+      execute: async (input: Record<string, unknown>) => {
+        return payload.delete({
+          collection: input.collection,
+          depth: input.depth ?? 0,
+          select: input.select,
+          where: input.where,
+          ...access,
+        })
+      },
+      inputSchema: z.object({
+        collection: z.string(),
+        depth,
+        select,
+        where: z
+          .record(z.string(), z.unknown())
+          .describe("Payload where query, e.g. { status: { equals: 'draft' } }."),
       }),
     },
 


### PR DESCRIPTION
## Summary

- Add `updateMany` and `deleteMany` tools that expose Payload's bulk update/delete via where instead of id, so the agent can apply the same change to many documents in a single call instead of looping one-by-one
- Add system prompt guidance in the token efficiency section to prefer bulk tools over per-document loops
- `where` is required on both tools to prevent accidental "update all" / "delete all"
- `updateMany` exposes limit for batch size capping

 ## Tests

- Updated tool-name snapshot tests to include updateMany and deleteMany
- Added `updateMany` calls payload.update with where (no id) test
- Added `updateMany` forwards limit test
- Added `deleteMany` calls payload.delete with where (no id) test
- Added both tools to `overrideAccess` - false invariant test
- Added both tools to read-mode filter exclusion assertions