### PR TITLE
feat(alt-text): add mistral resolver

### DIFF
--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+
+- feat: add `mistralResolver`, a resolver for Mistral's vision models (default `mistral-medium-latest`). It downloads the image and sends the bytes instead of passing the thumbnail URL to the provider: Mistral's fetcher requires a publicly reachable file — never true in local development, not true for private buckets — and some hosts refuse it with `File could not be fetched from url` (error 3310). All requested locales are generated in a single request.
+
 ## 0.9.1
 
 - fix: also export `getAltTextHealth` from the package root. Importing it from `/server` pulled the admin widget's `@payloadcms/ui` styles into the config graph and crashed `payload generate:*` (`ERR_UNKNOWN_FILE_EXTENSION`); import it from the package root in code loaded outside a bundler (custom endpoints, MCP tools).

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -6,7 +6,7 @@ A [Payload CMS](https://payloadcms.com/) plugin that adds AI-powered alt text ge
 
 - Generate alt text for images using AI in the Payload Admin UI
 - Supports any AI provider using a resolver pattern (e.g., OpenAI, Anthropic, etc.)
-- Comes with a ready-to-use OpenAI resolver out of the box
+- Comes with ready-to-use OpenAI and Mistral resolvers out of the box
 - Automatic keyword extraction for improved admin search
 - Bulk generation for processing multiple images at once
 - Full localization support
@@ -173,6 +173,28 @@ openAIResolver({
   model: 'gpt-4.1-mini', // or 'gpt-4.1-nano' (default)
 })
 ```
+
+#### Mistral Resolver
+
+```ts
+import { mistralResolver } from '@jhb.software/payload-alt-text-plugin'
+
+mistralResolver({
+  apiKey: process.env.MISTRAL_API_KEY,
+  model: 'mistral-medium-latest', // default; any vision-capable Mistral model works
+})
+```
+
+Unlike the OpenAI resolver, this one downloads the image and sends the bytes
+rather than handing Mistral the thumbnail URL. Mistral's own fetcher needs the
+file to be reachable from the public internet, which is never the case in local
+development and not the case for private buckets; some hosts also refuse it
+outright (`File could not be fetched from url`, error 3310). Sending the bytes
+costs one extra download and removes that whole class of failure.
+
+Because there is no image conversion step, `supportedMimeTypes` is limited to
+what the Mistral API accepts directly: JPEG, PNG, GIF and WebP. Documents in
+other formats — SVG or AVIF, for instance — keep their generate button disabled.
 
 ## Custom Resolver
 

--- a/alt-text/dev/src/payload.config.ts
+++ b/alt-text/dev/src/payload.config.ts
@@ -1,4 +1,5 @@
 import {
+  mistralResolver,
   openAIResolver,
   payloadAltTextPlugin,
   validateAltText,
@@ -76,10 +77,17 @@ export default buildConfig({
           },
         },
       ],
-      resolver: openAIResolver({
-        apiKey: process.env.OPENAI_API_KEY!,
-        model: 'gpt-4.1-mini',
-      }),
+      // Set MISTRAL_API_KEY to exercise the Mistral resolver, which sends the
+      // image bytes as a data URI instead of handing the provider a URL.
+      resolver: process.env.MISTRAL_API_KEY
+        ? mistralResolver({
+            apiKey: process.env.MISTRAL_API_KEY,
+            model: 'mistral-medium-latest',
+          })
+        : openAIResolver({
+            apiKey: process.env.OPENAI_API_KEY!,
+            model: 'gpt-4.1-mini',
+          }),
       // Cap how many images a single bulk-generate request may process.
       // Selecting more than this in the list view returns a 400 instead of
       // fanning out into an unbounded number of paid resolver calls.

--- a/alt-text/src/index.ts
+++ b/alt-text/src/index.ts
@@ -1,4 +1,6 @@
 export { payloadAltTextPlugin } from './plugin.js'
+export { mistralResolver } from './resolvers/mistral.js'
+export type { MistralResolverConfig } from './resolvers/mistral.js'
 export { openAIResolver } from './resolvers/openAI.js'
 export * from './resolvers/types.js'
 export type {

--- a/alt-text/src/resolvers/mistral.ts
+++ b/alt-text/src/resolvers/mistral.ts
@@ -1,0 +1,331 @@
+import { z } from 'zod'
+
+import type {
+  AltTextBulkResolverArgs,
+  AltTextBulkResolverResponse,
+  AltTextResolver,
+  AltTextResolverArgs,
+  AltTextResolverResponse,
+  AltTextResult,
+} from './types.js'
+
+export type MistralResolverConfig = {
+  /** Mistral API key for authentication */
+  apiKey: string
+  /**
+   * Base URL of the Mistral API.
+   * @default 'https://api.mistral.ai/v1'
+   */
+  baseUrl?: string
+  /**
+   * The vision-capable Mistral model to use for alt text generation.
+   *
+   * Must be able to read images — `mistral-medium-latest`,
+   * `mistral-large-latest`, `mistral-small-latest` and the `ministral-*` models
+   * all are.
+   *
+   * @default 'mistral-medium-latest'
+   */
+  model?: string
+  /**
+   * Abort after this many milliseconds. Covers downloading the image and the
+   * completion call together.
+   * @default 30000
+   */
+  timeoutMs?: number
+}
+
+/**
+ * Image formats the Mistral API accepts.
+ *
+ * Narrower than what an upload collection may hold — SVG and AVIF are missing,
+ * so the endpoint rejects those documents and their generate button stays
+ * disabled instead of failing at the provider.
+ */
+const SUPPORTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+
+/** Mistral rejects images above 20 MB. */
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024
+
+const altTextSchema = z.object({
+  altText: z.string().describe('A concise, descriptive alt text for the image'),
+  keywords: z.array(z.string()).describe('Keywords that describe the content of the image'),
+})
+
+/** One schema entry per requested locale, so the model must answer for all of them. */
+const schemaForLocales = (locales: string[]) =>
+  z.object(Object.fromEntries(locales.map((locale) => [locale, altTextSchema])))
+
+/**
+ * Downloads the image and returns it as a data URI.
+ *
+ * Mistral can fetch an image URL itself, but that path is not dependable for a
+ * CMS. It requires the file to be reachable from the public internet — never
+ * true in local development, and not true for private buckets — and some hosts
+ * refuse Mistral's fetcher outright, which surfaces as `File could not be
+ * fetched from url` (error 3310). Sending the bytes removes that whole class of
+ * failure for the price of one extra download.
+ */
+async function fetchImageAsDataUri(
+  url: string,
+  signal: AbortSignal,
+): Promise<{ dataUri: string } | { error: string }> {
+  let response: Response
+
+  try {
+    response = await fetch(url, { signal })
+  } catch (error) {
+    return {
+      error: `Could not download the image from ${url}: ${error instanceof Error ? error.message : 'unknown error'}`,
+    }
+  }
+
+  if (!response.ok) {
+    return { error: `Could not download the image from ${url}: status ${response.status}` }
+  }
+
+  // The document's mime type is checked by the endpoint before the resolver
+  // runs, but `getImageThumbnail` may point at a derivative in a different
+  // format, so trust what was actually served.
+  const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase()
+
+  if (!contentType || !SUPPORTED_MIME_TYPES.includes(contentType)) {
+    return {
+      error: `The image at ${url} was served as "${contentType ?? 'an unknown type'}", which Mistral cannot read. Supported types: ${SUPPORTED_MIME_TYPES.join(', ')}.`,
+    }
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer())
+
+  if (bytes.byteLength === 0) {
+    return { error: `The image at ${url} was empty.` }
+  }
+
+  if (bytes.byteLength > MAX_IMAGE_BYTES) {
+    return {
+      error: `The image at ${url} is ${Math.round(bytes.byteLength / 1024 / 1024)} MB, above Mistral's 20 MB limit. Point getImageThumbnail at a smaller image size.`,
+    }
+  }
+
+  return { dataUri: `data:${contentType};base64,${bytes.toString('base64')}` }
+}
+
+function buildPrompt(locales: string[]): string {
+  const languages = locales.join(', ')
+
+  return `
+      You are an expert at analyzing images and creating descriptive image alt text.
+
+      Please analyze the given image and provide the following in ${languages}:
+      - A concise, descriptive alt text (1-2 sentences) as "altText". Focus on the subject, action, and setting. Avoid phrases like 'Image of', 'A picture of', or 'Photo showing'. Be specific and include relevant details like location or context if visible. Make no assumptions.
+      - A list of keywords that describe the content (e.g., ["Camel", "Palm trees", "Desert"]) as "keywords"
+
+      If a context is provided, use it to enhance the alt text.
+
+      Format your response as a JSON object with ${locales.map((locale) => `"${locale}"`).join(', ')} keys, each containing "altText" and "keywords".
+    `
+}
+
+/**
+ * Reads the model's response.
+ *
+ * Deliberately strict about a blank `altText`: the field is required on the
+ * collection, so an empty string would satisfy that requirement while telling a
+ * screen reader nothing — and nobody looks at an alt text again once it is set.
+ */
+function parseResults(content: unknown, locales: string[]): null | Record<string, AltTextResult> {
+  const parsed = schemaForLocales(locales).safeParse(content)
+
+  if (!parsed.success) {
+    return null
+  }
+
+  const results: Record<string, AltTextResult> = {}
+
+  for (const locale of locales) {
+    const entry = parsed.data[locale]
+
+    if (entry.altText.trim().length === 0) {
+      return null
+    }
+
+    results[locale] = { altText: entry.altText.trim(), keywords: entry.keywords }
+  }
+
+  return results
+}
+
+/**
+ * One request, one or more locales.
+ *
+ * All locales go into a single call rather than one call each: the image is
+ * uploaded and analyzed once — the expensive part — and every language ends up
+ * describing the same reading of it.
+ */
+async function generate({
+  apiKey,
+  baseUrl,
+  filename,
+  imageThumbnailUrl,
+  locales,
+  model,
+  timeoutMs,
+}: {
+  apiKey: string
+  baseUrl: string
+  filename?: string
+  imageThumbnailUrl: string
+  locales: string[]
+  model: string
+  timeoutMs: number
+}): Promise<
+  { error: string; success: false } | { results: Record<string, AltTextResult>; success: true }
+> {
+  if (!apiKey) {
+    return { error: 'No Mistral API key configured', success: false }
+  }
+
+  if (locales.length === 0) {
+    return { error: 'No locale requested', success: false }
+  }
+
+  const signal = AbortSignal.timeout(timeoutMs)
+  const image = await fetchImageAsDataUri(imageThumbnailUrl, signal)
+
+  if ('error' in image) {
+    return { error: image.error, success: false }
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      body: JSON.stringify({
+        max_tokens: 150 * locales.length,
+        messages: [
+          { content: buildPrompt(locales), role: 'system' },
+          {
+            content: [
+              { type: 'image_url', image_url: image.dataUri },
+              ...(filename ? [{ type: 'text', text: filename }] : []),
+            ],
+            role: 'user',
+          },
+        ],
+        model,
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'data',
+            schema: z.toJSONSchema(schemaForLocales(locales), { target: 'draft-7' }),
+            strict: true,
+          },
+        },
+      }),
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      method: 'POST',
+      signal,
+    })
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '')
+
+      return {
+        error: `Mistral responded with status ${response.status}${body ? `: ${body}` : ''}`,
+        success: false,
+      }
+    }
+
+    const completion = (await response.json()) as {
+      choices?: { message?: { content?: unknown } }[]
+    }
+    const content = completion.choices?.[0]?.message?.content
+
+    if (typeof content !== 'string') {
+      return { error: 'No result from Mistral', success: false }
+    }
+
+    const results = parseResults(JSON.parse(content), locales)
+
+    if (!results) {
+      return {
+        error: `Mistral did not return a usable alt text for every requested locale (${locales.join(', ')})`,
+        success: false,
+      }
+    }
+
+    return { results, success: true }
+  } catch (error) {
+    console.error('Error generating alt text:', error)
+
+    return { error: error instanceof Error ? error.message : 'Unknown error', success: false }
+  }
+}
+
+/**
+ * Creates a Mistral-based resolver for alt text generation.
+ *
+ * @example
+ * ```typescript
+ * import { mistralResolver } from '@jhb.software/payload-alt-text-plugin'
+ *
+ * mistralResolver({
+ *   apiKey: process.env.MISTRAL_API_KEY,
+ *   model: 'mistral-medium-latest', // optional, this is the default
+ * })
+ * ```
+ */
+export const mistralResolver = (config: MistralResolverConfig): AltTextResolver => {
+  const {
+    apiKey,
+    baseUrl = 'https://api.mistral.ai/v1',
+    model = 'mistral-medium-latest',
+    timeoutMs = 30_000,
+  } = config
+
+  return {
+    key: 'mistral',
+    resolve: async ({
+      filename,
+      imageThumbnailUrl,
+      locale,
+    }: AltTextResolverArgs): Promise<AltTextResolverResponse> => {
+      const result = await generate({
+        apiKey,
+        baseUrl,
+        filename,
+        imageThumbnailUrl,
+        locales: [locale],
+        model,
+        timeoutMs,
+      })
+
+      if (!result.success) {
+        return { error: result.error, success: false }
+      }
+
+      return { result: result.results[locale], success: true }
+    },
+    resolveBulk: async ({
+      filename,
+      imageThumbnailUrl,
+      locales,
+    }: AltTextBulkResolverArgs): Promise<AltTextBulkResolverResponse> => {
+      const result = await generate({
+        apiKey,
+        baseUrl,
+        filename,
+        imageThumbnailUrl,
+        locales,
+        model,
+        timeoutMs,
+      })
+
+      if (!result.success) {
+        return { error: result.error, success: false }
+      }
+
+      return { results: result.results, success: true }
+    },
+    // https://docs.mistral.ai/capabilities/vision/
+    supportedMimeTypes: SUPPORTED_MIME_TYPES,
+  }
+}

--- a/alt-text/test/mistralResolver.test.ts
+++ b/alt-text/test/mistralResolver.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict'
+
+import { afterEach, describe, test } from 'vitest'
+
+import type { PayloadRequest } from 'payload'
+
+import { mistralResolver } from '../src/resolvers/mistral.ts'
+
+/**
+ * The Mistral resolver differs from the OpenAI one in a way that is easy to
+ * regress: it downloads the image and sends the bytes instead of handing the
+ * provider a URL. That is not a preference. Mistral's own fetcher needs the file
+ * to be reachable from the public internet — never true in local development,
+ * not true for private buckets — and some hosts refuse it outright with
+ * `File could not be fetched from url` (error 3310). Switching back to a URL
+ * would leave those setups generating nothing, with the failure only visible in
+ * a provider error message.
+ *
+ * The other behaviors pinned here concern what may reach the document: the alt
+ * text field is required on the collection, so a blank or partial result would
+ * satisfy that requirement while telling a screen reader nothing — and nobody
+ * reads an alt text again once it is set.
+ */
+
+const IMAGE_URL = 'https://example.test/photo-600x400.jpg'
+const PIXEL = Buffer.from('89504e470d0a1a0a', 'hex')
+
+type Recorded = { body: Record<string, unknown>; url: string }
+
+/**
+ * Replaces global fetch with a stub that serves the image first and the
+ * completion second, recording every request so a test can assert what was
+ * actually sent to the provider.
+ */
+function stubFetch(options: {
+  completion?: unknown
+  contentType?: string
+  imageStatus?: number
+  status?: number
+}): Recorded[] {
+  const recorded: Recorded[] = []
+  const { completion, contentType = 'image/jpeg', imageStatus = 200, status = 200 } = options
+  let call = 0
+
+  globalThis.fetch = (async (url: string, init?: { body?: string }) => {
+    call += 1
+
+    if (call === 1) {
+      return {
+        arrayBuffer: async () => PIXEL.buffer.slice(PIXEL.byteOffset, PIXEL.byteOffset + PIXEL.byteLength),
+        headers: { get: (name: string) => (name === 'content-type' ? contentType : null) },
+        ok: imageStatus === 200,
+        status: imageStatus,
+      }
+    }
+
+    recorded.push({ body: JSON.parse(init?.body ?? '{}'), url })
+
+    return {
+      json: async () => ({ choices: [{ message: { content: JSON.stringify(completion) } }] }),
+      ok: status === 200,
+      status,
+      text: async () => 'error body',
+    }
+  }) as unknown as typeof fetch
+
+  return recorded
+}
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const req = { payload: { logger: console } } as unknown as PayloadRequest
+
+const threeLocales = {
+  de: { altText: 'Ein Kamel vor Palmen.', keywords: ['Kamel', 'Palmen'] },
+  en: { altText: 'A camel in front of palm trees.', keywords: ['camel', 'palm trees'] },
+  fr: { altText: 'Un chameau devant des palmiers.', keywords: ['chameau', 'palmiers'] },
+}
+
+describe('mistral resolver', () => {
+  test('sends the image bytes to the provider instead of the URL', async () => {
+    const recorded = stubFetch({ completion: { en: threeLocales.en } })
+
+    await mistralResolver({ apiKey: 'key' }).resolve({ imageThumbnailUrl: IMAGE_URL, locale: 'en', req })
+
+    const content = (recorded[0]!.body.messages as { content: { image_url?: string }[] }[])[1]!
+      .content
+
+    assert.match(content[0]!.image_url!, /^data:image\/jpeg;base64,/)
+    assert.doesNotMatch(content[0]!.image_url!, /example\.test/)
+  })
+
+  test('asks for every locale in a single request', async () => {
+    const recorded = stubFetch({ completion: threeLocales })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolveBulk({
+      imageThumbnailUrl: IMAGE_URL,
+      locales: ['de', 'en', 'fr'],
+      req,
+    })
+
+    assert.equal(recorded.length, 1)
+    assert.deepEqual(
+      (recorded[0]!.body.response_format as { json_schema: { schema: { required: string[] } } })
+        .json_schema.schema.required,
+      ['de', 'en', 'fr'],
+    )
+    assert.equal(result.success, true)
+    assert.deepEqual(Object.keys(result.success ? result.results : {}), ['de', 'en', 'fr'])
+  })
+
+  test('rejects a response that is missing one of the requested locales', async () => {
+    stubFetch({ completion: { de: threeLocales.de, en: threeLocales.en } })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolveBulk({
+      imageThumbnailUrl: IMAGE_URL,
+      locales: ['de', 'en', 'fr'],
+      req,
+    })
+
+    assert.equal(result.success, false)
+  })
+
+  test('rejects a blank alt text rather than writing it to the document', async () => {
+    stubFetch({ completion: { en: { altText: '   ', keywords: ['camel'] } } })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+  })
+
+  test('reports the format when the thumbnail is served as something Mistral cannot read', async () => {
+    // An upload collection may hold SVG or AVIF, and `getImageThumbnail` falls
+    // back to the original when no derivative exists. Naming the format beats a
+    // provider-side error that says nothing about which file was at fault.
+    const recorded = stubFetch({ completion: {}, contentType: 'image/svg+xml' })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.match(result.success ? '' : (result.error ?? ''), /svg/)
+    assert.equal(recorded.length, 0, 'the provider must not be called for an unreadable format')
+  })
+
+  test('reports a missing API key instead of throwing when the resolver is built', async () => {
+    // The README wires `enabled: !!process.env.MISTRAL_API_KEY` alongside
+    // `resolver: mistralResolver({ apiKey: process.env.MISTRAL_API_KEY! })`.
+    // The resolver argument is evaluated even when the plugin is disabled, so
+    // constructing it without a key must not break the Payload config.
+    const recorded = stubFetch({ completion: {} })
+
+    const result = await mistralResolver({ apiKey: '' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.equal(recorded.length, 0)
+  })
+})


### PR DESCRIPTION
Adds a resolver for Mistral's vision models, alongside the existing OpenAI one.

No new dependencies — it uses global `fetch` and the `zod` the package already
depends on.

```ts
import { payloadAltTextPlugin, mistralResolver } from '@jhb.software/payload-alt-text-plugin'

payloadAltTextPlugin({
  collections: ['media'],
  resolver: mistralResolver({ apiKey: process.env.MISTRAL_API_KEY }),
  getImageThumbnail: (doc) => doc.url,
})
```

## Why not just `openAIResolver` with `baseUrl`

That was my first attempt, since Mistral is broadly OpenAI-compatible and 0.7.0
added `baseUrl` for exactly this. It does not hold up:

- `openAIResolver` passes `imageThumbnailUrl` to the provider and lets it fetch
  the file. Mistral's fetcher needs the image reachable from the public
  internet — never true in local development, and not true for private buckets.
- Even for public URLs it is unreliable. Testing the same request against
  several hosts, `raw.githubusercontent.com` and `upload.wikimedia.org` both
  failed with `File could not be fetched from url` (error 3310), while
  `picsum.photos` and `httpbin.org` succeeded. From a plugin user's side that
  looks like the generate button randomly not working, depending on where their
  media is served from.

So this resolver downloads the image and sends the bytes as a data URI. That
costs one extra request per generation and removes the whole class of failure.

## Trade-off

Without a conversion step the resolver can only accept what the API takes
directly, so `supportedMimeTypes` is JPEG, PNG, GIF and WebP. SVG and AVIF
documents keep their generate button disabled rather than failing at the
provider. `fetchImageAsDataUri` also checks the served `content-type` and names
the offending format in the error, since `getImageThumbnail` falls back to the
original file when no derivative exists.

I kept the prompt wording identical to `openAI.ts` so both resolvers produce
comparable output.

## Bulk behavior

`resolveBulk` puts every requested locale into one request. The image is
uploaded and analyzed once — the expensive part — and each language ends up
describing the same reading of it. The JSON schema requires a key per locale, so
a partial answer is rejected rather than silently leaving a locale empty.

## Tests

Six tests in `test/mistralResolver.test.ts`, network stubbed. Each one pins a
behavior that would otherwise regress silently:

- the image bytes are sent, not the URL (the reason this resolver exists)
- all locales are requested in a single call
- a response missing a locale is rejected
- a blank `altText` is rejected — the field is required on the collection, so an
  empty string would satisfy that while telling a screen reader nothing
- an unreadable `content-type` is reported by name and never reaches the API
- a missing API key reports an error instead of throwing

I mutation-checked the two load-bearing ones: swapping the data URI back to the
URL fails exactly the first test, and removing the blank-text guard fails
exactly the fourth.

Also verified end to end against the live API — single-locale and three-locale
generation both return usable results, and the zod-derived JSON schema is
accepted in strict mode.

`pnpm test`, `pnpm typecheck`, `pnpm lint` and `pnpm format` are clean in
`alt-text/`.

I added a `## 0.10.0` changelog heading per the release process in CLAUDE.md and
left `package.json` untouched. Happy to retarget that heading if you'd rather
land it in a different release.
