### PR TITLE
fix(alt-text): construct OpenAI client lazily in openAIResolver

### DIFF
--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: construct the OpenAI client lazily on first use in `openAIResolver` so building the resolver without an API key no longer throws — a plugin disabled via `enabled: !!process.env.OPENAI_API_KEY` now loads the Payload config even though its `resolver` argument is still evaluated
+
 ## 0.8.0
 
 - feat: bound and de-duplicate the bulk-generate `ids` array — duplicate IDs are collapsed and requests above the new `maxBulkGenerateIds` option (default 100) are rejected with `400`, so a single request can no longer fan out into an unbounded number of paid resolver calls

--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: construct the OpenAI client lazily on first use in `openAIResolver` so building the resolver without an API key no longer throws — a plugin disabled via `enabled: !!process.env.OPENAI_API_KEY` now loads the Payload config even though its `resolver` argument is still evaluated
+- fix: `openAIResolver` now builds its OpenAI client lazily, so a plugin disabled via `enabled: !!process.env.OPENAI_API_KEY` no longer throws at config load when the key is absent
 
 ## 0.8.0
 

--- a/alt-text/src/resolvers/openAI.ts
+++ b/alt-text/src/resolvers/openAI.ts
@@ -79,7 +79,15 @@ function zodResponseFormat<ZodInput extends z.ZodType>(
  */
 export const openAIResolver = (config: OpenAIResolverConfig): AltTextResolver => {
   const { apiKey, baseUrl, model = 'gpt-4.1-nano' } = config
-  const openai = new OpenAI({ apiKey, baseURL: baseUrl })
+
+  // Construct the OpenAI client lazily on first use rather than eagerly here.
+  // The `resolver` argument is evaluated even when the plugin is passed
+  // `enabled: false`, so building the client up front would throw "Missing
+  // credentials" and break the whole Payload config on machines without a key
+  // (e.g. `enabled: !!process.env.OPENAI_API_KEY`). Deferring construction lets
+  // a disabled plugin discard the resolver without ever touching the SDK.
+  let openai: OpenAI | undefined
+  const getClient = (): OpenAI => (openai ??= new OpenAI({ apiKey, baseURL: baseUrl }))
 
   return {
     key: 'openai',
@@ -94,7 +102,7 @@ export const openAIResolver = (config: OpenAIResolverConfig): AltTextResolver =>
           keywords: z.array(z.string()).describe('Keywords that describe the content of the image'),
         })
 
-        const response = await openai.chat.completions.parse({
+        const response = await getClient().chat.completions.parse({
           max_completion_tokens: 150,
           messages: [
             {
@@ -171,7 +179,7 @@ export const openAIResolver = (config: OpenAIResolverConfig): AltTextResolver =>
           ),
         )
 
-        const response = await openai.chat.completions.parse({
+        const response = await getClient().chat.completions.parse({
           max_completion_tokens: 300,
           messages: [
             {

--- a/alt-text/src/resolvers/openAI.ts
+++ b/alt-text/src/resolvers/openAI.ts
@@ -80,12 +80,9 @@ function zodResponseFormat<ZodInput extends z.ZodType>(
 export const openAIResolver = (config: OpenAIResolverConfig): AltTextResolver => {
   const { apiKey, baseUrl, model = 'gpt-4.1-nano' } = config
 
-  // Construct the OpenAI client lazily on first use rather than eagerly here.
-  // The `resolver` argument is evaluated even when the plugin is passed
-  // `enabled: false`, so building the client up front would throw "Missing
-  // credentials" and break the whole Payload config on machines without a key
-  // (e.g. `enabled: !!process.env.OPENAI_API_KEY`). Deferring construction lets
-  // a disabled plugin discard the resolver without ever touching the SDK.
+  // Build the client lazily (once, on first use): the `resolver` argument is
+  // evaluated even when the plugin is disabled, so eager construction would
+  // throw on a keyless `enabled: !!process.env.OPENAI_API_KEY` setup.
   let openai: OpenAI | undefined
   const getClient = (): OpenAI => (openai ??= new OpenAI({ apiKey, baseURL: baseUrl }))
 

--- a/alt-text/test/openAIResolverLazyInit.test.ts
+++ b/alt-text/test/openAIResolverLazyInit.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+
+import { afterEach, beforeEach, describe, test } from 'vitest'
+
+import { openAIResolver } from '../src/resolvers/openAI.ts'
+
+/**
+ * A common setup wires the plugin as
+ *
+ *   payloadAltTextPlugin({
+ *     enabled: !!process.env.OPENAI_API_KEY,
+ *     resolver: openAIResolver({ apiKey: process.env.OPENAI_API_KEY! }),
+ *   })
+ *
+ * The `resolver` argument is evaluated eagerly regardless of `enabled`, so on a
+ * machine without the key (`enabled: false`) `openAIResolver(...)` still runs.
+ * It must not construct the OpenAI client at that point — otherwise the SDK
+ * throws "Missing credentials" and the whole Payload config fails to load even
+ * though the plugin was deliberately turned off.
+ */
+describe('openAIResolver lazy client construction', () => {
+  let savedKey: string | undefined
+
+  beforeEach(() => {
+    savedKey = process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_API_KEY
+  })
+
+  afterEach(() => {
+    if (savedKey === undefined) {
+      delete process.env.OPENAI_API_KEY
+    } else {
+      process.env.OPENAI_API_KEY = savedKey
+    }
+  })
+
+  test('building the resolver without an API key does not throw', () => {
+    assert.doesNotThrow(() => {
+      openAIResolver({ apiKey: process.env.OPENAI_API_KEY as string })
+    })
+  })
+
+  test('the resolver built without a key is still a usable resolver object', () => {
+    const resolver = openAIResolver({ apiKey: process.env.OPENAI_API_KEY as string })
+
+    assert.equal(resolver.key, 'openai')
+    assert.equal(typeof resolver.resolve, 'function')
+    assert.equal(typeof resolver.resolveBulk, 'function')
+  })
+
+  test('the missing-key error surfaces when resolve() is called, not at build time', async () => {
+    const resolver = openAIResolver({ apiKey: process.env.OPENAI_API_KEY as string })
+
+    const response = await resolver.resolve({
+      filename: 'photo.jpg',
+      imageThumbnailUrl: 'https://example.com/thumb.jpg',
+      locale: 'en',
+      req: {} as never,
+    })
+
+    assert.equal(response.success, false)
+  })
+})

--- a/alt-text/test/openAIResolverLazyInit.test.ts
+++ b/alt-text/test/openAIResolverLazyInit.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 
-import { afterEach, beforeEach, describe, test } from 'vitest'
+import { afterEach, beforeEach, test } from 'vitest'
 
 import { openAIResolver } from '../src/resolvers/openAI.ts'
 
@@ -12,52 +12,28 @@ import { openAIResolver } from '../src/resolvers/openAI.ts'
  *     resolver: openAIResolver({ apiKey: process.env.OPENAI_API_KEY! }),
  *   })
  *
- * The `resolver` argument is evaluated eagerly regardless of `enabled`, so on a
- * machine without the key (`enabled: false`) `openAIResolver(...)` still runs.
- * It must not construct the OpenAI client at that point — otherwise the SDK
- * throws "Missing credentials" and the whole Payload config fails to load even
- * though the plugin was deliberately turned off.
+ * The `resolver` argument is evaluated regardless of `enabled`, so on a machine
+ * without the key `openAIResolver(...)` still runs. It must not construct the
+ * OpenAI client at that point — otherwise the SDK throws "Missing credentials"
+ * and the whole Payload config fails to load even though the plugin is off.
  */
-describe('openAIResolver lazy client construction', () => {
-  let savedKey: string | undefined
+let savedKey: string | undefined
 
-  beforeEach(() => {
-    savedKey = process.env.OPENAI_API_KEY
+beforeEach(() => {
+  savedKey = process.env.OPENAI_API_KEY
+  delete process.env.OPENAI_API_KEY
+})
+
+afterEach(() => {
+  if (savedKey === undefined) {
     delete process.env.OPENAI_API_KEY
-  })
+  } else {
+    process.env.OPENAI_API_KEY = savedKey
+  }
+})
 
-  afterEach(() => {
-    if (savedKey === undefined) {
-      delete process.env.OPENAI_API_KEY
-    } else {
-      process.env.OPENAI_API_KEY = savedKey
-    }
-  })
-
-  test('building the resolver without an API key does not throw', () => {
-    assert.doesNotThrow(() => {
-      openAIResolver({ apiKey: process.env.OPENAI_API_KEY as string })
-    })
-  })
-
-  test('the resolver built without a key is still a usable resolver object', () => {
-    const resolver = openAIResolver({ apiKey: process.env.OPENAI_API_KEY as string })
-
-    assert.equal(resolver.key, 'openai')
-    assert.equal(typeof resolver.resolve, 'function')
-    assert.equal(typeof resolver.resolveBulk, 'function')
-  })
-
-  test('the missing-key error surfaces when resolve() is called, not at build time', async () => {
-    const resolver = openAIResolver({ apiKey: process.env.OPENAI_API_KEY as string })
-
-    const response = await resolver.resolve({
-      filename: 'photo.jpg',
-      imageThumbnailUrl: 'https://example.com/thumb.jpg',
-      locale: 'en',
-      req: {} as never,
-    })
-
-    assert.equal(response.success, false)
+test('building the resolver without an API key does not throw', () => {
+  assert.doesNotThrow(() => {
+    openAIResolver({ apiKey: process.env.OPENAI_API_KEY as string })
   })
 })


### PR DESCRIPTION
The resolver argument is evaluated even when the plugin is passed
enabled: false, so building the OpenAI client eagerly in the factory
threw "Missing credentials" and broke the whole Payload config on
machines without an API key (e.g. enabled: !!process.env.OPENAI_API_KEY).
Defer client construction to the first resolve()/resolveBulk() call so a
disabled plugin can discard the resolver without touching the SDK.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hm4UdqfgaJXqm2Tg2qroLL