### PR TITLE
docs(pages): recommend a faster kv adapter for the path cache

### DIFF
--- a/pages/README.md
+++ b/pages/README.md
@@ -258,6 +258,17 @@ The plugin's [`baseFilter`](#multi-tenant-support) is applied to the lookup auto
 
 Resolving a path requires scanning the page collections for documents whose slug matches the last path segment and comparing their computed paths. To avoid this scan on repeated lookups, `findPageByPath` caches successful path→document-id resolutions in [Payload's KV store](https://payloadcms.com/docs/kv-store/overview) (`payload.kv`). A cache hit replaces the scan with a single fetch by id.
 
+Note that the KV store's default adapter (`databaseKVAdapter`) stores its entries in a `payload-kv` collection, so reading the cache is itself a database round trip — a hit saves the scan, but not the trip to the database. Frontends which resolve a path on every request should configure a faster adapter through the `kv` option of the Payload config, e.g. `redisKVAdapter` from `@payloadcms/kv-redis`, or `inMemoryKVAdapter` from `payload` for a single long-lived process:
+
+```ts
+import { redisKVAdapter } from '@payloadcms/kv-redis'
+
+export default buildConfig({
+  // ...
+  kv: redisKVAdapter({ redisURL: process.env.REDIS_URL }),
+})
+```
+
 The cache never requires manual invalidation: every cached mapping is verified against the requested path on read. If the page was renamed, moved, unpublished or deleted in the meantime, the stale entry is deleted and the lookup transparently falls back to the scan.
 
 Draft and published lookups (`draft: true`) are cached under separate keys, so an unpublished change never leaks into a published lookup and vice versa. Because the cache only maps a path to a document id and the document is re-fetched on every lookup, draft content changes are always reflected without invalidating the cached path — so a preview that re-renders on every edit still benefits from the cache as long as the page's path stays the same.


### PR DESCRIPTION
## Summary

The `findPageByPath` path cache stores its entries in Payload's KV store (`payload.kv`). Payload's default KV adapter (`databaseKVAdapter`) keeps those entries in a `payload-kv` collection, so every cache read is itself a database round trip — a hit avoids the collection scan, but still pays full DB latency. That cost is invisible from the current docs, which describe a hit as "a single fetch by id".

This adds a short paragraph to the **Path lookup caching** section of `pages/README.md` pointing out the default adapter's cost and recommending a faster adapter for frontends that resolve a path on every request.

## Verification of the referenced APIs

All names in the new text were checked against the published packages rather than assumed:

- `kv` is a real config option — `kv?: KVAdapterResult` in payload's `Config` type.
- `databaseKVAdapter` is genuinely the default — `config.kv = config.kv ?? databaseKVAdapter()` in payload's config defaults, and it registers a `payload-kv` collection.
- `inMemoryKVAdapter` is exported from `payload` itself (`export * from './kv/adapters/InMemoryKVAdapter.js'`).
- `@payloadcms/kv-redis` exists on npm (published in lockstep with payload) and exports `redisKVAdapter(options)` with a `redisURL` option defaulting to `process.env.REDIS_URL`.

## Notes

- Docs-only change — no `CHANGELOG.md` entry, per the repo convention that only `fix`/`feat` earn one.
- `prettier --check pages/README.md` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8cpPcWPRYLM2Acw1S2H69)_