### PR TITLE
fix(alt-text): return real status for access-denied endpoint requests

### DIFF
--- a/alt-text/src/endpoints/bulkGenerateAltTexts.ts
+++ b/alt-text/src/endpoints/bulkGenerateAltTexts.ts
@@ -1,6 +1,7 @@
 import type { BasePayload, CollectionSlug, PayloadHandler, PayloadRequest } from 'payload'
 
 import pMap from 'p-map'
+import { APIError, Forbidden } from 'payload'
 import { ZodError } from 'zod'
 
 import type { AltTextPluginConfig } from '../types/AltTextPluginConfig.js'
@@ -98,6 +99,13 @@ export const bulkGenerateAltTextsEndpoint =
               `${updatedDocs}/${uniqueIds.length} updated (${Math.round((updatedDocs / uniqueIds.length) * 100)}%)`,
             )
           } catch (error) {
+            // A Forbidden means the user has no read/update access to the
+            // collection at all — it applies to every id, so fail the whole
+            // request with a real 403 instead of silently listing all ids as
+            // errored. Row-level NotFound stays a per-doc error (partial success).
+            if (error instanceof Forbidden) {
+              throw error
+            }
             console.error(`Error generating alt text for ${id}:`, error)
             erroredDocs.push(id)
           }
@@ -117,6 +125,11 @@ export const bulkGenerateAltTextsEndpoint =
     } catch (error) {
       if (error instanceof ZodError) {
         return Response.json(formatZodError(error), { status: 400 })
+      }
+      // Surface Payload access errors (Forbidden 403) with their real status so
+      // an agent gets an accurate, non-retryable signal instead of a 500.
+      if (error instanceof APIError) {
+        return Response.json({ error: error.message }, { status: error.status })
       }
       console.error('Error in bulk generation:', error)
       return Response.json(

--- a/alt-text/src/endpoints/generateAltText.ts
+++ b/alt-text/src/endpoints/generateAltText.ts
@@ -1,5 +1,6 @@
 import type { PayloadHandler, PayloadRequest } from 'payload'
 
+import { APIError } from 'payload'
 import { ZodError } from 'zod'
 
 import type { AltTextPluginConfig } from '../types/AltTextPluginConfig.js'
@@ -151,6 +152,12 @@ export const generateAltTextEndpoint =
     } catch (error) {
       if (error instanceof ZodError) {
         return Response.json(formatZodError(error), { status: 400 })
+      }
+      // Surface Payload access errors (Forbidden 403 / NotFound 404) with their
+      // real status so an agent gets an accurate, non-retryable signal instead
+      // of a misleading 500.
+      if (error instanceof APIError) {
+        return Response.json({ error: error.message }, { status: error.status })
       }
       console.error('Error generating alt text:', error)
       return Response.json(

--- a/alt-text/test/endpointAccessControl.test.ts
+++ b/alt-text/test/endpointAccessControl.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 
+import { Forbidden } from 'payload'
 import { describe, test } from 'vitest'
 
 import type { PayloadRequest } from 'payload'
@@ -105,6 +106,30 @@ describe('generate endpoint access control', () => {
   })
 })
 
+describe('generate endpoint denial responses', () => {
+  test('returns 403 (not 500) when the user lacks read access to the document', async () => {
+    const { req } = buildRequest({ id: 'doc-1', collection: 'media', locale: null, update: false })
+    req.payload.findByID = async () => {
+      throw new Forbidden(req.t)
+    }
+
+    const response = await generateAltTextEndpoint(buildPluginConfig().access)(req)
+
+    assert.equal(response.status, 403)
+  })
+
+  test('returns 403 (not 500) when the user lacks update access to the document', async () => {
+    const { req } = buildRequest({ id: 'doc-1', collection: 'media', locale: null, update: true })
+    req.payload.update = async () => {
+      throw new Forbidden(req.t)
+    }
+
+    const response = await generateAltTextEndpoint(buildPluginConfig().access)(req)
+
+    assert.equal(response.status, 403)
+  })
+})
+
 describe('bulk generate endpoint access control', () => {
   test('reads each document under the requesting user, not with overridden access', async () => {
     const { findByIDCalls, req } = buildRequest({ collection: 'media', ids: ['doc-1'] })
@@ -124,5 +149,16 @@ describe('bulk generate endpoint access control', () => {
     assert.equal(updateCalls.length, 1)
     assert.equal(updateCalls[0].overrideAccess, false)
     assert.equal(updateCalls[0].user, user)
+  })
+
+  test('returns 403 (not 200 with errored ids) when the user lacks access to the collection', async () => {
+    const { req } = buildRequest({ collection: 'media', ids: ['doc-1', 'doc-2'] })
+    req.payload.findByID = async () => {
+      throw new Forbidden(req.t)
+    }
+
+    const response = await bulkGenerateAltTextsEndpoint(buildPluginConfig().access)(req)
+
+    assert.equal(response.status, 403)
   })
 })


### PR DESCRIPTION
## Problem

Since #159 the generate endpoints run their Local API reads/writes under the requesting user (`overrideAccess: false`). When a user lacks read or update access, Payload throws `Forbidden` (403) / `NotFound` (404) — but the endpoint catch blocks only special-cased `ZodError`, so these fell through to a hardcoded **500**.

An AI agent calling these endpoints without access therefore received a misleading `500` (a transient server fault it would retry) instead of a clear, non-retryable permissions error.

## Fix

- **`generateAltText`**: map any Payload `APIError` to its real status (`403`/`404`) before the generic `500`.
- **`bulkGenerateAltTexts`**: a `Forbidden` thrown per-document (a collection-wide denial applies to every id) now fails the whole request with `403` instead of silently dumping every id into `erroredDocs` and returning `200`. A per-row `NotFound` still stays a partial-success `200`. The outer catch gained the same `APIError → status` mapping.

The coarse plugin-level `access` gate still returns its `401` as before.

### Resulting behavior for a caller

| Scenario | Before | After |
|---|---|---|
| Fails plugin `access` gate | 401 | 401 |
| No read access to collection | 500 | **403** |
| No update access (`update:true` / bulk) | 500 / 200+errored | **403** |
| Row-level filtered / missing doc (single) | 500 | **404** |

## Tests

Added three tests to `endpointAccessControl.test.ts` (single read denial, single update denial, bulk denial) that throw `Forbidden` from the mocked Local API and assert a `403`. Full alt-text suite passes (64 tests).