### PR TITLE
refactor(alt-text): dedupe endpoint test fixtures into shared harness

### DIFF
--- a/alt-text/test/bulkGenerateIdsLimit.test.ts
+++ b/alt-text/test/bulkGenerateIdsLimit.test.ts
@@ -2,99 +2,58 @@ import assert from 'node:assert/strict'
 
 import { describe, test } from 'vitest'
 
-import type { PayloadRequest } from 'payload'
-
-import type { AltTextPluginConfig } from '../src/types/AltTextPluginConfig.ts'
-
 import { bulkGenerateAltTextsEndpoint } from '../src/endpoints/bulkGenerateAltTexts.ts'
+import { buildEndpointRequest, buildPluginConfig } from './support/endpointHarness.ts'
 
 /**
  * The bulk endpoint bounds and de-duplicates the `ids` array so a single
  * request cannot fan out into an unbounded number of paid resolver calls.
  */
 
-const user = { id: 'user-1', email: 'user@example.com', role: 'user' }
+/**
+ * Builds a request for the bulk endpoint with the given per-request id limit.
+ * The endpoint reads each id via `findByID`, so the recorded `findByIDCalls`
+ * reveal exactly which ids made it past the bound/de-duplication step — read
+ * them via `resolvedIds()` after invoking the endpoint.
+ */
+function buildRequest(body: unknown, maxBulkGenerateIds: number) {
+  const pluginConfig = buildPluginConfig({ maxBulkGenerateIds })
+  const { findByIDCalls, req } = buildEndpointRequest(body, { pluginConfig })
 
-function buildPluginConfig(maxBulkGenerateIds: number): AltTextPluginConfig {
-  return {
-    access: ({ req }) => !!req.user,
-    collections: [{ slug: 'media', mimeTypes: ['image/*'] }],
-    enabled: true,
-    getImageThumbnail: () => 'https://example.com/thumb.png',
-    healthCheck: true,
-    healthCheckAccess: ({ req }) => !!req.user,
-    locale: 'en',
-    locales: [],
-    maxBulkGenerateConcurrency: 1,
-    maxBulkGenerateIds,
-    resolver: {
-      key: 'mock',
-      resolve: async () => ({
-        success: true,
-        result: { altText: 'generated alt', keywords: ['a', 'b'] },
-      }),
-      resolveBulk: async () => ({
-        success: true,
-        results: { en: { altText: 'generated alt', keywords: ['a', 'b'] } },
-      }),
-    },
-  }
-}
-
-function buildRequest(
-  body: unknown,
-  maxBulkGenerateIds: number,
-): { req: PayloadRequest; resolveBulkIds: (number | string)[] } {
-  const pluginConfig = buildPluginConfig(maxBulkGenerateIds)
-  const resolveBulkIds: (number | string)[] = []
-
-  const req = {
-    json: async () => body,
-    payload: {
-      config: { custom: { altTextPluginConfig: pluginConfig } },
-      findByID: async (args: { id: number | string }) => {
-        resolveBulkIds.push(args.id)
-        return { id: args.id, filename: 'photo.png', mimeType: 'image/png' }
-      },
-      update: async (args: { id: number | string }) => ({ id: args.id }),
-    },
-    user,
-  } as unknown as PayloadRequest
-
-  return { req, resolveBulkIds }
+  return { req, resolvedIds: () => findByIDCalls.map((call) => call.id as number | string) }
 }
 
 describe('bulk generate ids limit', () => {
   test('rejects a batch larger than the configured maximum without generating anything', async () => {
-    const { req, resolveBulkIds } = buildRequest({ collection: 'media', ids: ['a', 'b', 'c'] }, 2)
+    const { req, resolvedIds } = buildRequest({ collection: 'media', ids: ['a', 'b', 'c'] }, 2)
 
-    const response = await bulkGenerateAltTextsEndpoint(buildPluginConfig(2).access)(req)
+    const response = await bulkGenerateAltTextsEndpoint(buildPluginConfig().access)(req)
 
     assert.equal(response.status, 400)
-    assert.equal(resolveBulkIds.length, 0)
+    assert.equal(resolvedIds().length, 0)
   })
 
   test('collapses duplicate ids so each image is generated only once', async () => {
-    const { req, resolveBulkIds } = buildRequest({ collection: 'media', ids: ['a', 'a', 'b'] }, 100)
+    const { req, resolvedIds } = buildRequest({ collection: 'media', ids: ['a', 'a', 'b'] }, 100)
 
-    const response = await bulkGenerateAltTextsEndpoint(buildPluginConfig(100).access)(req)
+    const response = await bulkGenerateAltTextsEndpoint(buildPluginConfig().access)(req)
     const result = (await response.json()) as { totalDocs: number; updatedDocs: number }
 
-    assert.deepEqual([...resolveBulkIds].sort(), ['a', 'b'])
+    assert.deepEqual(resolvedIds().sort(), ['a', 'b'])
     assert.equal(result.totalDocs, 2)
     assert.equal(result.updatedDocs, 2)
   })
 
   test('counts deduplicated ids against the limit, not the raw array length', async () => {
     // Six raw ids but only two distinct — must pass a limit of 2.
-    const { req, resolveBulkIds } = buildRequest(
+    const { req, resolvedIds } = buildRequest(
       { collection: 'media', ids: ['a', 'a', 'a', 'b', 'b', 'b'] },
       2,
     )
 
-    const response = await bulkGenerateAltTextsEndpoint(buildPluginConfig(2).access)(req)
+    const response = await bulkGenerateAltTextsEndpoint(buildPluginConfig().access)(req)
 
     assert.equal(response.status, 200)
-    assert.deepEqual([...resolveBulkIds].sort(), ['a', 'b'])
+    assert.deepEqual(resolvedIds().sort(), ['a', 'b'])
   })
 })

--- a/alt-text/test/endpointAccessControl.test.ts
+++ b/alt-text/test/endpointAccessControl.test.ts
@@ -3,10 +3,11 @@ import assert from 'node:assert/strict'
 import { Forbidden } from 'payload'
 import { describe, test } from 'vitest'
 
-import type { PayloadRequest } from 'payload'
-
-import type { AltTextPluginConfig } from '../src/types/AltTextPluginConfig.ts'
-
+import {
+  buildEndpointRequest as buildRequest,
+  buildPluginConfig,
+  testUser as user,
+} from './support/endpointHarness.ts'
 import { bulkGenerateAltTextsEndpoint } from '../src/endpoints/bulkGenerateAltTexts.ts'
 import { generateAltTextEndpoint } from '../src/endpoints/generateAltText.ts'
 
@@ -17,62 +18,6 @@ import { generateAltTextEndpoint } from '../src/endpoints/generateAltText.ts'
  * able to touch. Every Local API call the endpoints make must run under the
  * requesting user's access (`overrideAccess: false` + `user: req.user`).
  */
-
-const user = { id: 'low-priv-user', email: 'user@example.com', role: 'user' }
-
-type LocalApiCall = Record<string, unknown>
-
-function buildPluginConfig(): AltTextPluginConfig {
-  return {
-    access: ({ req }) => !!req.user,
-    collections: [{ slug: 'media', mimeTypes: ['image/*'] }],
-    enabled: true,
-    getImageThumbnail: () => 'https://example.com/thumb.png',
-    healthCheck: true,
-    healthCheckAccess: ({ req }) => !!req.user,
-    locale: 'en',
-    locales: [],
-    maxBulkGenerateConcurrency: 1,
-    resolver: {
-      key: 'mock',
-      resolve: async () => ({
-        success: true,
-        result: { altText: 'generated alt', keywords: ['a', 'b'] },
-      }),
-      resolveBulk: async () => ({
-        success: true,
-        results: { en: { altText: 'generated alt', keywords: ['a', 'b'] } },
-      }),
-    },
-  }
-}
-
-function buildRequest(body: unknown): {
-  findByIDCalls: LocalApiCall[]
-  req: PayloadRequest
-  updateCalls: LocalApiCall[]
-} {
-  const findByIDCalls: LocalApiCall[] = []
-  const updateCalls: LocalApiCall[] = []
-
-  const req = {
-    json: async () => body,
-    payload: {
-      config: { custom: { altTextPluginConfig: buildPluginConfig() } },
-      findByID: async (args: LocalApiCall) => {
-        findByIDCalls.push(args)
-        return { id: args.id, filename: 'photo.png', mimeType: 'image/png' }
-      },
-      update: async (args: LocalApiCall) => {
-        updateCalls.push(args)
-        return { id: args.id }
-      },
-    },
-    user,
-  } as unknown as PayloadRequest
-
-  return { findByIDCalls, req, updateCalls }
-}
 
 describe('generate endpoint access control', () => {
   test('reads the document under the requesting user, not with overridden access', async () => {

--- a/alt-text/test/endpointCollectionAllowlist.test.ts
+++ b/alt-text/test/endpointCollectionAllowlist.test.ts
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict'
 
 import { describe, test } from 'vitest'
 
-import type { PayloadRequest } from 'payload'
-
-import type { AltTextPluginConfig } from '../src/types/AltTextPluginConfig.ts'
-
+import {
+  buildEndpointRequest as buildRequest,
+  buildPluginConfig,
+} from './support/endpointHarness.ts'
 import { bulkGenerateAltTextsEndpoint } from '../src/endpoints/bulkGenerateAltTexts.ts'
 import { generateAltTextEndpoint } from '../src/endpoints/generateAltText.ts'
 
@@ -16,62 +16,6 @@ import { generateAltTextEndpoint } from '../src/endpoints/generateAltText.ts'
  * pointed at any collection in the app, widening the blast radius of the
  * access-control surface to the entire data model.
  */
-
-const user = { id: 'low-priv-user', email: 'user@example.com', role: 'user' }
-
-type LocalApiCall = Record<string, unknown>
-
-function buildPluginConfig(): AltTextPluginConfig {
-  return {
-    access: ({ req }) => !!req.user,
-    collections: [{ slug: 'media', mimeTypes: ['image/*'] }],
-    enabled: true,
-    getImageThumbnail: () => 'https://example.com/thumb.png',
-    healthCheck: true,
-    healthCheckAccess: ({ req }) => !!req.user,
-    locale: 'en',
-    locales: [],
-    maxBulkGenerateConcurrency: 1,
-    resolver: {
-      key: 'mock',
-      resolve: async () => ({
-        success: true,
-        result: { altText: 'generated alt', keywords: ['a', 'b'] },
-      }),
-      resolveBulk: async () => ({
-        success: true,
-        results: { en: { altText: 'generated alt', keywords: ['a', 'b'] } },
-      }),
-    },
-  }
-}
-
-function buildRequest(body: unknown): {
-  findByIDCalls: LocalApiCall[]
-  req: PayloadRequest
-  updateCalls: LocalApiCall[]
-} {
-  const findByIDCalls: LocalApiCall[] = []
-  const updateCalls: LocalApiCall[] = []
-
-  const req = {
-    json: async () => body,
-    payload: {
-      config: { custom: { altTextPluginConfig: buildPluginConfig() } },
-      findByID: async (args: LocalApiCall) => {
-        findByIDCalls.push(args)
-        return { id: args.id, filename: 'photo.png', mimeType: 'image/png' }
-      },
-      update: async (args: LocalApiCall) => {
-        updateCalls.push(args)
-        return { id: args.id }
-      },
-    },
-    user,
-  } as unknown as PayloadRequest
-
-  return { findByIDCalls, req, updateCalls }
-}
 
 describe('generate endpoint collection allowlist', () => {
   test('rejects a collection the plugin does not manage with 403 and no Local API call', async () => {

--- a/alt-text/test/endpointLocaleValidation.test.ts
+++ b/alt-text/test/endpointLocaleValidation.test.ts
@@ -2,11 +2,10 @@ import assert from 'node:assert/strict'
 
 import { describe, test } from 'vitest'
 
-import type { PayloadRequest } from 'payload'
-
-import type { AltTextPluginConfig } from '../src/types/AltTextPluginConfig.ts'
+import type { AltTextResolver } from '../src/resolvers/types.ts'
 
 import { generateAltTextEndpoint } from '../src/endpoints/generateAltText.ts'
+import { buildEndpointRequest, buildPluginConfig } from './support/endpointHarness.ts'
 
 /**
  * When localization is enabled, the generate endpoint must reject a request
@@ -17,65 +16,38 @@ import { generateAltTextEndpoint } from '../src/endpoints/generateAltText.ts'
  * unvalidated locale is a prompt-injection surface.
  */
 
-const user = { id: 'low-priv-user', email: 'user@example.com', role: 'user' }
-
-type LocalApiCall = Record<string, unknown>
-
 type ResolveArgs = { locale: string }
 
-function buildPluginConfig(resolveCalls: ResolveArgs[]): AltTextPluginConfig {
-  return {
-    access: ({ req }: { req: PayloadRequest }) => !!req.user,
-    collections: [{ slug: 'media', mimeTypes: ['image/*'] }],
-    enabled: true,
-    getImageThumbnail: () => 'https://example.com/thumb.png',
-    healthCheck: true,
-    healthCheckAccess: ({ req }: { req: PayloadRequest }) => !!req.user,
+/**
+ * Builds a request with localization enabled (`en`/`de`) and a resolver that
+ * records the locale it was called with, so a test can assert whether an
+ * unconfigured locale ever reached the resolver.
+ */
+function buildRequest(body: unknown): {
+  req: ReturnType<typeof buildEndpointRequest>['req']
+  resolveCalls: ResolveArgs[]
+  updateCalls: ReturnType<typeof buildEndpointRequest>['updateCalls']
+} {
+  const resolveCalls: ResolveArgs[] = []
+  const resolve: AltTextResolver['resolve'] = async (args) => {
+    resolveCalls.push({ locale: args.locale })
+    return { success: true, result: { altText: 'generated alt', keywords: ['a', 'b'] } }
+  }
+
+  const pluginConfig = buildPluginConfig({
     // localization enabled: these are the only valid request locales
     locales: ['en', 'de'],
-    maxBulkGenerateConcurrency: 1,
     resolver: {
       key: 'mock',
-      resolve: async (args: ResolveArgs) => {
-        resolveCalls.push({ locale: args.locale })
-        return {
-          success: true,
-          result: { altText: 'generated alt', keywords: ['a', 'b'] },
-        }
-      },
+      resolve,
       resolveBulk: async () => ({
         success: true,
         results: { en: { altText: 'generated alt', keywords: ['a', 'b'] } },
       }),
     },
-  } as unknown as AltTextPluginConfig
-}
+  })
 
-function buildRequest(body: unknown): {
-  req: PayloadRequest
-  resolveCalls: ResolveArgs[]
-  updateCalls: LocalApiCall[]
-} {
-  const resolveCalls: ResolveArgs[] = []
-  const updateCalls: LocalApiCall[] = []
-  const pluginConfig = buildPluginConfig(resolveCalls)
-
-  const req = {
-    json: async () => body,
-    payload: {
-      config: { custom: { altTextPluginConfig: pluginConfig } },
-      findByID: async (args: LocalApiCall) => ({
-        id: args.id,
-        filename: 'photo.png',
-        mimeType: 'image/png',
-      }),
-      update: async (args: LocalApiCall) => {
-        updateCalls.push(args)
-        return { id: args.id }
-      },
-    },
-    user,
-  } as unknown as PayloadRequest
+  const { req, updateCalls } = buildEndpointRequest(body, { pluginConfig })
 
   return { req, resolveCalls, updateCalls }
 }

--- a/alt-text/test/support/endpointHarness.ts
+++ b/alt-text/test/support/endpointHarness.ts
@@ -1,0 +1,86 @@
+import type { PayloadRequest } from 'payload'
+
+import type { AltTextPluginConfig } from '../../src/types/AltTextPluginConfig.ts'
+
+/**
+ * Shared fixtures for the alt-text endpoint tests. Every endpoint test needs the
+ * same two things: a resolved plugin config exposed on `req.payload.config.custom`
+ * and a fake `PayloadRequest` whose `findByID`/`update` Local API calls are
+ * recorded so the test can assert how the endpoint invoked them. Centralizing them
+ * here keeps each test focused on the one behavior it protects.
+ */
+
+export const testUser = { id: 'low-priv-user', email: 'user@example.com', role: 'user' }
+
+export type LocalApiCall = Record<string, unknown>
+
+/**
+ * A resolved plugin config with sensible defaults for an `image/*` `media`
+ * collection. Pass `overrides` to vary the single facet a test cares about
+ * (e.g. `locales`, `maxBulkGenerateIds`, or a recording `resolver`).
+ */
+export function buildPluginConfig(
+  overrides: Partial<AltTextPluginConfig> = {},
+): AltTextPluginConfig {
+  return {
+    access: ({ req }) => !!req.user,
+    collections: [{ slug: 'media', mimeTypes: ['image/*'] }],
+    enabled: true,
+    getImageThumbnail: () => 'https://example.com/thumb.png',
+    healthCheck: true,
+    healthCheckAccess: ({ req }) => !!req.user,
+    locale: 'en',
+    locales: [],
+    maxBulkGenerateConcurrency: 1,
+    maxBulkGenerateIds: 100,
+    resolver: {
+      key: 'mock',
+      resolve: async () => ({
+        success: true,
+        result: { altText: 'generated alt', keywords: ['a', 'b'] },
+      }),
+      resolveBulk: async () => ({
+        success: true,
+        results: { en: { altText: 'generated alt', keywords: ['a', 'b'] } },
+      }),
+    },
+    ...overrides,
+  }
+}
+
+/**
+ * Builds a fake `PayloadRequest` for an endpoint handler. `findByID` returns a
+ * minimal image document by default; pass `pluginConfig` to use a config other
+ * than the shared default. The returned `findByIDCalls`/`updateCalls` arrays
+ * record the arguments of every Local API call the endpoint makes.
+ */
+export function buildEndpointRequest(
+  body: unknown,
+  options: { pluginConfig?: AltTextPluginConfig } = {},
+): {
+  findByIDCalls: LocalApiCall[]
+  req: PayloadRequest
+  updateCalls: LocalApiCall[]
+} {
+  const findByIDCalls: LocalApiCall[] = []
+  const updateCalls: LocalApiCall[] = []
+  const pluginConfig = options.pluginConfig ?? buildPluginConfig()
+
+  const req = {
+    json: async () => body,
+    payload: {
+      config: { custom: { altTextPluginConfig: pluginConfig } },
+      findByID: async (args: LocalApiCall) => {
+        findByIDCalls.push(args)
+        return { id: args.id, filename: 'photo.png', mimeType: 'image/png' }
+      },
+      update: async (args: LocalApiCall) => {
+        updateCalls.push(args)
+        return { id: args.id }
+      },
+    },
+    user: testUser,
+  } as unknown as PayloadRequest
+
+  return { findByIDCalls, req, updateCalls }
+}


### PR DESCRIPTION
## What

Four alt-text endpoint test files each carried near-identical copies of `buildPluginConfig` and a fake-`PayloadRequest` builder. This extracts them into a single shared module, `alt-text/test/support/endpointHarness.ts`, exposing:

- `buildPluginConfig(overrides?)` — a base resolved `AltTextPluginConfig` plus spread overrides, so each test varies only the facet it exercises (`locales`, `maxBulkGenerateIds`, a recording `resolver`)
- `buildEndpointRequest(body, { pluginConfig? })` — a fake request that records the `findByID` / `update` Local API calls
- `testUser`

`endpointAccessControl.test.ts` and `endpointCollectionAllowlist.test.ts` previously had byte-for-byte identical setup; `endpointLocaleValidation.test.ts` and `bulkGenerateIdsLimit.test.ts` varied only one facet each. `healthEndpointAccess.test.ts` builds over the *incoming* config type (a different shape) and is intentionally left untouched.

## Why

Removes ~94 net lines of duplicated fixture code and gives the endpoint tests a single place to evolve the mock plugin config as the plugin grows.

## Verification

- Full alt-text suite green: **69 tests / 13 files passing** (rebased on latest `main`, includes the newly-added `endpointPaths` and `openAIResolverLazyInit` suites)
- `pnpm typecheck` clean; prettier clean
- Test behaviors and assertions unchanged — pure refactor, no source changes

No changelog entry: this is a test-only `refactor`, which per the repo guidelines doesn't earn one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Thqu7QtoVPhcESr2B9Wv6m)_