### PR TITLE
fix(cloudinary): persist client uploads and serve files on Payload 3.82+

### DIFF
--- a/cloudinary/CHANGELOG.md
+++ b/cloudinary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: restore client uploads on Payload 3.82+. Client-uploaded documents now keep a usable `url`/`cloudinaryPublicId`, and files served from `disablePayloadAccessControl` collections no longer fail with "missing on the disk".
 - fix: harden the client-upload signature endpoint (`/cloudinary-generate-signature`). The endpoint now only signs the `timestamp`, `folder`, and `public_id` parameters, only issues signatures for collections the plugin manages, enforces the configured upload folder, and rejects stale timestamps. The default access control now requires `create` access to the target upload collection instead of merely being authenticated.
 
 ## 0.3.4

--- a/cloudinary/src/handleUpload.ts
+++ b/cloudinary/src/handleUpload.ts
@@ -5,8 +5,6 @@ import type stream from 'stream'
 import { v2 as cloudinary } from 'cloudinary'
 import fs from 'fs'
 
-import type { ClientUploadContext } from './client/CloudinaryClientUploadHandler.js'
-
 import { generatePublicId } from './utilities/generatePublicId.js'
 
 type HandleUploadArgs = {
@@ -23,16 +21,6 @@ export const getHandleUpload = ({
   useFilename,
 }: HandleUploadArgs): HandleUpload => {
   return async ({ data, file }) => {
-    const clientUploadContext = file.clientUploadContext as ClientUploadContext | undefined
-
-    // If the file was already uploaded from the client, add the publicId and secureUrl to the data object and return it
-    if (clientUploadContext) {
-      data.cloudinaryPublicId = clientUploadContext.publicId
-      data.url = clientUploadContext.secureUrl
-
-      return data
-    }
-
     const uploadOptions: UploadApiOptions = {
       folder: folderSrc,
       public_id: useFilename ? generatePublicId(prefix, file.filename) : undefined,

--- a/cloudinary/src/index.test.ts
+++ b/cloudinary/src/index.test.ts
@@ -1,0 +1,150 @@
+import type { CollectionConfig, Config } from 'payload'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { CloudinaryStorageOptions } from './types.js'
+
+import { payloadCloudinaryPlugin } from './index.js'
+
+const baseOptions = {
+  cloudName: 'demo',
+  credentials: { apiKey: 'key', apiSecret: 'secret' },
+} satisfies Partial<CloudinaryStorageOptions>
+
+function buildConfig(options: CloudinaryStorageOptions): Config {
+  const incomingConfig = {
+    collections: [{ slug: 'media', fields: [], upload: true }],
+  } as unknown as Config
+
+  return payloadCloudinaryPlugin(options)(incomingConfig) as Config
+}
+
+function getCollection(config: Config, slug: string): CollectionConfig {
+  const collection = (config.collections || []).find((c) => c.slug === slug)
+  if (!collection) {
+    throw new Error(`collection ${slug} not found`)
+  }
+  return collection
+}
+
+async function runBeforeChange(
+  collection: CollectionConfig,
+  req: unknown,
+): Promise<Record<string, unknown>> {
+  let data: Record<string, unknown> = {}
+  for (const hook of collection.hooks?.beforeChange ?? []) {
+    data =
+      ((await hook({ data, operation: 'create', req } as never)) as
+        | Record<string, unknown>
+        | undefined) ?? data
+  }
+  return data
+}
+
+describe('payloadCloudinaryPlugin client-upload persistence', () => {
+  it('persists cloudinaryPublicId and url from the client upload context before the DB write', async () => {
+    const config = buildConfig({
+      ...baseOptions,
+      clientUploads: true,
+      collections: { media: true },
+    })
+    const collection = getCollection(config, 'media')
+
+    const data = await runBeforeChange(collection, {
+      context: {},
+      file: {
+        clientUploadContext: {
+          publicId: 'media/photo',
+          secureUrl: 'https://res.cloudinary.com/demo/media/photo',
+        },
+      },
+    })
+
+    expect(data.cloudinaryPublicId).toBe('media/photo')
+    expect(data.url).toBe('https://res.cloudinary.com/demo/media/photo')
+  })
+
+  it('leaves the document untouched when the upload did not come from the client', async () => {
+    const config = buildConfig({
+      ...baseOptions,
+      clientUploads: true,
+      collections: { media: true },
+    })
+    const collection = getCollection(config, 'media')
+
+    const data = await runBeforeChange(collection, { context: {} })
+
+    expect(data.cloudinaryPublicId).toBeUndefined()
+    expect(data.url).toBeUndefined()
+  })
+
+  it('does not register the persistence hook when client uploads are disabled', async () => {
+    const config = buildConfig({ ...baseOptions, collections: { media: true } })
+    const collection = getCollection(config, 'media')
+
+    const data = await runBeforeChange(collection, {
+      context: {},
+      file: {
+        clientUploadContext: {
+          publicId: 'media/photo',
+          secureUrl: 'https://res.cloudinary.com/demo/media/photo',
+        },
+      },
+    })
+
+    expect(data.cloudinaryPublicId).toBeUndefined()
+    expect(data.url).toBeUndefined()
+  })
+})
+
+describe('payloadCloudinaryPlugin static file serving', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('serves a file resolved by filename when disablePayloadAccessControl is enabled', async () => {
+    const config = buildConfig({
+      ...baseOptions,
+      clientUploads: true,
+      collections: { media: { disablePayloadAccessControl: true } },
+    })
+    const collection = getCollection(config, 'media')
+    const handlers = (typeof collection.upload === 'object' && collection.upload.handlers) || []
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(4)),
+        headers: new Headers({ 'Content-Type': 'image/jpeg' }),
+      }),
+    )
+
+    const req = {
+      headers: new Headers(),
+      payload: {
+        find: vi.fn().mockResolvedValue({
+          docs: [
+            {
+              cloudinaryPublicId: 'media/photo',
+              url: 'https://res.cloudinary.com/demo/media/photo',
+            },
+          ],
+        }),
+      },
+    }
+    // A plain admin GET of the file carries no clientUploadContext.
+    const params = { collection: 'media', filename: 'photo.jpg' }
+
+    let served: Response | undefined
+    for (const handler of handlers) {
+      const res = (await handler(req as never, { params } as never)) as Response | undefined
+      if (res) {
+        served = res
+        break
+      }
+    }
+
+    expect(served?.status).toBe(200)
+    expect(served?.headers.get('Content-Type')).toBe('image/jpeg')
+  })
+})

--- a/cloudinary/src/index.ts
+++ b/cloudinary/src/index.ts
@@ -4,13 +4,16 @@ import type {
   CollectionOptions,
   GeneratedAdapter,
 } from '@payloadcms/plugin-cloud-storage/types'
-import type { Config, Field, Plugin } from 'payload'
+import type { CollectionBeforeChangeHook, Config, Field, Plugin } from 'payload'
 
 import { cloudStoragePlugin } from '@payloadcms/plugin-cloud-storage'
 import { initClientUploads } from '@payloadcms/plugin-cloud-storage/utilities'
 import { v2 as cloudinary } from 'cloudinary'
 
-import type { CloudinaryClientUploadHandlerExtra } from './client/CloudinaryClientUploadHandler.js'
+import type {
+  ClientUploadContext,
+  CloudinaryClientUploadHandlerExtra,
+} from './client/CloudinaryClientUploadHandler.js'
 import type { CloudinaryStorageOptions } from './types.js'
 
 import { getGenerateUrl } from './generateURL.js'
@@ -122,9 +125,65 @@ export const payloadCloudinaryPlugin: (cloudinaryStorageOpts: CloudinaryStorageO
       }),
     }
 
-    return cloudStoragePlugin({
+    const result = cloudStoragePlugin({
       collections: collectionsWithAdapter,
     })(config)
+
+    // The workarounds below only matter when client uploads are enabled; otherwise cloud-storage's
+    // own afterChange/handleUpload and static handler behave as this plugin expects.
+    if (!options.clientUploads) {
+      return result
+    }
+
+    // Since Payload 3.82, cloud-storage's afterChange skips handleUpload for files that carry a
+    // `clientUploadContext`. This plugin relied on handleUpload to persist `cloudinaryPublicId`/`url`
+    // from that context, so without this hook a client-uploaded document is saved without a usable URL.
+    const persistClientUploadContext: CollectionBeforeChangeHook = ({ data, req }) => {
+      const clientUploadContext = (req?.file as { clientUploadContext?: ClientUploadContext })
+        ?.clientUploadContext
+
+      if (clientUploadContext) {
+        data.cloudinaryPublicId = clientUploadContext.publicId
+        data.url = clientUploadContext.secureUrl
+      }
+
+      return data
+    }
+
+    result.collections = (result.collections || []).map((collection) => {
+      const collOptions = options.collections[collection.slug]
+      if (!collOptions) {
+        return collection
+      }
+
+      const existingHooks = collection.hooks || {}
+      const withHook = {
+        ...collection,
+        hooks: {
+          ...existingHooks,
+          beforeChange: [persistClientUploadContext, ...(existingHooks.beforeChange || [])],
+        },
+      }
+
+      // With `disablePayloadAccessControl: true`, cloud-storage only invokes the static handler when
+      // the request carries a `clientUploadContext`, so a plain admin GET of the file 404s with
+      // "missing on the disk". The plugin's static handler resolves the file by filename, so register
+      // it as the first handler for those collections. Other collections already get the static handler
+      // from cloud-storage unconditionally.
+      if (typeof collOptions !== 'object' || collOptions.disablePayloadAccessControl !== true) {
+        return withHook
+      }
+
+      const upload = typeof collection.upload === 'object' ? collection.upload : {}
+      const existingHandlers = Array.isArray(upload.handlers) ? upload.handlers : []
+
+      return {
+        ...withHook,
+        upload: { ...upload, handlers: [getStaticHandler(), ...existingHandlers] },
+      }
+    })
+
+    return result
   }
 
 function cloudinaryStorageAdapter(options: CloudinaryStorageOptions): Adapter {


### PR DESCRIPTION
## Problem

Two behavior changes in `@payloadcms/plugin-cloud-storage` (Payload 3.82+) broke client uploads:

1. **No usable URL persisted.** Cloud-storage's `afterChange` now skips `handleUpload` for files carrying a `clientUploadContext`. This plugin relied on `handleUpload` to persist `cloudinaryPublicId`/`url` from that context, so client-uploaded documents were saved without a usable URL.
2. **File serving 404s.** With `disablePayloadAccessControl: true`, cloud-storage only invokes the static handler when the request carries a `clientUploadContext`. A plain admin GET of `/api/{collection}/file/{filename}` therefore fell through and failed with "missing on the disk".

## Fix

After delegating to `cloudStoragePlugin`, post-process the managed collections — only when `clientUploads` is enabled, so it's a no-op for everyone else:

- Add a `beforeChange` hook that copies `publicId`/`secureUrl` from `req.file.clientUploadContext` into the doc before the DB write (restores persistence for all client-upload collections).
- Prepend the plugin's static handler (which resolves by filename via `payload.find`) for `disablePayloadAccessControl` collections only — other collections already get it from cloud-storage unconditionally.

Also removes the now-dead `clientUploadContext` branch in `handleUpload` (peer dep is `^3.84.1`, where `afterChange` always filters those files out), leaving the new hook as the single source of truth.

## Tests

`src/index.test.ts` covers both fixes: persistence from a client upload context, no-op without a context, no hook when client uploads are off, and the static handler serving a file resolved by filename. Verified manually in the dev app (`images` collection: `disablePayloadAccessControl` + `clientUploads`).