### PR TITLE
perf(pages): scan page collections in parallel in findPageByPath

### DIFF
--- a/pages/src/queries/findPageByPath.ts
+++ b/pages/src/queries/findPageByPath.ts
@@ -186,7 +186,8 @@ export async function findPageByPath<TDoc extends PageDocument = PageDocument>(
     }
   }
 
-  for (const collection of candidates) {
+  /** Queries a single collection for the documents whose slug matches the last path segment. */
+  const scanCollection = async (collection: PageCollectionConfig): Promise<PageDocument[]> => {
     const result = await payload.find({
       collection: collection.slug,
       depth: 0,
@@ -199,8 +200,31 @@ export async function findPageByPath<TDoc extends PageDocument = PageDocument>(
       where: buildWhere({ slug: { equals: slug } }, collection),
     })
 
+    return result.docs
+  }
+
+  // Scanning the collections concurrently turns the per-collection round-trip latency into a
+  // single wait instead of one wait per collection, which dominates lookups that match late or
+  // not at all (a 404 scans every collection).
+  //
+  // A read operation does not open a transaction on its own, but when the caller's `req` already
+  // carries one (e.g. a lookup from within an `afterChange` hook) every query runs on that single
+  // database session: MongoDB forbids concurrent operations on one session and Postgres
+  // serializes them on one connection, so the scans must stay sequential in that case.
+  // `transactionID` holds a promise while the transaction is still being created, so a truthiness
+  // check covers both states — the same guard payload's own `initTransaction` applies.
+  //
+  // A rejected scan rejects the whole lookup, matching the sequential scan's error behavior.
+  const scans = args.req?.transactionID
+    ? undefined
+    : await Promise.all(candidates.map((collection) => scanCollection(collection)))
+
+  for (const [index, collection] of candidates.entries()) {
+    // Without concurrent scans, each collection is only queried until one of them matches.
+    const docs = scans?.[index] ?? (await scanCollection(collection))
+
     // The slug only matches the last path segment, so verify the full path.
-    const match = (result.docs as PageDocument[]).find((doc) => doc.path === path)
+    const match = docs.find((doc) => doc.path === path)
     if (!match) {
       continue
     }


### PR DESCRIPTION
## Summary

When the KV cache does not resolve a lookup, `findPageByPath` falls back to a lean scan (`select: { slug, path }`, `depth: 0`) across all page collections. That scan ran one sequential `payload.find` per collection, so the database round-trip latency added up per collection. It is worst for lookups that do not resolve at all — a 404 (bot traffic, dead links) always scans every collection, so with 5 page collections and ~8ms round-trip latency that is ~40ms of pure sequential waiting.

The per-collection scans now run concurrently via `Promise.all`, and the results are evaluated in the original `candidates` order. The candidate order is load-bearing (for short paths, root collections are sorted first), so evaluating in order keeps the resolved document identical to the sequential loop's. The number of queries is unchanged; only the waiting overlaps. The follow-up `fetchDocument` for the winning match, the cache logic, and the rest of the file are untouched.

**Transaction safety**: a read operation does not open a transaction on its own, but when the caller's `req` already carries one (e.g. a lookup from within an `afterChange` hook) every query runs on that single database session — MongoDB forbids concurrent operations on one session and Postgres serializes them on one connection. When `req.transactionID` is set, the scan therefore falls back to the original sequential loop, which also keeps its early exit so no extra queries are issued inside a transaction. `transactionID` holds a promise while the transaction is still being created, so the guard is a truthiness check — the same guard payload's own `initTransaction` applies.

Error semantics are preserved in the sense that matters: a rejected scan rejects the whole lookup rather than being swallowed.

No changelog entry — per the repo conventions only `fix` and `feat` earn one, and this is a `perf` change with no user-visible behavior change.

## Verification

Run from `pages/dev` against sqlite:

- `vitest run findPageByPath` — 25/25 pass (covers cache hit / miss / stale, draft and 404 lookups)
- `vitest run plugin` — 64/64 pass
- `pages/dev_multi_tenant`: `vitest run` — 9/9 pass (covers the `baseFilter`-scoped path lookup)
- `pnpm exec tsc --noEmit`, `eslint ./src` and `prettier --check` are clean

Opt-in benchmark (`RUN_PERF_BENCH=1`, instrumented adapter at 8ms simulated latency), scenario `findPageByPath /de/does/not/exist (404)`:

| | DB ops | wall time |
| --- | --- | --- |
| before | 6 | 53ms |
| after | 6 | 20ms |

Identical query count, ~2.6x lower wall time. The benchmark file is not part of this branch and is not committed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8cpPcWPRYLM2Acw1S2H69)_