### PR TITLE
fix(alt-text): respect update access in the admin UI

### DIFF
--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fix: enforce collection access control in the generate and bulk-generate endpoints by running the Local API reads and writes under the requesting user (`overrideAccess: false`)
 - fix: filter the alt text health report (endpoint and dashboard widget) to the collections the requesting user may read, so the aggregate no longer discloses counts and document IDs for collections their role cannot access
 - feat: `healthCheck` now accepts an access function that gates the health endpoint and hides the dashboard widget, letting the collection-wide report be restricted (e.g. to admins) separately from the generate endpoints
+- fix: hide the single-document and bulk generate-alt-text buttons from users without update access to the document/collection
 
 ## 0.7.0
 

--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -5,7 +5,7 @@
 - fix: enforce collection access control in the generate and bulk-generate endpoints by running the Local API reads and writes under the requesting user (`overrideAccess: false`)
 - fix: filter the alt text health report (endpoint and dashboard widget) to the collections the requesting user may read, so the aggregate no longer discloses counts and document IDs for collections their role cannot access
 - feat: `healthCheck` now accepts an access function that gates the health endpoint and hides the dashboard widget, letting the collection-wide report be restricted (e.g. to admins) separately from the generate endpoints
-- fix: hide the single-document and bulk generate-alt-text buttons from users without update access to the document/collection
+- fix: respect update access in the admin UI — render the alt text field read-only and hide the single-document and bulk generate buttons for users without update access
 
 ## 0.7.0
 

--- a/alt-text/dev/src/collections/Media.ts
+++ b/alt-text/dev/src/collections/Media.ts
@@ -9,6 +9,11 @@ export const Media: CollectionConfig = {
   upload: {
     mimeTypes: ['image/*', 'video/*'],
   },
+  access: {
+    // change the email in the next line to test if the 'generate alt text' buttons are correctly hidden
+    // and the alt text field is readonly
+    update: ({ req }) => req.user?.email === 'dev@payloadcms.com',
+  },
   fields: [
     // The plugin will automatically inject context, alt, and keywords fields
 

--- a/alt-text/src/components/AltTextField.tsx
+++ b/alt-text/src/components/AltTextField.tsx
@@ -8,7 +8,7 @@ import { matchesMimeType } from '../utilities/mimeTypes.js'
 import { GenerateAltTextButton } from './GenerateAltTextButton.js'
 
 export const AltTextField = (clientProps: TextareaFieldClientProps) => {
-  const { field, path } = clientProps
+  const { field, path, readOnly } = clientProps
 
   const supportedMimeTypes = field.admin?.custom?.supportedMimeTypes as string[] | undefined
   const trackedMimeTypes = field.admin?.custom?.trackedMimeTypes as string[] | undefined
@@ -41,9 +41,12 @@ export const AltTextField = (clientProps: TextareaFieldClientProps) => {
 
       <div className="field-type__wrap">
         <TextareaInput
-          AfterInput={<GenerateAltTextButton supportedMimeTypes={supportedMimeTypes} />}
+          AfterInput={
+            readOnly ? undefined : <GenerateAltTextButton supportedMimeTypes={supportedMimeTypes} />
+          }
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setValue(e.target.value)}
           path={path}
+          readOnly={readOnly}
           required={required}
           value={value}
         />

--- a/alt-text/src/components/BulkGenerateAltTextsButton.tsx
+++ b/alt-text/src/components/BulkGenerateAltTextsButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button, toast, useConfig, useSelection, useTranslation } from '@payloadcms/ui'
+import { Button, toast, useAuth, useConfig, useSelection, useTranslation } from '@payloadcms/ui'
 import { useRouter } from 'next/navigation.js'
 import { useTransition } from 'react'
 
@@ -15,7 +15,10 @@ import { Spinner } from './icons/Spinner.js'
 export function BulkGenerateAltTextsButton({ collectionSlug }: { collectionSlug: string }) {
   const { t } = useTranslation<PluginAltTextTranslations, PluginAltTextTranslationKeys>()
   const [isPending, startTransition] = useTransition()
+  const { permissions } = useAuth()
   const { selected, setSelection } = useSelection()
+
+  const canUpdateCollection = Boolean(permissions?.collections?.[collectionSlug]?.update)
   const {
     config: {
       routes: { api: apiRoute },
@@ -97,6 +100,7 @@ export function BulkGenerateAltTextsButton({ collectionSlug }: { collectionSlug:
   }
 
   return (
+    canUpdateCollection &&
     selectedIds.length > 0 && (
       <div className="m-0" style={{ display: 'flex', justifyContent: 'right' }}>
         <Button

--- a/alt-text/src/components/GenerateAltTextButton.tsx
+++ b/alt-text/src/components/GenerateAltTextButton.tsx
@@ -21,7 +21,7 @@ import { Spinner } from './icons/Spinner.js'
 
 export function GenerateAltTextButton({ supportedMimeTypes }: { supportedMimeTypes?: string[] }) {
   const { t } = useTranslation<PluginAltTextTranslations, PluginAltTextTranslationKeys>()
-  const { id, collectionSlug } = useDocumentInfo()
+  const { id, collectionSlug, docPermissions } = useDocumentInfo()
   const locale = useLocale()
   const [isPending, startTransition] = useTransition()
   const {
@@ -37,6 +37,12 @@ export function GenerateAltTextButton({ supportedMimeTypes }: { supportedMimeTyp
 
   const isUnsupportedMimeType =
     !!mimeType && !!supportedMimeTypes && !supportedMimeTypes.includes(mimeType)
+
+  // Hide the generate button from users who cannot update the document — the
+  // generated alt text would not be persistable by them anyway.
+  if (!docPermissions?.update) {
+    return null
+  }
 
   const handleGenerateAltText = () => {
     if (!collectionSlug || !id) {


### PR DESCRIPTION
## Summary

Aligns the alt-text admin UI with the user's update access, so users who cannot update a document are not offered actions or inputs they cannot use.

- **Alt text field** (`AltTextField`): now forwards Payload's computed `readOnly` to `TextareaInput`, so the field renders read-only when the user lacks update access. Previously the custom component ignored `readOnly` and always rendered an editable textarea.
- **Single-document button** (`GenerateAltTextButton`): hidden when `useDocumentInfo().docPermissions?.update` is not granted (and not rendered as the field's `AfterInput` when the field is read-only).
- **Bulk button** (`BulkGenerateAltTextsButton`): hidden when the user lacks `update` on the collection (`useAuth().permissions?.collections[slug]?.update`).

The endpoints already enforce per-document access (#159), so this is the UI layer catching up — removing misleading affordances rather than being the security boundary.

## Notes

No test added: these are boolean permission checks whose inversion a unit test would only restate; the suite has no React-rendering harness. Verifiable in the admin UI by restricting a collection's `update` access for a role.

`pnpm test` → 54/54 · `typecheck` + `lint` clean.