### PR TITLE
docs(content-translator): document translate endpoint and auth

### DIFF
--- a/content-translator/README.md
+++ b/content-translator/README.md
@@ -46,12 +46,13 @@ export default buildConfig({
 
 ### Plugin Options
 
-| Option        | Type                | Required | Description                           |
-| ------------- | ------------------- | -------- | ------------------------------------- |
-| `collections` | `CollectionSlug[]`  | Yes      | Collections to enable translation for |
-| `globals`     | `GlobalSlug[]`      | Yes      | Globals to enable translation for     |
-| `resolver`    | `TranslateResolver` | Yes      | Translation resolver to use           |
-| `enabled`     | `boolean`           | No       | Whether to enable the plugin.         |
+| Option        | Type                                             | Required | Description                                                                                                |
+| ------------- | ------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `collections` | `CollectionSlug[]`                               | Yes      | Collections to enable translation for                                                                      |
+| `globals`     | `GlobalSlug[]`                                   | Yes      | Globals to enable translation for                                                                          |
+| `resolver`    | `TranslateResolver`                              | Yes      | Translation resolver to use                                                                                |
+| `enabled`     | `boolean`                                        | No       | Whether to enable the plugin.                                                                              |
+| `access`      | `(args: { req }) => boolean \| Promise<boolean>` | No       | Access control for the translate endpoint. Defaults to `({ req }) => !!req.user` (any authenticated user). |
 
 ### Resolvers
 
@@ -69,6 +70,36 @@ openAIResolver({
   model: 'gpt-4o-mini', // or 'gpt-4', 'gpt-3.5-turbo', etc.
 })
 ```
+
+## API Endpoint
+
+The plugin registers a single REST endpoint that the admin UI calls to translate a document or global. It computes the translated values and returns them in the response — it never writes to the database, so changes still go through Payload's normal save/publish flow.
+
+| Method | Path                        | Description                                                          |
+| ------ | --------------------------- | -------------------------------------------------------------------- |
+| `POST` | `/api/translator/translate` | Translates the given entity's fields and returns the translated data |
+
+### Authentication
+
+The endpoint requires an authenticated request and responds with `401` otherwise. By default any authenticated Payload user (admin session or API key) is allowed:
+
+```ts
+;({ req }) => !!req.user
+```
+
+Override this with the `access` option to restrict who may translate content:
+
+```ts
+payloadContentTranslatorPlugin({
+  collections: ['pages', 'posts'],
+  globals: ['settings'],
+  resolver: openAIResolver({ apiKey: process.env.OPENAI_API_KEY }),
+  // Only allow admins to use the translate endpoint
+  access: ({ req }) => req.user?.role === 'admin',
+})
+```
+
+Beyond this gate, the endpoint reads the source and target documents with `overrideAccess: false`, so each collection's and global's own access control still applies — a user can only translate entities they are allowed to read.
 
 ## Custom Resolver
 

--- a/content-translator/README.md
+++ b/content-translator/README.md
@@ -90,13 +90,8 @@ The endpoint requires an authenticated request and responds with `401` otherwise
 Override this with the `access` option to restrict who may translate content:
 
 ```ts
-payloadContentTranslatorPlugin({
-  collections: ['pages', 'posts'],
-  globals: ['settings'],
-  resolver: openAIResolver({ apiKey: process.env.OPENAI_API_KEY }),
-  // Only allow admins to use the translate endpoint
-  access: ({ req }) => req.user?.role === 'admin',
-})
+// Only allow admins to use the translate endpoint
+access: ({ req }) => req.user?.role === 'admin'
 ```
 
 Beyond this gate, the endpoint reads the source and target documents with `overrideAccess: false`, so each collection's and global's own access control still applies — a user can only translate entities they are allowed to read.


### PR DESCRIPTION
## Summary

The content-translator plugin exposes a REST endpoint (`POST /api/translator/translate`) and a configurable `access` option, but neither was documented in the plugin's README. This PR adds that documentation.

## Changes

- Add the `access` option to the **Plugin Options** table (type, optional, and the `({ req }) => !!req.user` default).
- Add a new **API Endpoint** section documenting:
  - The route `POST /api/translator/translate` and that it only computes and returns translated data — it never writes to the database (changes still go through Payload's normal save/publish flow).
  - An **Authentication** subsection: the `401` behavior, the default "any authenticated user (session or API key)" gate, an `access` override example, and the second layer where reads use `overrideAccess: false` so each collection's/global's own access control still applies.

## Notes

- Docs-only change — no behavior change. Per the repo's changelog convention, docs that don't change behavior don't earn a CHANGELOG entry (the `access` feature itself was already logged under 0.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V36RptM624BKTJ9xMDYFLv)_