### PR TITLE
fix(vercel-deployments): validate and encode deployment id query param

### DIFF
--- a/vercel-deployments/CHANGELOG.md
+++ b/vercel-deployments/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: validate the `id` query parameter on the deployments endpoint and encode it before building the Vercel API request path, so only well-formed deployment ids are accepted
+
 ## 0.3.1
 
 - fix: stop the deployment widget skeleton from flashing again right after load — the first background poll no longer triggers a redundant refresh of already-rendered data

--- a/vercel-deployments/src/endpoints/endpoints.test.ts
+++ b/vercel-deployments/src/endpoints/endpoints.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { VercelDeploymentsPluginConfig } from '../types.js'
 
@@ -36,6 +36,10 @@ function createMockReq(overrides: {
 }
 
 describe('getDeploymentsEndpoint', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('returns 401 when user is not authenticated (default access)', async () => {
     const req = createMockReq({ user: null })
     const response = await getDeploymentsEndpoint(req)
@@ -59,6 +63,21 @@ describe('getDeploymentsEndpoint', () => {
     expect(response.status).toBe(500)
     const body = await response.json()
     expect(body.error).toBe('Plugin config not found')
+  })
+
+  it('rejects an id containing path separators without contacting the Vercel API', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const req = createMockReq({
+      url: 'http://localhost:3000/api/vercel-deployments?id=..%2F..%2Fv9%2Fprojects',
+      user: { id: 'user-1' },
+    })
+
+    const response = await getDeploymentsEndpoint(req)
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.error).toBe('Invalid deployment id')
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/vercel-deployments/src/endpoints/getDeployments.ts
+++ b/vercel-deployments/src/endpoints/getDeployments.ts
@@ -51,6 +51,13 @@ export const getDeploymentsEndpoint: PayloadHandler = async (req: PayloadRequest
   const url = new URL(req.url!)
   const id = url.searchParams.get('id')
 
+  // A Vercel deployment id is an opaque token (e.g. `dpl_…`). Reject anything
+  // that isn't, so a caller cannot pass path separators or `../` segments that
+  // would change which upstream Vercel API path gets requested.
+  if (id !== null && !/^[\w-]+$/.test(id)) {
+    return Response.json({ error: 'Invalid deployment id' }, { status: 400 })
+  }
+
   try {
     const vercelClient = new VercelApiClient(pluginConfig.vercel.apiToken)
 

--- a/vercel-deployments/src/utilities/vercelApiClient.test.ts
+++ b/vercel-deployments/src/utilities/vercelApiClient.test.ts
@@ -96,6 +96,19 @@ describe('VercelApiClient', () => {
       )
       expect(result.id).toBe('dpl-abc')
     })
+
+    it('encodes the id so path separators cannot alter the request path', async () => {
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve({}),
+        ok: true,
+      })
+
+      await client.getDeployment({ idOrUrl: '../../v9/projects' })
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string
+      expect(calledUrl).toContain('/v13/deployments/..%2F..%2Fv9%2Fprojects')
+      expect(calledUrl).not.toContain('/v9/projects')
+    })
   })
 
   describe('createDeployment', () => {

--- a/vercel-deployments/src/utilities/vercelApiClient.ts
+++ b/vercel-deployments/src/utilities/vercelApiClient.ts
@@ -112,9 +112,10 @@ export class VercelApiClient {
       searchParams.teamId = params.teamId
     }
 
-    return this.request<VercelDeployment>(`/v13/deployments/${params.idOrUrl}`, {
-      searchParams,
-    })
+    return this.request<VercelDeployment>(
+      `/v13/deployments/${encodeURIComponent(params.idOrUrl)}`,
+      { searchParams },
+    )
   }
 
   /**


### PR DESCRIPTION
## Summary

Tightens input handling for the `?id=<deploymentId>` lookup on the `GET /api/vercel-deployments` endpoint.

- Validate `id` against the expected opaque-token shape (`^[\w-]+$`) at the endpoint boundary and return `400 Invalid deployment id` for anything else, before any upstream request is made.
- Encode `idOrUrl` with `encodeURIComponent` in `VercelApiClient.getDeployment` before interpolating it into the Vercel API request path, so the request path stays a single, well-formed segment regardless of the input.

A malformed `id` previously flowed straight into the constructed request path and produced a confusing wrapped `500`; it now fails fast with a clear `400` and no wasted outbound call.

## Tests

- Endpoint test: a malformed `id` returns `400` and the Vercel API is never contacted.
- API-client test: the id is percent-encoded so separators can't alter the request path.

All 25 tests pass; lint and typecheck are clean.

## Changelog

Added under `## Unreleased` in the plugin's `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkmj5HspG6gjMAZ2YQerSG)_