### PR TITLE
fix(content-translator): translate hasMany text fields per entry

### DIFF
--- a/content-translator/CHANGELOG.md
+++ b/content-translator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: translate each entry of `hasMany` text fields individually so keyword/tag lists are translated instead of crashing
 - fix: translate fields inside unnamed (presentational) groups instead of throwing an "Unnamed groups are currently not supported" error
 - fix: skip fields and tabs named `__proto__`, `constructor`, or `prototype` during traversal to avoid prototype-polluting writes when a user-supplied Payload config contains such a name
 

--- a/content-translator/dev/payload-types.ts
+++ b/content-translator/dev/payload-types.ts
@@ -146,6 +146,7 @@ export interface Page {
     };
     [k: string]: unknown;
   } | null;
+  keywords?: string[] | null;
   meta?: {
     title?: string | null;
     description?: string | null;
@@ -332,6 +333,7 @@ export interface PagesSelect<T extends boolean = true> {
   title?: T;
   slug?: T;
   content?: T;
+  keywords?: T;
   meta?:
     | T
     | {

--- a/content-translator/dev/src/collections/pages.ts
+++ b/content-translator/dev/src/collections/pages.ts
@@ -23,6 +23,13 @@ export const pagesSchema: CollectionConfig = {
       localized: true,
     },
     {
+      // hasMany text field: each keyword is translated individually
+      name: 'keywords',
+      type: 'text',
+      hasMany: true,
+      localized: true,
+    },
+    {
       name: 'meta',
       type: 'group',
       fields: [

--- a/content-translator/dev/src/seed.ts
+++ b/content-translator/dev/src/seed.ts
@@ -8,6 +8,7 @@ interface AuthorSeedData {
 }
 
 interface PageSeedData {
+  keywords: string[]
   slug: string
   title: string
 }
@@ -73,18 +74,22 @@ export const seed = async (payload: Payload) => {
   const pages: PageSeedData[] = [
     {
       slug: 'home',
+      keywords: ['welcome', 'home page', 'getting started'],
       title: 'Welcome to Our Website',
     },
     {
       slug: 'about',
+      keywords: ['company', 'team', 'our story'],
       title: 'About Our Company',
     },
     {
       slug: 'services',
+      keywords: ['services', 'solutions', 'consulting'],
       title: 'Our Services and Solutions',
     },
     {
       slug: 'contact',
+      keywords: ['contact', 'support', 'get in touch'],
       title: 'Get in Touch With Us',
     },
   ]

--- a/content-translator/src/translate/traverseFields.ts
+++ b/content-translator/src/translate/traverseFields.ts
@@ -320,7 +320,7 @@ export const traverseFields = ({
 
         break
       case 'text':
-      case 'textarea':
+      case 'textarea': {
         if (field.custom && typeof field.custom === 'object' && field.custom.translatorSkip) {
           break
         }
@@ -337,13 +337,43 @@ export const traverseFields = ({
           break
         }
 
+        const fieldValue = siblingDataFrom[field.name]
+
+        // `hasMany` text fields store an array of strings (e.g. keywords /
+        // tags). Translate each element individually - sending the whole
+        // array as a single value makes the resolver return a non-string,
+        // which then crashes in he.decode(...) ("e.replace is not a
+        // function"). Pre-seed the target with the originals and replace
+        // each entry in place as its translation resolves, so a skipped or
+        // failed element keeps its original text.
+        if (Array.isArray(fieldValue)) {
+          const translatedArray = [...fieldValue]
+          siblingDataTranslated[field.name] = translatedArray
+
+          fieldValue.forEach((item, itemIndex) => {
+            if (typeof item !== 'string' || isEmpty(item)) {
+              return
+            }
+
+            valuesToTranslate.push({
+              onTranslate: (translated) => {
+                translatedArray[itemIndex] = translated
+              },
+              value: item,
+            })
+          })
+
+          break
+        }
+
         valuesToTranslate.push({
-          onTranslate: (translated: string) => {
+          onTranslate: (translated) => {
             siblingDataTranslated[field.name] = translated
           },
-          value: siblingDataFrom[field.name],
+          value: fieldValue,
         })
         break
+      }
 
       default:
         break

--- a/content-translator/test/traverseFields.test.ts
+++ b/content-translator/test/traverseFields.test.ts
@@ -224,6 +224,66 @@ describe('traverseFields - emptyOnly with missing target sub-objects (#137)', ()
   })
 })
 
+describe('traverseFields - hasMany text fields', () => {
+  test('translates each element of a hasMany text field individually', () => {
+    const fields: Field[] = [{ name: 'keywords', type: 'text', hasMany: true, localized: true }]
+
+    const translated = runTraverse(fields, { keywords: ['alpha', 'beta', 'gamma'] }, false)
+
+    assert.deepEqual(translated.keywords, [
+      'TRANSLATED:alpha',
+      'TRANSLATED:beta',
+      'TRANSLATED:gamma',
+    ])
+  })
+
+  test('keeps non-string entries in place while translating the rest', () => {
+    const fields: Field[] = [{ name: 'keywords', type: 'text', hasMany: true, localized: true }]
+
+    const translatedData: Record<string, unknown> = {}
+    const valuesToTranslate: ValueToTranslate[] = []
+
+    traverseFields({
+      dataFrom: { keywords: ['alpha', 42, 'gamma'] },
+      emptyOnly: false,
+      fields,
+      payloadConfig,
+      translatedData,
+      valuesToTranslate,
+    })
+
+    // Only the two strings are sent to the resolver; the non-string is left alone.
+    assert.equal(valuesToTranslate.length, 2)
+
+    for (const v of valuesToTranslate) {
+      v.onTranslate(`TRANSLATED:${v.value}`)
+    }
+
+    assert.deepEqual(translatedData.keywords, ['TRANSLATED:alpha', 42, 'TRANSLATED:gamma'])
+  })
+
+  test('does not send the whole array as a single value', () => {
+    const fields: Field[] = [{ name: 'keywords', type: 'text', hasMany: true, localized: true }]
+
+    const valuesToTranslate: ValueToTranslate[] = []
+
+    traverseFields({
+      dataFrom: { keywords: ['alpha', 'beta'] },
+      emptyOnly: false,
+      fields,
+      payloadConfig,
+      translatedData: {},
+      valuesToTranslate,
+    })
+
+    assert.equal(valuesToTranslate.length, 2)
+    assert.deepEqual(
+      valuesToTranslate.map((v) => v.value),
+      ['alpha', 'beta'],
+    )
+  })
+})
+
 describe('traverseFields - unnamed (presentational) groups', () => {
   test('translates a localized field inside an unnamed group stored in place', () => {
     const fields: Field[] = [


### PR DESCRIPTION
## What

`hasMany` text fields (e.g. keyword/tag lists) store an array of strings. The traversal previously pushed the **whole array** as a single value to translate, so the resolver received a non-string entry — at best the array got clobbered into one string, at worst it crashed in `he.decode(...)` with `"e.replace is not a function"`.

Now each element is translated **individually**. The target is pre-seeded with the originals and each entry is replaced in place as its translation resolves, so a skipped or non-string element keeps its original text.

## Tests
`test/traverseFields.test.ts`:
- translates each element of a hasMany text field individually;
- keeps non-string entries in place while translating the rest;
- does not send the whole array as a single value.

## Dev app
Added a localized `hasMany` `keywords` field to the dev `pages` collection (seeded with sample values) so the behavior is clickable in the admin panel.

## Notes
Split out from a combined branch; the rich-text marker / index-reconstruction fixes ship separately in #166. Builds on the unnamed-group fix already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4xMrsaXkGmviWmb8MK1hb

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4xMrsaXkGmviWmb8MK1hb)_