### PR TITLE
fix(pages): strip auto-selected dependent fields from responses

### DIFF
--- a/pages/CHANGELOG.md
+++ b/pages/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: a `select` no longer returns the raw fields (`slug`, the parent field, `isRootPage` and the breadcrumb label field) which are only selected internally to compute the virtual fields — responses now contain exactly the fields the caller requested. Select such a field explicitly if a response is expected to contain it.
+
 ## 0.9.0-beta.1
 
 - feat: add `waitUntil` and `onCacheResult` arguments to `findPageByPath` — defer cache maintenance writes off the critical path (e.g. via `waitUntil` from `@vercel/functions` or Cloudflare's `ctx.waitUntil`) and observe the cache lookup status (`hit` / `stale` / `miss`)

--- a/pages/dev/plugin.test.ts
+++ b/pages/dev/plugin.test.ts
@@ -1898,6 +1898,134 @@ describe('Select during create and update operations', () => {
   })
 })
 
+describe('Select does not leak the fields the plugin needs to compute the virtual fields', () => {
+  let childPageId: DefaultIDType
+
+  beforeEach(async () => {
+    await deleteCollection('pages')
+
+    const rootPage = await payload.create({
+      collection: 'pages',
+      locale: 'de',
+      data: {
+        title: 'Root Page',
+        slug: '',
+        content: 'Root content',
+        isRootPage: true,
+        ...virtualFields,
+      },
+    })
+
+    childPageId = (
+      await payload.create({
+        collection: 'pages',
+        locale: 'de',
+        data: {
+          title: 'Child Page',
+          slug: 'child-page',
+          content: 'Child content',
+          parent: rootPage.id,
+          ...virtualFields,
+        },
+      })
+    ).id
+  })
+
+  test('findByID with select: { path: true } returns the path without the dependent raw fields', async () => {
+    const doc = await payload.findByID({
+      collection: 'pages',
+      id: childPageId,
+      locale: 'de',
+      select: {
+        path: true,
+      },
+    })
+
+    expect(doc.path).toBe('/de/child-page')
+    expect(doc).not.toHaveProperty('slug')
+    expect(doc).not.toHaveProperty('parent')
+    expect(doc).not.toHaveProperty('isRootPage')
+    expect(doc).not.toHaveProperty('title')
+  })
+
+  test('findByID keeps a dependent field which the caller selected explicitly', async () => {
+    const doc = await payload.findByID({
+      collection: 'pages',
+      id: childPageId,
+      locale: 'de',
+      select: {
+        path: true,
+        slug: true,
+      },
+    })
+
+    expect(doc.path).toBe('/de/child-page')
+    expect(doc.slug).toBe('child-page')
+    expect(doc).not.toHaveProperty('parent')
+    expect(doc).not.toHaveProperty('isRootPage')
+    expect(doc).not.toHaveProperty('title')
+  })
+
+  test('findByID with select: { slug: false } excludes the slug and still computes the virtual fields', async () => {
+    const doc = await payload.findByID({
+      collection: 'pages',
+      id: childPageId,
+      locale: 'de',
+      select: {
+        slug: false,
+      },
+    })
+
+    expect(doc).not.toHaveProperty('slug')
+    expect(doc.path).toBe('/de/child-page')
+    expect(doc.breadcrumbs).toHaveLength(2)
+    // Fields the caller did not exclude are untouched
+    expect(doc.title).toBe('Child Page')
+  })
+
+  test('find with select: { path: true } returns the path without the dependent raw fields', async () => {
+    const result = await payload.find({
+      collection: 'pages',
+      locale: 'de',
+      where: {
+        slug: { equals: 'child-page' },
+      },
+      select: {
+        path: true,
+      },
+    })
+
+    expect(result.docs).toHaveLength(1)
+    const doc = result.docs[0]
+
+    expect(doc.path).toBe('/de/child-page')
+    expect(doc).not.toHaveProperty('slug')
+    expect(doc).not.toHaveProperty('parent')
+    expect(doc).not.toHaveProperty('isRootPage')
+    expect(doc).not.toHaveProperty('title')
+  })
+
+  test('update with select: { path: true } returns the path without the dependent raw fields', async () => {
+    const doc = await payload.update({
+      collection: 'pages',
+      id: childPageId,
+      locale: 'de',
+      data: {
+        content: 'Updated content',
+      },
+      select: {
+        path: true,
+      },
+    })
+
+    expect(doc.path).toBe('/de/child-page')
+    expect(doc).not.toHaveProperty('slug')
+    expect(doc).not.toHaveProperty('parent')
+    expect(doc).not.toHaveProperty('isRootPage')
+    expect(doc).not.toHaveProperty('title')
+  })
+})
+
 describe('The afterChange hook doc and previousDoc contain the path of the page.', () => {
   beforeEach(async () => {
     // authors has a non-nullable FK to pages (SQLite/Postgres), so delete it first.

--- a/pages/src/collections/PageCollectionConfig.ts
+++ b/pages/src/collections/PageCollectionConfig.ts
@@ -18,6 +18,7 @@ import {
   setVirtualFieldsAfterChange,
   setVirtualFieldsBeforeRead,
 } from '../hooks/setVirtualFields.js'
+import { stripAutoSelectedFieldsAfterOperation } from '../hooks/stripAutoSelectedFieldsAfterOperation.js'
 
 /**
  * Creates a collection config for a page-like collection by adding:
@@ -132,6 +133,11 @@ export const createPageCollectionConfig = ({
       afterChange: [
         setVirtualFieldsAfterChange,
         ...(incomingCollectionConfig.hooks?.afterChange || []),
+      ],
+      // Runs last so that a user hook cannot reintroduce the auto-selected fields into the response
+      afterOperation: [
+        ...(incomingCollectionConfig.hooks?.afterOperation || []),
+        stripAutoSelectedFieldsAfterOperation,
       ],
       beforeChange: [
         ...(incomingCollectionConfig.hooks?.beforeChange || []),

--- a/pages/src/hooks/selectDependentFieldsBeforeOperation.ts
+++ b/pages/src/hooks/selectDependentFieldsBeforeOperation.ts
@@ -2,6 +2,7 @@ import type { CollectionBeforeOperationHook } from 'payload'
 
 import { getSelectMode } from 'payload/shared'
 
+import { recordAutoSelectedFields } from '../utils/autoSelectedFields.js'
 import { hasVirtualFieldSelected } from '../utils/hasVirtualFieldSelected.js'
 import { asPageCollectionConfigOrThrow } from '../utils/pageCollectionConfigHelpers.js'
 import { dependentFields } from './setVirtualFields.js'
@@ -10,6 +11,10 @@ import { dependentFields } from './setVirtualFields.js'
  * A CollectionBeforeOperationHook that alters the select in case a virtual field is selected
  * to ensure that the fields the setVirtualFields hook depends on to correctly generate
  * the virtual fields are also selected.
+ *
+ * Every field which is selected here on the plugin's own behalf is recorded on the operation
+ * args, so `stripAutoSelectedFieldsAfterOperation` can remove it from the response again —
+ * a caller must only receive the fields it asked for.
  */
 export const selectDependentFieldsBeforeOperation: CollectionBeforeOperationHook = ({
   args,
@@ -40,15 +45,23 @@ export const selectDependentFieldsBeforeOperation: CollectionBeforeOperationHook
     const hasVirtualFieldsSelected = hasVirtualFieldSelected(args.select)
 
     if (hasVirtualFieldsSelected && selectMode === 'include') {
+      const select = args.select
+      // Fields the caller selected itself must not be stripped from the response afterwards
+      const addedFields = dependendSelectedFields.filter((field) => !select[field])
+
       // extend the select with the dependent fields
       args.select = {
         ...args.select,
-        ...dependendSelectedFields.reduce((acc, field) => ({ ...acc, [field]: true }), {}),
+        ...addedFields.reduce((acc, field) => ({ ...acc, [field]: true }), {}),
       }
+
+      recordAutoSelectedFields(args, addedFields)
 
       // Indicate that the virtual fields should be generated in the setVirtualFields hook
       context.generateVirtualFields = true
     } else if (hasVirtualFieldsSelected && selectMode === 'exclude') {
+      const deselectedFields = dependendSelectedFields.filter((field) => field in args.select!)
+
       // remove deselection of the dependent fields
       args.select = Object.fromEntries(
         Object.entries(args.select).filter(([field]) => !dependendSelectedFields.includes(field)),
@@ -58,6 +71,8 @@ export const selectDependentFieldsBeforeOperation: CollectionBeforeOperationHook
       if (Object.keys(args.select).length === 0) {
         args.select = undefined
       }
+
+      recordAutoSelectedFields(args, deselectedFields)
 
       // Indicate that the virtual fields should be generated in the setVirtualFields hook
       context.generateVirtualFields = true

--- a/pages/src/hooks/stripAutoSelectedFieldsAfterOperation.ts
+++ b/pages/src/hooks/stripAutoSelectedFieldsAfterOperation.ts
@@ -1,0 +1,47 @@
+import type { CollectionAfterOperationHook } from 'payload'
+
+import { readAutoSelectedFields } from '../utils/autoSelectedFields.js'
+
+/**
+ * A CollectionAfterOperationHook that removes the fields which
+ * `selectDependentFieldsBeforeOperation` added to the caller's `select` from the result, so a
+ * response never contains a field the caller did not ask for.
+ *
+ * An `afterOperation` hook is used (rather than an `afterRead` hook), because it is the only
+ * point that runs after every consumer of the dependent fields:
+ * - during create/update Payload applies `select` and runs the `afterRead` hooks *before* the
+ *   `afterChange` hooks, where `setVirtualFieldsAfterChange` still needs the dependent fields
+ * - relationship population fires the `afterRead` hooks of the populated documents as part of
+ *   the surrounding operation, which must not strip fields off those documents
+ */
+export const stripAutoSelectedFieldsAfterOperation: CollectionAfterOperationHook = ({
+  args,
+  result,
+}) => {
+  const fields = readAutoSelectedFields(args)
+
+  if (!fields?.length || !result || typeof result !== 'object') {
+    return result
+  }
+
+  if ('docs' in result && Array.isArray(result.docs)) {
+    for (const doc of result.docs) {
+      stripFields(doc, fields)
+    }
+  } else {
+    stripFields(result, fields)
+  }
+
+  return result
+}
+
+/** Deletes the given fields from the document. */
+function stripFields(doc: unknown, fields: string[]): void {
+  if (!doc || typeof doc !== 'object') {
+    return
+  }
+
+  for (const field of fields) {
+    delete (doc as Record<string, unknown>)[field]
+  }
+}

--- a/pages/src/utils/autoSelectedFields.ts
+++ b/pages/src/utils/autoSelectedFields.ts
@@ -1,0 +1,20 @@
+/**
+ * Symbol under which the fields the plugin added to the caller's `select` are recorded.
+ *
+ * The record lives on the operation `args` object — which Payload hands to both the
+ * `beforeOperation` and the `afterOperation` hook of the same operation — instead of on
+ * `req.context`. Nested reads that run while an operation is in flight (relationship
+ * population above all) share the request context but carry their own args, so keying on
+ * args prevents a nested read from stripping fields off the outer response, or vice versa.
+ */
+const AUTO_SELECTED_FIELDS = Symbol('pagesPluginAutoSelectedFields')
+
+/** Records the fields which the plugin added to the caller's `select` for the given operation. */
+export function recordAutoSelectedFields(args: object, fields: string[]): void {
+  ;(args as Record<symbol, string[]>)[AUTO_SELECTED_FIELDS] = fields
+}
+
+/** Returns the fields which the plugin added to the caller's `select` for the given operation. */
+export function readAutoSelectedFields(args: object): string[] | undefined {
+  return (args as Record<symbol, string[] | undefined>)[AUTO_SELECTED_FIELDS]
+}


### PR DESCRIPTION
## The bug

To compute the virtual fields (`path`, `breadcrumbs`, `meta.alternatePaths`), `selectDependentFieldsBeforeOperation` widens the caller's `select` with the raw fields those computations depend on (`isRootPage`, `slug`, the parent field and the breadcrumb label field — see `dependentFields()`), and in exclude mode removes the caller's deselection of them.

Those fields were never removed again, so the response leaked fields the caller never asked for:

- `findByID({ select: { path: true } })` also returned `slug`, `parent`, `isRootPage` and `title`
- `find({ select: { slug: false } })` still returned `slug`

This violates Payload's `select` semantics.

## The fix

- `selectDependentFieldsBeforeOperation` now records exactly which fields it added (include mode) or un-deselected (exclude mode) — fields the caller selected itself are never recorded, so they are never stripped.
- The record is stored on the operation `args` object under a `Symbol` (`src/utils/autoSelectedFields.ts`), **not** on `req.context`. Payload hands the same `args` object to both the `beforeOperation` and the `afterOperation` hook of one operation, whereas `req.context` is shared with nested reads that run while the operation is in flight (relationship population in particular), which would cross-contaminate the record.
- A new `stripAutoSelectedFieldsAfterOperation` hook deletes those fields from the result (`result`, or each entry of `result.docs`).

### Why `afterOperation` and not `afterRead`

`afterOperation` is the only point that runs after every consumer of the dependent fields:

- during create/update Payload applies `select` and runs the `afterRead` hooks **before** the `afterChange` hooks, where `setVirtualFieldsAfterChange` still needs the dependent fields — stripping in `afterRead` would break virtual fields on mutations;
- relationship population runs the populated documents' `afterRead` hooks as part of the surrounding operation, so an `afterRead`-based strip would also strip fields off a populated parent document (covered by the existing "parent relationship field is correctly populated when using select and depth 1" tests).

The hook runs after user-defined `afterOperation` hooks so a user hook cannot reintroduce the stripped fields into the response.

### Unaffected by design

- **Internal ancestor fetches**: `getBreadcrumbs` → `findByIDCached` selects `{ breadcrumbs: true }` and reads `parent.breadcrumbs`. The widened raw fields are consumed in `beforeRead`, long before `afterOperation` strips them, so the recursion is unchanged.
- **`findPageByPath`**: the lean scan selects `slug` + `path` itself (caller-requested → kept), and `ensurePathSelected` keeps `path` in the user's select, so the returned document still carries `path`.
- **Versions/drafts**: a versions `select` is shaped `{ version: { … } }`, so no widening happens and nothing is stripped from the version wrapper.

## Tests

Five integration tests were added to `pages/dev/plugin.test.ts` (all five fail on `main`, all pass with the fix):

- `findByID` with `select: { path: true }` returns `path` but no `slug` / `parent` / `isRootPage` / `title`
- `findByID` with `select: { path: true, slug: true }` keeps the explicitly requested `slug`
- `findByID` with `select: { slug: false }` excludes `slug` while still computing `path` and `breadcrumbs`
- the list `find` variant of the first case
- `update` with `select: { path: true }` (mutation path, `setVirtualFieldsAfterChange` still works)

Full suites, all on SQLite:

| suite | result |
| --- | --- |
| `pages` unit tests | 5 passed |
| `pages/dev` | 94 passed |
| `pages/dev_unlocalized` | 18 passed |
| `pages/dev_multi_tenant` | 9 passed |

`tsc --noEmit`, `eslint ./src` and `prettier --check` are clean on the plugin and on all changed files. (`pages/dev`'s `tsc` reports the same 19 pre-existing errors before and after this change.)

## Breaking change judgement

**Not breaking.** Responses do lose fields, but only fields the plugin selected on its own behalf and that the caller never requested — the documented contract of Payload's `select` is that a response contains the selected fields. The leak was a defect, never documented behavior, and the plugin is still pre-1.0. A caller who was accidentally relying on a leaked field simply has to add it to its `select`, which the changelog entry spells out. Shipped as a plain `fix` (patch bump).

## Changelog

```
- fix: a `select` no longer returns the raw fields (`slug`, the parent field, `isRootPage` and the breadcrumb label field) which are only selected internally to compute the virtual fields — responses now contain exactly the fields the caller requested. Select such a field explicitly if a response is expected to contain it.
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01M8cpPcWPRYLM2Acw1S2H69)_