### PR TITLE
fix(cloudinary): declare @payloadcms/plugin-cloud-storage as a peer dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Run tests (astro-payload-richtext-lexical)
         run: cd astro-payload-richtext-lexical && pnpm test
 
+      - name: Run tests (cloudinary)
+        run: cd cloudinary && pnpm test
+
       - name: Run tests (content-translator)
         run: cd content-translator && pnpm test
 

--- a/cloudinary/CHANGELOG.md
+++ b/cloudinary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: declare `@payloadcms/plugin-cloud-storage` as a peer dependency instead of a direct dependency, so it resolves to the same version as the host project's Payload suite and no longer pulls in a second copy of `@payloadcms/ui` (which broke the Payload admin with React context errors). **Breaking:** consuming projects must now install `@payloadcms/plugin-cloud-storage` alongside `payload`.
 - fix: restore client uploads on Payload 3.82+. Client-uploaded documents now keep a usable `url`/`cloudinaryPublicId`, and files served from `disablePayloadAccessControl` collections no longer fail with "missing on the disk".
 - fix: harden the client-upload signature endpoint (`/cloudinary-generate-signature`). The endpoint now only signs the `timestamp`, `folder`, and `public_id` parameters, only issues signatures for collections the plugin manages, enforces the configured upload folder, and rejects stale timestamps. The default access control now requires `create` access to the target upload collection instead of merely being authenticated.
 

--- a/cloudinary/README.md
+++ b/cloudinary/README.md
@@ -2,6 +2,14 @@
 
 This package provides a Payload CMS Storage Adapter for [Cloudinary](https://cloudinary.com/) to seamlessly integrate Cloudinary with Payload CMS for media asset management.
 
+## Installation
+
+```sh
+pnpm add @jhb.software/payload-cloudinary-plugin @payloadcms/plugin-cloud-storage
+```
+
+`@payloadcms/plugin-cloud-storage` is a peer dependency and must be installed explicitly. Keep it on the same version as the rest of the Payload suite (`payload`, `@payloadcms/next`, …) so a single copy of `@payloadcms/ui` is resolved — a version mismatch installs a second copy and breaks the admin panel with React context errors.
+
 ## Usage
 
 - Configure the `collections` object to specify which collections should use the Cloudinary adapter. The slug _must_ match one of your existing collection slugs.

--- a/cloudinary/dev/package.json
+++ b/cloudinary/dev/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@jhb.software/payload-cloudinary-plugin": "workspace:*",
     "@payloadcms/db-mongodb": "^3.84.1",
+    "@payloadcms/plugin-cloud-storage": "^3.84.1",
     "@payloadcms/next": "^3.84.1",
     "next": "16.2.6",
     "payload": "^3.84.1",

--- a/cloudinary/package.json
+++ b/cloudinary/package.json
@@ -32,11 +32,11 @@
     "prepublishOnly": "pnpm clean && pnpm build"
   },
   "dependencies": {
-    "@payloadcms/plugin-cloud-storage": "^3.84.1",
     "cloudinary": "^2.10.0"
   },
   "devDependencies": {
     "@payloadcms/eslint-config": "^3.28.0",
+    "@payloadcms/plugin-cloud-storage": "^3.84.1",
     "@swc/cli": "^0.8.1",
     "@swc/core": "^1.15.33",
     "@types/react": "19.2.14",
@@ -49,6 +49,7 @@
     "vitest": "^4.1.6"
   },
   "peerDependencies": {
+    "@payloadcms/plugin-cloud-storage": "^3.84.1",
     "next": "^15.0.0 || ^16.0.0",
     "payload": "^3.84.1"
   },

--- a/cloudinary/pnpm-lock.yaml
+++ b/cloudinary/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
 
   .:
     dependencies:
-      '@payloadcms/plugin-cloud-storage':
-        specifier: ^3.84.1
-        version: 3.84.1(@types/react@19.2.14)(monaco-editor@0.55.1)(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       cloudinary:
         specifier: ^2.10.0
         version: 2.10.0
@@ -45,6 +42,9 @@ importers:
       '@payloadcms/eslint-config':
         specifier: ^3.28.0
         version: 3.28.0(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4)(typescript@6.0.3))(ts-api-utils@2.5.0(typescript@6.0.3))
+      '@payloadcms/plugin-cloud-storage':
+        specifier: ^3.84.1
+        version: 3.84.1(@types/react@19.2.14)(monaco-editor@0.55.1)(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@swc/cli':
         specifier: ^0.8.1
         version: 0.8.1(@swc/core@1.15.33)
@@ -87,6 +87,9 @@ importers:
       '@payloadcms/next':
         specifier: ^3.84.1
         version: 3.84.1(@types/react@19.2.14)(graphql@16.12.0)(monaco-editor@0.55.1)(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@payloadcms/plugin-cloud-storage':
+        specifier: ^3.84.1
+        version: 3.84.1(@types/react@19.2.14)(monaco-editor@0.55.1)(next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4))(payload@3.84.1(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       next:
         specifier: 16.2.6
         version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4)


### PR DESCRIPTION
## Problem

`@payloadcms/plugin-cloud-storage` was a direct `dependency` of the plugin. That package exact-pins its own `@payloadcms/ui` (`"@payloadcms/ui": "3.84.1"`), so whichever version of `plugin-cloud-storage` lands in the plugin's subtree drags in *that exact* `@payloadcms/ui`. When a host project's Payload suite is on a different version (e.g. 3.85.1), the result is two copies of `@payloadcms/ui` — provider in one copy, hooks read from the other — and the Payload admin breaks with React context errors. Consumers had to work around it with a manual `pnpm.overrides` entry.

## Fix

Move `@payloadcms/plugin-cloud-storage` from `dependencies` to `peerDependencies` (kept as a `devDependency` for the monorepo build/typecheck). It now resolves in the host project's tree alongside `payload`, so a single `@payloadcms/ui` is used and the override is no longer needed.

This matches the principle behind the official `@payloadcms/storage-*` adapters (the cloud-storage version must track the host's Payload version) while keeping an independent release cadence via a flexible range instead of exact lockstep.

**Breaking:** consuming projects must now install `@payloadcms/plugin-cloud-storage` alongside `payload`. Documented in the README; pnpm's default `auto-install-peers` makes this near-zero-friction for pnpm users.

## Changes

- `package.json`: `@payloadcms/plugin-cloud-storage` → `peerDependencies` + `devDependencies`
- `dev/package.json`: dev app now provides the peer like a real consumer
- `README.md`: new Installation section documenting the peer + version-alignment rationale
- `CHANGELOG.md`: Unreleased entry
- `ci.yml`: run the cloudinary test suite in CI

## Verification

- Lockfile resolves a single `@payloadcms/ui` and single `@payloadcms/plugin-cloud-storage`
- `pnpm typecheck` clean