### PR TITLE
fix(content-translator): restrict translate endpoint to configured entities

### DIFF
--- a/content-translator/CHANGELOG.md
+++ b/content-translator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: restrict the translate endpoint to the collections and globals configured in the plugin options; requests targeting any other entity are now rejected with a 400 before any document is read or written or sent to the resolver
+
 ## 0.4.0
 
 - feat: add a per-field `custom['content-translator']` config (typed via module augmentation) with orthogonal `skip`, `beforeTranslate`, and `afterTranslate` hooks, so a slug can either be derived from the translated title (skip + derive) or translated and then slugified (translate + normalize)

--- a/content-translator/src/plugin.ts
+++ b/content-translator/src/plugin.ts
@@ -67,6 +67,7 @@ export const payloadContentTranslatorPlugin: (pluginConfig: TranslatorConfig) =>
         {
           handler: translateEndpoint(
             pluginConfig.access ?? (({ req }: { req: PayloadRequest }) => !!req.user),
+            { collections: pluginConfig.collections, globals: pluginConfig.globals },
           ),
           method: 'post',
           path: `/${PLUGIN_SLUG}/translate`,

--- a/content-translator/src/translate/endpoint.ts
+++ b/content-translator/src/translate/endpoint.ts
@@ -1,4 +1,4 @@
-import type { PayloadHandler } from 'payload'
+import type { CollectionSlug, GlobalSlug, PayloadHandler } from 'payload'
 
 import { APIError } from 'payload'
 
@@ -6,8 +6,14 @@ import type { TranslateAccess, TranslateEndpointArgs } from './types.js'
 
 import { translateOperation } from './operation.js'
 
+/** Slugs the plugin was configured to translate. */
+type EnabledEntities = {
+  collections: CollectionSlug[]
+  globals: GlobalSlug[]
+}
+
 export const translateEndpoint =
-  (access: TranslateAccess): PayloadHandler =>
+  (access: TranslateAccess, enabledEntities: EnabledEntities): PayloadHandler =>
   async (req) => {
     if (!req.json) {
       throw new APIError('Request body must be valid JSON', 400)
@@ -33,6 +39,23 @@ export const translateEndpoint =
       locale: body.locale,
       localeFrom: body.localeFrom,
       update: body.update ?? false,
+    }
+
+    // Only entities the plugin was explicitly configured to translate may be
+    // targeted. Without this, any collection/global the requesting user can
+    // access would be translatable through this endpoint (and its content sent
+    // to the external resolver), not just the opt-in set. Checked against the
+    // plugin config — never against `req.payload.config.collections`, which
+    // lists every entity. `globalSlug` takes precedence, matching the
+    // operation's `isGlobal = !!globalSlug`. Fails closed.
+    if (args.globalSlug) {
+      if (!enabledEntities.globals.includes(args.globalSlug)) {
+        throw new APIError('Translation is not enabled for this global', 400)
+      }
+    } else if (args.collectionSlug) {
+      if (!enabledEntities.collections.includes(args.collectionSlug)) {
+        throw new APIError('Translation is not enabled for this collection', 400)
+      }
     }
 
     // The access function receives the parsed request args (e.g. `update`,

--- a/content-translator/test/translateEndpoint.test.ts
+++ b/content-translator/test/translateEndpoint.test.ts
@@ -17,6 +17,9 @@ import { translateEndpoint } from '../src/translate/endpoint.ts'
 
 const allowAll = () => true
 
+/** Entities the plugin was configured to translate (matches the mock config). */
+const enabled = { collections: ['posts'], globals: [] as string[] }
+
 type UpdateCall = Record<string, unknown>
 
 function buildReq(body: unknown): {
@@ -41,9 +44,20 @@ function buildReq(body: unknown): {
         slug: 'posts',
         fields: [{ name: 'title', type: 'text', localized: true }],
       },
+      // Exists in the Payload config and is readable by the user, but is NOT
+      // opted into translation — the endpoint must refuse to touch it.
+      {
+        slug: 'users',
+        fields: [{ name: 'title', type: 'text', localized: true }],
+      },
     ],
     custom: { translator: { resolver } },
-    globals: [],
+    globals: [
+      {
+        slug: 'secrets',
+        fields: [{ name: 'title', type: 'text', localized: true }],
+      },
+    ],
   }
 
   const req = {
@@ -54,10 +68,15 @@ function buildReq(body: unknown): {
         findByIDCalls.push(args)
         return { id: 'post-1', title: 'Hello' }
       },
-      logger: { error: () => {} },
+      findGlobal: async () => ({ title: 'Hello' }),
+      logger: { error: () => {}, warn: () => {} },
       update: async (args: UpdateCall) => {
         updateCalls.push(args)
         return { id: args.id }
+      },
+      updateGlobal: async (args: UpdateCall) => {
+        updateCalls.push(args)
+        return {}
       },
     },
     user: { id: 'agent', email: 'agent@example.com' },
@@ -78,7 +97,7 @@ describe('translate endpoint persistence', () => {
   test('does not write the document when update is omitted', async () => {
     const { req, updateCalls } = buildReq({ ...baseBody })
 
-    const response = await translateEndpoint(allowAll)(req)
+    const response = await translateEndpoint(allowAll, enabled)(req)
     const result = await response.json()
 
     assert.equal(updateCalls.length, 0)
@@ -89,7 +108,7 @@ describe('translate endpoint persistence', () => {
   test('persists the translation at the target locale when update is true', async () => {
     const { req, updateCalls } = buildReq({ ...baseBody, update: true })
 
-    await translateEndpoint(allowAll)(req)
+    await translateEndpoint(allowAll, enabled)(req)
 
     assert.equal(updateCalls.length, 1)
     assert.equal(updateCalls[0].id, 'post-1')
@@ -101,7 +120,7 @@ describe('translate endpoint persistence', () => {
   test('writes under the requesting user, never with overridden access', async () => {
     const { req, updateCalls } = buildReq({ ...baseBody, update: true })
 
-    await translateEndpoint(allowAll)(req)
+    await translateEndpoint(allowAll, enabled)(req)
 
     assert.equal(updateCalls[0].overrideAccess, false)
   })
@@ -109,7 +128,7 @@ describe('translate endpoint persistence', () => {
   test('saves as a published version by default', async () => {
     const { req, updateCalls } = buildReq({ ...baseBody, update: true })
 
-    await translateEndpoint(allowAll)(req)
+    await translateEndpoint(allowAll, enabled)(req)
 
     assert.notEqual(updateCalls[0].draft, true)
   })
@@ -117,7 +136,7 @@ describe('translate endpoint persistence', () => {
   test('saves as a draft when draft is true', async () => {
     const { req, updateCalls } = buildReq({ ...baseBody, draft: true, update: true })
 
-    await translateEndpoint(allowAll)(req)
+    await translateEndpoint(allowAll, enabled)(req)
 
     assert.equal(updateCalls[0].draft, true)
   })
@@ -127,7 +146,7 @@ describe('translate endpoint access control', () => {
   test('ignores overrideAccess in the request body so access cannot be bypassed', async () => {
     const { req, updateCalls } = buildReq({ ...baseBody, overrideAccess: true, update: true })
 
-    await translateEndpoint(allowAll)(req)
+    await translateEndpoint(allowAll, enabled)(req)
 
     assert.equal(updateCalls.length, 1)
     assert.equal(updateCalls[0].overrideAccess, false)
@@ -139,14 +158,14 @@ describe('translate endpoint access control', () => {
     // update: true is denied and nothing is written
     const denied = buildReq({ ...baseBody, update: true })
     await assert.rejects(
-      () => translateEndpoint(returnOnly)(denied.req),
+      () => translateEndpoint(returnOnly, enabled)(denied.req),
       (err) => err instanceof APIError && err.status === 401,
     )
     assert.equal(denied.updateCalls.length, 0)
 
     // the same caller may still translate-and-return
     const allowed = buildReq({ ...baseBody })
-    const response = await translateEndpoint(returnOnly)(allowed.req)
+    const response = await translateEndpoint(returnOnly, enabled)(allowed.req)
     const result = await response.json()
     assert.equal(result.success, true)
     assert.equal(allowed.updateCalls.length, 0)
@@ -161,7 +180,7 @@ describe('translate endpoint access control', () => {
 
     const { req } = buildReq({ ...baseBody, draft: true, update: true })
 
-    await translateEndpoint(capture)(req)
+    await translateEndpoint(capture, enabled)(req)
 
     assert.equal(received?.update, true)
     assert.equal(received?.draft, true)
@@ -173,7 +192,7 @@ describe('translate endpoint access control', () => {
     // baseBody supplies `data`, so only the source (localeFrom) read happens
     const { findByIDCalls, req } = buildReq({ ...baseBody })
 
-    await translateEndpoint(allowAll)(req)
+    await translateEndpoint(allowAll, enabled)(req)
 
     assert.equal(findByIDCalls.length, 1)
     assert.equal(findByIDCalls[0].overrideAccess, false)
@@ -187,7 +206,7 @@ describe('translate endpoint access control', () => {
       localeFrom: 'en',
     })
 
-    await translateEndpoint(allowAll)(req)
+    await translateEndpoint(allowAll, enabled)(req)
 
     assert.equal(findByIDCalls.length, 2)
     for (const call of findByIDCalls) {
@@ -202,8 +221,50 @@ describe('translate endpoint access control', () => {
     }
 
     await assert.rejects(
-      () => translateEndpoint(allowAll)(req),
+      () => translateEndpoint(allowAll, enabled)(req),
       (err) => err instanceof APIError && err.status === 400,
     )
+  })
+})
+
+describe('translate endpoint entity allow-list', () => {
+  test('rejects a collection not enabled for translation before reading or writing', async () => {
+    // `users` exists and the user may even have access to it, but it was not
+    // opted into translation, so the endpoint must not touch it.
+    const { findByIDCalls, req, updateCalls } = buildReq({
+      ...baseBody,
+      collectionSlug: 'users',
+      update: true,
+    })
+
+    await assert.rejects(
+      () => translateEndpoint(allowAll, enabled)(req),
+      (err) => err instanceof APIError && err.status === 400,
+    )
+    assert.equal(findByIDCalls.length, 0)
+    assert.equal(updateCalls.length, 0)
+  })
+
+  test('rejects a global not enabled for translation', async () => {
+    const { req } = buildReq({
+      data: {},
+      globalSlug: 'secrets',
+      locale: 'de',
+      localeFrom: 'en',
+    })
+
+    await assert.rejects(
+      () => translateEndpoint(allowAll, enabled)(req),
+      (err) => err instanceof APIError && err.status === 400,
+    )
+  })
+
+  test('allows a collection that is enabled for translation', async () => {
+    const { req } = buildReq({ ...baseBody })
+
+    const response = await translateEndpoint(allowAll, enabled)(req)
+    const result = await response.json()
+
+    assert.equal(result.success, true)
   })
 })


### PR DESCRIPTION
## Summary

Security hardening for the content-translator translate endpoint (finding #2 from the security audit of this plugin).

The endpoint resolved the requested `collectionSlug`/`globalSlug` against the **entire** Payload config (`config.collections` / `config.globals`), not against the collections/globals the plugin was configured to translate. As a result, any authenticated user could translate — and thus send to the external translation resolver (e.g. OpenAI) — any entity they had access to, not only the opt-in set the admin enabled.

Reads and writes already run with `overrideAccess: false` (per-request access control landed in #175), so this was no longer a privilege-escalation vector on its own, but it left a hardening gap: content from non-enabled entities could still leave through the endpoint.

## Change

- Pass the plugin-configured `collections` and `globals` into `translateEndpoint`.
- Reject any request whose target entity is outside that set with a `400`, **before** any document is read, written, or sent to the resolver. `globalSlug` takes precedence, matching the operation's `isGlobal = !!globalSlug`. Fails closed.

## Tests

Added to `test/translateEndpoint.test.ts` (failing-first, per the repo's TDD guideline). The mock config now includes a `users` collection and a `secrets` global that exist and are readable but are **not** enabled for translation:

- rejects a collection not enabled for translation, before reading or writing (asserts no `findByID`/`update` calls)
- rejects a global not enabled for translation
- still allows a collection that is enabled

All 53 tests pass; `tsc` and `eslint` are clean.

## Changelog

Added an `## Unreleased` entry in `content-translator/CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Byip6Nj6N62rUzkYJiJswm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Byip6Nj6N62rUzkYJiJswm)_