### PR TITLE
feat(chat-agent): add bulk update/delete via where queries

### DIFF
--- a/chat-agent/CHANGELOG.md
+++ b/chat-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: `update` and `delete` tools now accept a `where` query for bulk operations, mirroring Payload's local API. Pass `id` to target a single document or `where` to update/delete many in one call; `update` also accepts an optional `limit` when using `where`.
+
 ## 0.1.0-beta.7
 
 - feat: `emptyState` accepts a per-request callback `({ req }) => EmptyStateConfig | Promise<EmptyStateConfig>` in addition to a static object, so the empty chat screen can be loaded from a Payload global or varied per tenant.

--- a/chat-agent/src/tools.test.ts
+++ b/chat-agent/src/tools.test.ts
@@ -21,6 +21,7 @@ import {
  */
 const asConfig = (v: unknown) => v as SanitizedConfig
 const asReq = (v: unknown) => v as PayloadRequest
+const asSchema = (v: unknown) => v as { safeParse: (input: unknown) => { success: boolean } }
 
 describe('buildTools', () => {
   // Cast to `TypedUser` — the parameter is typed against Payload's generated
@@ -206,6 +207,101 @@ describe('buildTools', () => {
         user: mockUser,
       }),
     )
+  })
+
+  it('update with where forwards to payload.update without an id (bulk path)', async () => {
+    const payload = createMockPayload()
+    const tools = buildTools(payload, mockUser)
+
+    await tools.update.execute(
+      {
+        collection: 'posts',
+        data: { status: 'published' },
+        where: { status: { equals: 'draft' } },
+      },
+      { abortSignal: undefined, messages: [], toolCallId: '1' },
+    )
+
+    expect(payload.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'posts',
+        data: { status: 'published' },
+        overrideAccess: false,
+        user: mockUser,
+        where: { status: { equals: 'draft' } },
+      }),
+    )
+    expect(payload.update).toHaveBeenCalledWith(
+      expect.not.objectContaining({ id: expect.anything() }),
+    )
+  })
+
+  it('update with where forwards limit', async () => {
+    const payload = createMockPayload()
+    const tools = buildTools(payload, mockUser)
+
+    await tools.update.execute(
+      {
+        collection: 'posts',
+        data: { status: 'published' },
+        limit: 10,
+        where: { status: { equals: 'draft' } },
+      },
+      { abortSignal: undefined, messages: [], toolCallId: '1' },
+    )
+
+    expect(payload.update).toHaveBeenCalledWith(expect.objectContaining({ limit: 10 }))
+  })
+
+  it('delete with where forwards to payload.delete without an id (bulk path)', async () => {
+    const payload = createMockPayload()
+    const tools = buildTools(payload, mockUser)
+
+    await tools.delete.execute(
+      {
+        collection: 'posts',
+        where: { status: { equals: 'draft' } },
+      },
+      { abortSignal: undefined, messages: [], toolCallId: '1' },
+    )
+
+    expect(payload.delete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'posts',
+        overrideAccess: false,
+        user: mockUser,
+        where: { status: { equals: 'draft' } },
+      }),
+    )
+    expect(payload.delete).toHaveBeenCalledWith(
+      expect.not.objectContaining({ id: expect.anything() }),
+    )
+  })
+
+  it('update schema requires exactly one of id or where', () => {
+    // Mirrors Payload's local update API: `id` updates a single doc, `where`
+    // updates many. Passing neither would silently target nothing useful;
+    // passing both is ambiguous. Both must be caught at the schema, since the
+    // AI SDK validates input before `execute` runs.
+    const schema = asSchema(buildTools(createMockPayload(), mockUser).update.inputSchema)
+
+    expect(schema.safeParse({ collection: 'posts', data: {} }).success).toBe(false)
+    expect(
+      schema.safeParse({ id: '1', collection: 'posts', data: {}, where: { x: {} } }).success,
+    ).toBe(false)
+    expect(schema.safeParse({ id: '1', collection: 'posts', data: {} }).success).toBe(true)
+    expect(schema.safeParse({ collection: 'posts', data: {}, where: { x: {} } }).success).toBe(true)
+  })
+
+  it('delete schema requires exactly one of id or where', () => {
+    // Same rationale as `update` — the schema guards a destructive op against
+    // accidental "delete everything" when `where` is forgotten.
+    const schema = asSchema(buildTools(createMockPayload(), mockUser).delete.inputSchema)
+
+    expect(schema.safeParse({ collection: 'posts' }).success).toBe(false)
+    expect(schema.safeParse({ id: '1', collection: 'posts', where: { x: {} } }).success).toBe(false)
+    expect(schema.safeParse({ id: '1', collection: 'posts' }).success).toBe(true)
+    expect(schema.safeParse({ collection: 'posts', where: { x: {} } }).success).toBe(true)
   })
 
   it('count calls payload.count correctly', async () => {

--- a/chat-agent/src/tools.ts
+++ b/chat-agent/src/tools.ts
@@ -336,46 +336,83 @@ export function buildTools(
     },
 
     update: {
-      description: 'Update a document by ID. Partial — omitted fields are unchanged.',
+      description:
+        'Update one document by `id`, or many documents matching `where`. Partial — omitted fields are unchanged. With `id`, returns the updated document; with `where`, returns `{ docs, errors }`. Exactly one of `id` / `where` is required.',
       execute: async (input: Record<string, unknown>) => {
         return payload.update({
-          id: input.id,
           collection: input.collection,
           data: input.data,
+          ...(input.id !== undefined
+            ? { id: input.id }
+            : {
+                where: input.where,
+                ...(input.limit !== undefined && { limit: input.limit }),
+              }),
           ...commonParams(input),
           ...access,
         })
       },
-      inputSchema: z.object({
-        id: z.union([z.string(), z.number()]),
-        collection: z.string(),
-        data: z.record(z.string(), z.unknown()),
-        depth,
-        draft,
-        fallbackLocale,
-        locale,
-        populate,
-        select,
-      }),
+      inputSchema: z
+        .object({
+          id: z
+            .union([z.string(), z.number()])
+            .optional()
+            .describe('Single-document target. Omit when using `where`.'),
+          collection: z.string(),
+          data: z.record(z.string(), z.unknown()),
+          depth,
+          draft,
+          fallbackLocale,
+          limit: z
+            .number()
+            .optional()
+            .describe('Max documents to update; only applies with `where`.'),
+          locale,
+          populate,
+          select,
+          where: z
+            .record(z.string(), z.unknown())
+            .optional()
+            .describe(
+              "Bulk-update target, e.g. { status: { equals: 'draft' } }. Omit when using `id`.",
+            ),
+        })
+        .refine((input) => (input.id !== undefined) !== (input.where !== undefined), {
+          message: 'Pass exactly one of `id` (single document) or `where` (multiple documents).',
+        }),
     },
 
     delete: {
-      description: 'Delete a document by ID.',
+      description:
+        'Delete one document by `id`, or many documents matching `where`. With `id`, returns the deleted document; with `where`, returns `{ docs, errors }`. Exactly one of `id` / `where` is required.',
       execute: async (input: Record<string, unknown>) => {
         return payload.delete({
-          id: input.id,
           collection: input.collection,
           depth: input.depth ?? 0,
           select: input.select,
+          ...(input.id !== undefined ? { id: input.id } : { where: input.where }),
           ...access,
         })
       },
-      inputSchema: z.object({
-        id: z.union([z.string(), z.number()]),
-        collection: z.string(),
-        depth,
-        select,
-      }),
+      inputSchema: z
+        .object({
+          id: z
+            .union([z.string(), z.number()])
+            .optional()
+            .describe('Single-document target. Omit when using `where`.'),
+          collection: z.string(),
+          depth,
+          select,
+          where: z
+            .record(z.string(), z.unknown())
+            .optional()
+            .describe(
+              "Bulk-delete target, e.g. { status: { equals: 'draft' } }. Omit when using `id`.",
+            ),
+        })
+        .refine((input) => (input.id !== undefined) !== (input.where !== undefined), {
+          message: 'Pass exactly one of `id` (single document) or `where` (multiple documents).',
+        }),
     },
 
     count: {


### PR DESCRIPTION
## Summary

The `update` and `delete` tools now support bulk operations via `where` queries, mirroring Payload's local API. Users can pass `id` to target a single document or `where` to update/delete many in one call.

## Changes

- **Update tool**: Now accepts optional `where` query and `limit` parameters. Exactly one of `id` or `where` is required (enforced by schema validation). When using `where`, returns `{ docs, errors }`; with `id`, returns the updated document.
- **Delete tool**: Now accepts optional `where` query. Exactly one of `id` or `where` is required (enforced by schema validation). When using `where`, returns `{ docs, errors }`; with `id`, returns the deleted document.
- **Schema validation**: Both tools use `.refine()` to ensure exactly one of `id` or `where` is provided, preventing accidental "delete/update everything" scenarios when a parameter is forgotten.
- **Test coverage**: Added tests for bulk update/delete execution paths, limit forwarding, and schema validation of the mutually-exclusive `id`/`where` constraint.

## Implementation Details

- The `execute` functions conditionally spread either `{ id }` or `{ where, limit? }` into the Payload API call based on which parameter is provided.
- Schema descriptions clarify the purpose of each parameter and when to use `id` vs. `where`.
- The refine validation uses XOR logic: `(input.id !== undefined) !== (input.where !== undefined)` ensures exactly one is defined.

https://claude.ai/code/session_01A3ToMyvbcHvjeF9vuQhoQw