### PR TITLE
docs(admin-search): document search index access-control requirements

### DIFF
--- a/admin-search/README.md
+++ b/admin-search/README.md
@@ -28,12 +28,25 @@ export default {
     adminSearchPlugin({}),
     searchPlugin({
       collections: ['pages', 'posts', 'authors'],
+      // The index is exposed at GET /api/search — set its access to match who should read it (see Security).
+      searchOverrides: {
+        access: {
+          read: ({ req }) => Boolean(req.user),
+        },
+      },
     }),
   ],
 }
 ```
 
 You can control which collections you can search by adjusting the `collections` option in the search plugin config.
+
+## Security
+
+Search results are served by the `search` collection from [@payloadcms/plugin-search](https://www.npmjs.com/package/@payloadcms/plugin-search), exposed at `GET /api/search`. Two things to be aware of when deciding its access:
+
+- **It is public by default** (`read: () => true`): the titles and IDs of every indexed document are readable by anyone. If that doesn't fit your app, set `searchOverrides.access.read` — e.g. `({ req }) => Boolean(req.user)` for admin-only, or leave it open if your frontend reads the index.
+- **Its read access is coarse:** the collection flattens documents from every configured collection into one and does not inherit per-collection access control. To limit which documents a user sees, return a `where` constraint from `searchOverrides.access.read`. This can only be done server-side — the admin UI shows whatever the endpoint returns.
 
 ## Configuration
 

--- a/admin-search/dev/src/payload.config.ts
+++ b/admin-search/dev/src/payload.config.ts
@@ -74,6 +74,13 @@ export default buildConfig({
   plugins: [
     adminSearchPlugin({ headerSearchComponentStyle: 'bar' }),
     searchPlugin({
+      // The `search` collection defaults to public read (`read: () => true`). This dev
+      // app restricts it to authenticated users; set access to match your app's needs.
+      searchOverrides: {
+        access: {
+          read: ({ req }) => Boolean(req.user),
+        },
+      },
       beforeSync: ({ originalDoc, searchDoc }) => {
         return {
           ...searchDoc,


### PR DESCRIPTION
## Summary

A security review of the `admin-search` plugin found that its documented setup could expose the search index unintentionally.

The plugin is a thin admin UI over the `search` collection created by [`@payloadcms/plugin-search`](https://www.npmjs.com/package/@payloadcms/plugin-search). That generated collection defaults to `read: () => true`, so `GET /api/search` — including the titles and IDs of every indexed document (pages, posts, author names, media filenames, …) — is readable by anyone. The previous README setup example didn't mention this, so it was easy to ship without realizing.

A public index is a **legitimate choice** (e.g. when a frontend consumes it), so this PR documents the trade-off and makes the access decision a conscious one rather than prescribing authentication. Because the plugin doesn't create the `search` collection, access control can only live in the consumer's search-plugin config — a browser-side filter wouldn't be a security boundary (and would break the result `limit`), so nothing is added to the UI.

## Changes

- **README** — the setup example now sets `searchOverrides.access.read`, and a short **Security** section explains the two access-control properties of the search collection:
  - it is **public by default** (`read: () => true`) — restrict it if that doesn't fit your app, or leave it open for a frontend, and
  - its read access is **coarse** — it doesn't inherit per-collection access control, so per-user scoping must be done server-side via a `where` constraint.
- **Dev app** (`dev/src/payload.config.ts`) — sets `searchOverrides.access.read` as a worked example (restricted to authenticated users, with a comment noting it should match your app's needs).

No plugin runtime code changes; documentation and a dev-config example only.

## Other audit findings (not addressed here)

- **Per-collection leakage (medium):** same server-side `searchOverrides.access.read` scoping is the fix; documented rather than enforced in the UI (deliberately — see above).
- **Raw query into `like`/`$regex` (low):** owned by Payload core's query sanitization and reachable via the endpoint regardless of this plugin; mitigated by keeping the `payload` peer dep current.
- Confirmed clean: result-highlight XSS/ReDoS (regex metacharacters escaped), navigation/open-redirect, dependencies.

## Test plan

- `pnpm --filter <admin-search dev app> dev`, open the admin panel, confirm search works and that `/api/search` behaves per the configured access.
- `pnpm typecheck` ✓ and `pnpm lint` ✓ in `admin-search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)