### PR TITLE
feat(alt-text): gate health report via healthCheck access function

### DIFF
--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: enforce collection access control in the generate and bulk-generate endpoints by running the Local API reads and writes under the requesting user (`overrideAccess: false`)
 - fix: filter the alt text health report (endpoint and dashboard widget) to the collections the requesting user may read, so the aggregate no longer discloses counts and document IDs for collections their role cannot access
+- feat: `healthCheck` now accepts an access function that gates the health endpoint and hides the dashboard widget, letting the collection-wide report be restricted (e.g. to admins) separately from the generate endpoints
 
 ## 0.7.0
 

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -77,16 +77,16 @@ This is also the recommended escape hatch if you hit Payload's Postgres SQL-buil
 
 ### Plugin Options
 
-| Option                       | Type                                  | Required | Description                                                                                                      |
-| ---------------------------- | ------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `collections`                | `(CollectionSlug \| CollectionObj)[]` | Yes      | Collections to enable alt text generation for (see [Per-collection options](#per-collection-options))            |
-| `resolver`                   | `AltTextResolver`                     | Yes      | Alt text resolver to use (e.g., `openAIResolver`)                                                                |
-| `getImageThumbnail`          | `Function`                            | Yes      | Function to get the thumbnail URL from an image document                                                         |
-| `enabled`                    | `boolean`                             | No       | Whether to enable the plugin                                                                                     |
-| `locale`                     | `string`                              | No       | Locale for alt text generation (required when localization is disabled)                                          |
-| `maxBulkGenerateConcurrency` | `number`                              | No       | Maximum concurrent API requests for bulk operations (default: 16)                                                |
-| `fieldsOverride`             | `Function`                            | No       | Override the default fields inserted by the plugin                                                               |
-| `healthCheck`                | `boolean`                             | No       | Enable alt text health tracking: REST endpoint, cache revalidation hooks, and dashboard widget (default: `true`) |
+| Option                       | Type                                  | Required | Description                                                                                                                                                                                                                                                                                                               |
+| ---------------------------- | ------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `collections`                | `(CollectionSlug \| CollectionObj)[]` | Yes      | Collections to enable alt text generation for (see [Per-collection options](#per-collection-options))                                                                                                                                                                                                                     |
+| `resolver`                   | `AltTextResolver`                     | Yes      | Alt text resolver to use (e.g., `openAIResolver`)                                                                                                                                                                                                                                                                         |
+| `getImageThumbnail`          | `Function`                            | Yes      | Function to get the thumbnail URL from an image document                                                                                                                                                                                                                                                                  |
+| `enabled`                    | `boolean`                             | No       | Whether to enable the plugin                                                                                                                                                                                                                                                                                              |
+| `locale`                     | `string`                              | No       | Locale for alt text generation (required when localization is disabled)                                                                                                                                                                                                                                                   |
+| `maxBulkGenerateConcurrency` | `number`                              | No       | Maximum concurrent API requests for bulk operations (default: 16)                                                                                                                                                                                                                                                         |
+| `fieldsOverride`             | `Function`                            | No       | Override the default fields inserted by the plugin                                                                                                                                                                                                                                                                        |
+| `healthCheck`                | `boolean \| Function`                 | No       | Alt text health tracking (REST endpoint, cache revalidation hooks, dashboard widget). `false` disables it; `true` enables it gated by `access`; a `({ req }) => boolean` function enables it and gates both the endpoint and the widget — use it to restrict the collection-wide report, e.g. to admins (default: `true`) |
 
 ### Per-collection options
 
@@ -204,7 +204,7 @@ export const customResolver = (): AltTextResolver => ({
 
 ## REST API Endpoints
 
-The plugin registers the following REST API endpoints under `/api/alt-text-plugin/`. All endpoints require authentication by default (configurable via the `access` option).
+The plugin registers the following REST API endpoints under `/api/alt-text-plugin/`. All endpoints require authentication by default (configurable via the `access` option). Beyond that gate, the generate endpoints enforce each collection's own access control on the documents they read and write, and the health endpoint reports only the collections the requesting user can read (and can be gated separately via the `healthCheck` function).
 
 ### `POST /api/alt-text-plugin/generate`
 

--- a/alt-text/dev/src/payload.config.ts
+++ b/alt-text/dev/src/payload.config.ts
@@ -80,7 +80,10 @@ export default buildConfig({
         apiKey: process.env.OPENAI_API_KEY!,
         model: 'gpt-4.1-mini',
       }),
-      healthCheck: true,
+      // The function form gates the collection-wide health report (endpoint and
+      // widget) more strictly than the per-document generate endpoints, which
+      // allow any authenticated user: here only the designated admin sees it.
+      healthCheck: ({ req }) => req.user?.email === 'dev@payloadcms.com',
       getImageThumbnail: (doc: Record<string, unknown>) => {
         // in a real application, you would use a function to get a thumbnail URL (e.g. from the sizes)
         return doc.url as string

--- a/alt-text/package.json
+++ b/alt-text/package.json
@@ -27,7 +27,6 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "test": "vitest run",
-    "test:health": "vitest run test/altTextHealth.test.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm clean && pnpm build"
   },

--- a/alt-text/src/components/AltTextHealthWidget.tsx
+++ b/alt-text/src/components/AltTextHealthWidget.tsx
@@ -6,7 +6,7 @@ import { formatAdminURL } from 'payload/shared'
 
 import type { PluginAltTextTranslationKeys } from '../translations/index.js'
 
-import { getAltTextHealthWidgetData } from '../utilities/altTextHealth.js'
+import { canViewHealthReport, getAltTextHealthWidgetData } from '../utilities/altTextHealth.js'
 import { getAltTextHealthWidgetDisplayState } from '../utilities/altTextHealthWidgetDisplay.js'
 import { getCollectionLabel } from '../utilities/getCollectionLabel.js'
 import { ArrowRightIcon } from './icons/ArrowRightIcon.js'
@@ -14,6 +14,11 @@ import { CheckIcon } from './icons/CheckIcon.js'
 import { ImageIcon } from './icons/ImageIcon.js'
 
 export async function AltTextHealthWidget({ req }: WidgetServerProps) {
+  // Hide the widget from users the health gate denies, matching the endpoint.
+  if (!(await canViewHealthReport(req))) {
+    return null
+  }
+
   const t = req.t as TFunction<PluginAltTextTranslationKeys>
   const { collections, errors, isLocalized, localeCount, totalDocs } =
     await getAltTextHealthWidgetData(req)

--- a/alt-text/src/plugin.ts
+++ b/alt-text/src/plugin.ts
@@ -51,13 +51,23 @@ export const payloadAltTextPlugin =
 
     const normalizedCollections = normalizeCollectionsConfig(incomingPluginConfig.collections)
 
+    const access = incomingPluginConfig.access ?? (({ req }) => !!req.user)
+
+    // A function form of `healthCheck` doubles as the health report's access
+    // gate; otherwise it falls back to the shared `access`.
+    const healthCheckAccess =
+      typeof incomingPluginConfig.healthCheck === 'function'
+        ? incomingPluginConfig.healthCheck
+        : access
+
     const pluginConfig: AltTextPluginConfig = {
-      access: incomingPluginConfig.access ?? (({ req }) => !!req.user),
+      access,
       collections: normalizedCollections,
       enabled: incomingPluginConfig.enabled ?? true,
       fieldsOverride: incomingPluginConfig.fieldsOverride,
       getImageThumbnail: incomingPluginConfig.getImageThumbnail,
       healthCheck: enableHealthCheck,
+      healthCheckAccess,
       locale: incomingPluginConfig.locale,
       locales,
       maxBulkGenerateConcurrency: incomingPluginConfig.maxBulkGenerateConcurrency ?? 16,
@@ -188,7 +198,7 @@ export const payloadAltTextPlugin =
         ...(enableHealthCheck
           ? [
               {
-                handler: altTextHealthEndpoint(pluginConfig.access),
+                handler: altTextHealthEndpoint(pluginConfig.healthCheckAccess),
                 method: 'get' as const,
                 path: '/alt-text-plugin/health',
               },

--- a/alt-text/src/types/AltTextPluginConfig.ts
+++ b/alt-text/src/types/AltTextPluginConfig.ts
@@ -53,12 +53,20 @@ export type IncomingAltTextPluginConfig = {
   getImageThumbnail: (doc: Record<string, unknown>) => string
 
   /**
-   * Enable alt text health tracking (REST endpoint, cache revalidation hooks, and dashboard widget).
-   * Set to `false` to disable the entire feature.
+   * Controls the alt text health feature (REST endpoint, cache revalidation hooks, and dashboard widget).
+   *
+   * - `false` disables the entire feature.
+   * - `true` enables it, gated by `access`.
+   * - A function enables it and gates both the endpoint and the dashboard widget
+   *   with that access check — use this to restrict the collection-wide report
+   *   more strictly than the per-document generate endpoints (e.g. to admins).
+   *
+   * Regardless of the gate, the report is always filtered to the collections the
+   * requesting user can read.
    *
    * @default true
    */
-  healthCheck?: boolean
+  healthCheck?: ((args: { req: PayloadRequest }) => boolean | Promise<boolean>) | boolean
 
   /**
    * The locale to generate alt texts in when localization is disabled.
@@ -98,6 +106,9 @@ export type AltTextPluginConfig = {
 
   /** Whether alt text health tracking is enabled. */
   healthCheck: boolean
+
+  /** Access control for the health endpoint. Defaults to `access`. */
+  healthCheckAccess: (args: { req: PayloadRequest }) => boolean | Promise<boolean>
 
   /** The locale to generate alt texts in when localization is disabled. */
   locale?: string

--- a/alt-text/src/utilities/altTextHealth.ts
+++ b/alt-text/src/utilities/altTextHealth.ts
@@ -282,6 +282,23 @@ export async function filterScanByReadAccess(
   return { ...scan, collections, errors }
 }
 
+/**
+ * Whether the requesting user may view the health report at all, per the
+ * configured `healthCheck` access gate. The dashboard widget uses this to hide
+ * itself, mirroring the gate enforced on the health endpoint.
+ */
+export async function canViewHealthReport(req: PayloadRequest): Promise<boolean> {
+  const pluginConfig = req.payload.config.custom?.altTextPluginConfig as
+    | AltTextPluginConfig
+    | undefined
+
+  if (!pluginConfig) {
+    return false
+  }
+
+  return pluginConfig.healthCheckAccess({ req })
+}
+
 export function toWidgetData(scan: AltTextHealthScan): AltTextHealthWidgetData {
   return {
     collections: scan.collections,

--- a/alt-text/test/endpointAccessControl.test.ts
+++ b/alt-text/test/endpointAccessControl.test.ts
@@ -28,6 +28,7 @@ function buildPluginConfig(): AltTextPluginConfig {
     enabled: true,
     getImageThumbnail: () => 'https://example.com/thumb.png',
     healthCheck: true,
+    healthCheckAccess: ({ req }) => !!req.user,
     locale: 'en',
     locales: [],
     maxBulkGenerateConcurrency: 1,

--- a/alt-text/test/healthEndpointAccess.test.ts
+++ b/alt-text/test/healthEndpointAccess.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict'
+
+import type { Config, PayloadRequest } from 'payload'
+
+import { describe, test } from 'vitest'
+
+import type { IncomingAltTextPluginConfig } from '../src/types/AltTextPluginConfig.ts'
+
+import { payloadAltTextPlugin } from '../src/plugin.ts'
+import { canViewHealthReport } from '../src/utilities/altTextHealth.ts'
+
+/**
+ * The health report exposes a collection-wide overview, so operators must be
+ * able to gate it independently of the per-document generate access. The
+ * function form of `healthCheck` guards both the health endpoint and the
+ * dashboard widget; the boolean form falls back to the shared `access`.
+ */
+
+const baseConfig = {
+  collections: [{ slug: 'media', fields: [], upload: true }],
+} as unknown as Config
+
+function buildPluginConfig(
+  overrides: Partial<IncomingAltTextPluginConfig>,
+): IncomingAltTextPluginConfig {
+  return {
+    collections: ['media'],
+    getImageThumbnail: () => 'https://example.com/thumb.png',
+    locale: 'en',
+    resolver: {
+      key: 'mock',
+      resolve: async () => ({ success: true, result: { altText: 'a', keywords: [] } }),
+      resolveBulk: async () => ({ success: true, results: {} }),
+    },
+    ...overrides,
+  }
+}
+
+function healthHandler(incoming: IncomingAltTextPluginConfig) {
+  const config = payloadAltTextPlugin(incoming)(baseConfig)
+  const endpoint = config.endpoints?.find((e) => e.path === '/alt-text-plugin/health')
+  assert.ok(endpoint, 'health endpoint should be registered')
+  return endpoint.handler
+}
+
+const req = { user: { id: 'user-1' } } as unknown as PayloadRequest
+
+describe('health endpoint access gate', () => {
+  test('is guarded by the healthCheck function, not the generate access', async () => {
+    let generateAccessCalled = false
+    let healthAccessCalled = false
+
+    const handler = healthHandler(
+      buildPluginConfig({
+        access: () => {
+          generateAccessCalled = true
+          return true
+        },
+        healthCheck: () => {
+          healthAccessCalled = true
+          return false
+        },
+      }),
+    )
+
+    const response = await handler(req)
+
+    assert.equal(response.status, 401)
+    assert.equal(healthAccessCalled, true)
+    assert.equal(generateAccessCalled, false)
+  })
+
+  test('falls back to the generate access when healthCheck is true', async () => {
+    let accessCalled = false
+
+    const handler = healthHandler(
+      buildPluginConfig({
+        access: () => {
+          accessCalled = true
+          return false
+        },
+        healthCheck: true,
+      }),
+    )
+
+    const response = await handler(req)
+
+    assert.equal(response.status, 401)
+    assert.equal(accessCalled, true)
+  })
+})
+
+describe('health widget visibility', () => {
+  function reqWithResolvedConfig(incoming: IncomingAltTextPluginConfig): PayloadRequest {
+    const config = payloadAltTextPlugin(incoming)(baseConfig)
+    return {
+      payload: { config: { custom: config.custom } },
+      user: { id: 'user-1' },
+    } as unknown as PayloadRequest
+  }
+
+  test('is hidden when the healthCheck function denies the user', async () => {
+    const visible = await canViewHealthReport(
+      reqWithResolvedConfig(buildPluginConfig({ healthCheck: () => false })),
+    )
+
+    assert.equal(visible, false)
+  })
+
+  test('is shown when the healthCheck function allows the user', async () => {
+    const visible = await canViewHealthReport(
+      reqWithResolvedConfig(buildPluginConfig({ healthCheck: () => true })),
+    )
+
+    assert.equal(visible, true)
+  })
+
+  test('falls back to the generate access when healthCheck is the default', async () => {
+    const visible = await canViewHealthReport(
+      reqWithResolvedConfig(buildPluginConfig({ access: () => false })),
+    )
+
+    assert.equal(visible, false)
+  })
+})


### PR DESCRIPTION
## Summary

Builds on #159. The health report exposes a collection-wide overview, so operators need to restrict it independently of the per-document generate access.

- `healthCheck` now accepts an access function in addition to a boolean: `false` disables the feature, `true` enables it gated by `access`, and a `({ req }) => boolean` function enables it and gates the report.
- The gate applies to **both** the health REST endpoint and the dashboard widget — a denied user gets `401` from the endpoint and the widget renders nothing, instead of the widget showing for anyone who can see the dashboard.
- The per-collection read filtering from #159 still applies on top, so even an allowed user only ever sees the collections they can read.

## Tests

- `healthEndpointAccess.test.ts` — the health endpoint is gated by the `healthCheck` function (not the generate `access`), falls back to `access` when `healthCheck` is `true`, and the widget visibility helper hides/shows the widget per the same gate.

`pnpm test` → 54/54 · `typecheck` clean.

## Dev app

`dev/src/payload.config.ts` uses the function form to restrict the report to a single admin email, demonstrating the gate end-to-end.