### PR TITLE
fix(content-translator): support unnamed (presentational) groups

### DIFF
--- a/content-translator/CHANGELOG.md
+++ b/content-translator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: translate fields inside unnamed (presentational) groups instead of throwing an "Unnamed groups are currently not supported" error
 - fix: skip fields and tabs named `__proto__`, `constructor`, or `prototype` during traversal to avoid prototype-polluting writes when a user-supplied Payload config contains such a name
 
 ## 0.2.0

--- a/content-translator/dev/src/collections/pages.ts
+++ b/content-translator/dev/src/collections/pages.ts
@@ -39,6 +39,20 @@ export const pagesSchema: CollectionConfig = {
       ],
     },
     {
+      // Unnamed (presentational) group: its fields are stored on the document
+      // root, not under a key. Used here to demonstrate that the translator
+      // traverses into unnamed groups instead of throwing.
+      type: 'group',
+      label: 'Call to action',
+      fields: [
+        {
+          name: 'ctaLabel',
+          type: 'text',
+          localized: true,
+        },
+      ],
+    },
+    {
       type: 'tabs',
       tabs: [
         {

--- a/content-translator/src/translate/traverseFields.ts
+++ b/content-translator/src/translate/traverseFields.ts
@@ -186,8 +186,21 @@ export const traverseFields = ({
         break
       case 'group': {
         if (!('name' in field)) {
-          // TODO: handle unnamed groups
-          throw new Error('Unnamed groups are currently not supported by this plugin.')
+          // Unnamed (presentational) groups have no own data key — their fields
+          // are stored on the sibling data directly, so traverse them in place
+          // like row/collapsible, propagating the parent's localization context.
+          traverseFields({
+            dataFrom,
+            emptyOnly,
+            fields: field.fields,
+            localizedParent,
+            payloadConfig,
+            siblingDataFrom,
+            siblingDataTranslated,
+            translatedData,
+            valuesToTranslate,
+          })
+          break
         }
 
         const groupDataFrom = siblingDataFrom[field.name] as Record<string, unknown>

--- a/content-translator/test/traverseFields.test.ts
+++ b/content-translator/test/traverseFields.test.ts
@@ -224,6 +224,41 @@ describe('traverseFields - emptyOnly with missing target sub-objects (#137)', ()
   })
 })
 
+describe('traverseFields - unnamed (presentational) groups', () => {
+  test('translates a localized field inside an unnamed group stored in place', () => {
+    const fields: Field[] = [
+      {
+        type: 'group',
+        fields: [{ name: 'title', type: 'text', localized: true }],
+      } as Field,
+    ]
+
+    const translated = runTraverse(fields, { title: 'Hello' }, false)
+
+    assert.deepEqual(translated, { title: 'TRANSLATED:Hello' })
+  })
+
+  test('propagates localizedParent into an unnamed group nested in a localized named group', () => {
+    const fields: Field[] = [
+      {
+        name: 'meta',
+        type: 'group',
+        localized: true,
+        fields: [
+          {
+            type: 'group',
+            fields: [{ name: 'title', type: 'text' }],
+          } as Field,
+        ],
+      },
+    ]
+
+    const translated = runTraverse(fields, { meta: { title: 'Hello' } }, false)
+
+    assert.deepEqual(translated, { meta: { title: 'TRANSLATED:Hello' } })
+  })
+})
+
 describe('traverseFields - prototype pollution', () => {
   for (const unsafeName of ['__proto__', 'constructor', 'prototype']) {
     test(`ignores a field named "${unsafeName}" instead of writing to its key`, () => {

--- a/content-translator/test/traverseFields.test.ts
+++ b/content-translator/test/traverseFields.test.ts
@@ -230,7 +230,7 @@ describe('traverseFields - unnamed (presentational) groups', () => {
       {
         type: 'group',
         fields: [{ name: 'title', type: 'text', localized: true }],
-      } as Field,
+      },
     ]
 
     const translated = runTraverse(fields, { title: 'Hello' }, false)
@@ -238,17 +238,20 @@ describe('traverseFields - unnamed (presentational) groups', () => {
     assert.deepEqual(translated, { title: 'TRANSLATED:Hello' })
   })
 
-  test('propagates localizedParent into an unnamed group nested in a localized named group', () => {
+  test('propagates the localized context of a parent into a nested unnamed group', () => {
     const fields: Field[] = [
       {
+        // Localized named group acts as the parent that sets localizedParent.
         name: 'meta',
         type: 'group',
         localized: true,
         fields: [
           {
+            // Unnamed (presentational) group: its non-localized field must still
+            // be translated because the localized context is inherited.
             type: 'group',
             fields: [{ name: 'title', type: 'text' }],
-          } as Field,
+          },
         ],
       },
     ]


### PR DESCRIPTION
Traverse the fields of an unnamed group in place (like row/collapsible),
propagating the parent's localization context, instead of throwing
"Unnamed groups are currently not supported by this plugin."

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LpxmHWLTQPrF9hqCovruQt