### PR TITLE
feat(admin-search)!: add baseFilter to scope search results per request

### DIFF
--- a/admin-search/CHANGELOG.md
+++ b/admin-search/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- feat: add a `baseFilter` option that restricts search results to a constraint resolved against the current request, e.g. the tenant selected in a multi-tenant admin panel
-- refactor: **BREAKING**: the header component is now a server component, so it can evaluate `baseFilter` before rendering. It moved from `@jhb.software/payload-admin-search/client#SearchWrapper` to `@jhb.software/payload-admin-search/rsc#SearchWrapper`: **run `payload generate:importmap` after upgrading**, otherwise the search component resolves to nothing and disappears from the admin header. The `/client` export now provides `SearchWrapperClient` in place of `SearchWrapper`.
+- feat: add a `baseFilter` option that restricts search results to a constraint resolved against the current request, e.g. the tenant selected in a multi-tenant admin panel. A filter that throws is logged and the search falls back to unscoped, rather than failing the admin panel's render
+- **BREAKING**: the header component is now a server component, so it can evaluate `baseFilter` before rendering. It moved from `@jhb.software/payload-admin-search/client#SearchWrapper` to `@jhb.software/payload-admin-search/rsc#SearchWrapper`: **run `payload generate:importmap` after upgrading**, otherwise the search component resolves to nothing and disappears from the admin header. The `/client` export now provides `SearchWrapperClient` in place of `SearchWrapper`.
 
 ## 0.3.0
 

--- a/admin-search/CHANGELOG.md
+++ b/admin-search/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- feat: add a `baseFilter` option that restricts search results to a constraint resolved against the current request, e.g. the tenant selected in a multi-tenant admin panel. A filter that throws is logged and the search falls back to unscoped, rather than failing the admin panel's render
+- feat: add a `baseFilter` option that restricts search results to a constraint resolved against the current request, e.g. the tenant selected in a multi-tenant admin panel. A filter that cannot be evaluated is logged and the search returns no results, rather than widening to the documents the filter was meant to hide
+- fix: the result list shown before anything is typed now honours the same five-result limit as a typed search, instead of listing ten
 - **BREAKING**: the header component is now a server component, so it can evaluate `baseFilter` before rendering. It moved from `@jhb.software/payload-admin-search/client#SearchWrapper` to `@jhb.software/payload-admin-search/rsc#SearchWrapper`: **run `payload generate:importmap` after upgrading**, otherwise the search component resolves to nothing and disappears from the admin header. The `/client` export now provides `SearchWrapperClient` in place of `SearchWrapper`.
 
 ## 0.3.0

--- a/admin-search/CHANGELOG.md
+++ b/admin-search/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-- feat: add a `baseFilter` option that restricts search results to a constraint resolved against the current request, e.g. the tenant selected in a multi-tenant admin panel. A filter that cannot be evaluated is logged and the search returns no results, rather than widening to the documents the filter was meant to hide
+- feat: add a `baseFilter` option restricting search results to a constraint resolved against the current request, e.g. the tenant selected in a multi-tenant admin panel. A filter that cannot be evaluated is logged and the search returns no results, rather than widening to the documents the filter was meant to hide
 - fix: the result list shown before anything is typed now honours the same five-result limit as a typed search, instead of listing ten
-- **BREAKING**: the header component is now a server component, so it can evaluate `baseFilter` before rendering. It moved from `@jhb.software/payload-admin-search/client#SearchWrapper` to `@jhb.software/payload-admin-search/rsc#SearchWrapper`: **run `payload generate:importmap` after upgrading**, otherwise the search component resolves to nothing and disappears from the admin header. The `/client` export now provides `SearchWrapperClient` in place of `SearchWrapper`.
+- **BREAKING**: the header component moved from `@jhb.software/payload-admin-search/client#SearchWrapper` to `@jhb.software/payload-admin-search/rsc#SearchWrapper`, and `/client` now provides `SearchWrapperClient` in its place. **Run `payload generate:importmap` after upgrading**, otherwise the search disappears from the admin header.
 
 ## 0.3.0
 

--- a/admin-search/CHANGELOG.md
+++ b/admin-search/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- feat: add a `baseFilter` option that restricts search results to a constraint resolved against the current request, e.g. the tenant selected in a multi-tenant admin panel
+- refactor: **BREAKING**: the header component is now a server component, so it can evaluate `baseFilter` before rendering. It moved from `@jhb.software/payload-admin-search/client#SearchWrapper` to `@jhb.software/payload-admin-search/rsc#SearchWrapper`: **run `payload generate:importmap` after upgrading**, otherwise the search component resolves to nothing and disappears from the admin header. The `/client` export now provides `SearchWrapperClient` in place of `SearchWrapper`.
+
 ## 0.3.0
 
 - feat: broaden Next.js peer dependency to `^15.0.0 || ^16.0.0` so the plugin can be installed alongside Next.js 16

--- a/admin-search/README.md
+++ b/admin-search/README.md
@@ -83,6 +83,47 @@ adminSearchPlugin({
 })
 ```
 
+### `baseFilter`
+
+- **Type**: `({ req }) => Where | Promise<Where>`
+- **Default**: none
+- **Description**: Restricts document results to a constraint resolved against the current request. The filter runs on the server, and its result is combined with the typed query using `and` — so results stay in scope even before anything is typed.
+
+The main use is multi-tenancy: scope the search to the tenant selected in the admin panel, whose id [@payloadcms/plugin-multi-tenant](https://payloadcms.com/docs/plugins/multi-tenant) keeps in the `payload-tenant` cookie.
+
+```ts
+import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
+
+adminSearchPlugin({
+  baseFilter: ({ req }) => {
+    const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
+
+    // Returning `{}` leaves the search unscoped. Constraining `tenant` to `null` instead
+    // would match nothing whenever no tenant is selected.
+    return tenant ? { tenant: { equals: tenant } } : {}
+  },
+})
+```
+
+The `search` collection must carry the field the filter constrains, which means adding it in `searchOverrides` and populating it in `beforeSync`:
+
+```ts
+searchPlugin({
+  searchOverrides: {
+    fields: ({ defaultFields }) => [
+      ...defaultFields,
+      { name: 'tenant', type: 'relationship', index: true, relationTo: 'tenants' },
+    ],
+  },
+  beforeSync: ({ originalDoc, searchDoc }) => ({
+    ...searchDoc,
+    tenant: originalDoc.tenant ?? null,
+  }),
+})
+```
+
+> **This scopes what the search offers, not what the API permits.** The filter narrows the query the admin UI sends; it is not access control. Anyone who can read `GET /api/search` directly still sees whatever that endpoint returns — see [Security](#security) for constraining it server-side via `searchOverrides.access.read`.
+
 ## Contributing
 
 We welcome contributions! Please open an issue to report bugs or suggest improvements, or submit a pull request with your changes.

--- a/admin-search/README.md
+++ b/admin-search/README.md
@@ -89,6 +89,8 @@ adminSearchPlugin({
 - **Default**: none
 - **Description**: Restricts document results to a constraint resolved against the current request. The filter runs on the server, and its result is combined with the typed query using `and` — so results stay in scope even before anything is typed.
 
+`req` is the request the admin panel is being rendered for, so it carries the incoming cookies, the signed-in user and the locale currently being viewed.
+
 The main use is multi-tenancy: scope the search to the tenant selected in the admin panel, whose id [@payloadcms/plugin-multi-tenant](https://payloadcms.com/docs/plugins/multi-tenant) keeps in the `payload-tenant` cookie.
 
 ```ts

--- a/admin-search/README.md
+++ b/admin-search/README.md
@@ -100,10 +100,19 @@ adminSearchPlugin({
 
     // Returning `{}` leaves the search unscoped. Constraining `tenant` to `null` instead
     // would match nothing whenever no tenant is selected.
-    return tenant ? { tenant: { equals: tenant } } : {}
+    if (!tenant) {
+      return {}
+    }
+
+    // The `exists: false` branch keeps documents that carry no tenant at all. Without it,
+    // selecting a tenant hides every indexed collection the multi-tenant plugin does not
+    // scope — shared media, authors and the like vanish from the search.
+    return { or: [{ tenant: { equals: tenant } }, { tenant: { exists: false } }] }
   },
 })
 ```
+
+Note the `or`. A filter of just `{ tenant: { equals: tenant } }` restricts results to documents that carry the selected tenant, which also removes every document that has no tenant — search indexes are usually wider than the set of tenant-scoped collections, so those documents disappear the moment a tenant is picked. Include the un-tenanted ones explicitly unless hiding them is what you want.
 
 The `search` collection must carry the field the filter constrains, which means adding it in `searchOverrides` and populating it in `beforeSync`:
 
@@ -123,6 +132,13 @@ searchPlugin({
 ```
 
 > **This scopes what the search offers, not what the API permits.** The filter narrows the query the admin UI sends; it is not access control. Anyone who can read `GET /api/search` directly still sees whatever that endpoint returns — see [Security](#security) for constraining it server-side via `searchOverrides.access.read`.
+
+Two consequences of the filter being resolved on the server and applied by the client:
+
+- The resolved constraint is serialized into the page and readable in the browser's devtools. Keep anything secret out of the `Where` it returns.
+- Only the component the plugin mounts (`@jhb.software/payload-admin-search/rsc#SearchWrapper`) resolves the filter. Mounting `@jhb.software/payload-admin-search/client#SearchWrapperClient` by hand gives an unscoped search, with no warning.
+
+If the filter throws, the error is logged and the search falls back to unscoped rather than failing the admin panel's render.
 
 ## Contributing
 

--- a/admin-search/README.md
+++ b/admin-search/README.md
@@ -140,7 +140,17 @@ Two consequences of the filter being resolved on the server and applied by the c
 - The resolved constraint is serialized into the page and readable in the browser's devtools. Keep anything secret out of the `Where` it returns.
 - Only the component the plugin mounts (`@jhb.software/payload-admin-search/rsc#SearchWrapper`) resolves the filter. Mounting `@jhb.software/payload-admin-search/client#SearchWrapperClient` by hand gives an unscoped search, with no warning.
 
-If the filter throws, the error is logged and the search falls back to unscoped rather than failing the admin panel's render.
+#### When the filter cannot be evaluated
+
+If the filter throws or rejects, the error is logged and the search returns no results at all, showing its error state. It does not fall back to an unscoped search: the whole point of the filter is to keep documents out of the list, so widening on failure would expose exactly what it was meant to hide. The admin panel itself keeps rendering — only the search is affected.
+
+#### Cost
+
+The filter is evaluated during the server render of **every admin page**, not when the search is opened: the constraint has to be on the page before the modal can query anything. There is no cheaper hook that still sees the request, so keep the filter cheap.
+
+- Reading `req.headers` cookies or `req.user` — as in the example above — costs nothing measurable.
+- A filter that queries the database adds that query to every admin page load, and because it is awaited during the render, a slow one delays the page. Cache the lookup if you need one.
+- Leaving `baseFilter` unset costs nothing: nothing is resolved and nothing is passed to the client.
 
 ## Contributing
 

--- a/admin-search/README.md
+++ b/admin-search/README.md
@@ -95,9 +95,12 @@ The main use is multi-tenancy: scope the search to the tenant selected in the ad
 
 ```ts
 import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
+import type { Where } from 'payload'
 
 adminSearchPlugin({
-  baseFilter: ({ req }) => {
+  // Annotate the return type: without it TypeScript infers a union across the branches, and
+  // `{}` widens to `{ or?: undefined }`, which `Where`'s index signature rejects.
+  baseFilter: ({ req }): Where => {
     const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
 
     // Returning `{}` leaves the search unscoped. Constraining `tenant` to `null` instead

--- a/admin-search/dev/package.json
+++ b/admin-search/dev/package.json
@@ -21,6 +21,7 @@
     "@jhb.software/payload-admin-search": "workspace:*",
     "@payloadcms/db-mongodb": "^3.88.0",
     "@payloadcms/next": "^3.88.0",
+    "@payloadcms/plugin-multi-tenant": "^3.88.0",
     "@payloadcms/plugin-search": "^3.88.0",
     "@payloadcms/richtext-lexical": "^3.88.0",
     "@payloadcms/translations": "^3.88.0",

--- a/admin-search/dev/payload-types.ts
+++ b/admin-search/dev/payload-types.ts
@@ -71,6 +71,7 @@ export interface Config {
     posts: Post;
     authors: Author;
     media: Media;
+    tenants: Tenant;
     users: User;
     search: Search;
     'payload-kv': PayloadKv;
@@ -84,6 +85,7 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     authors: AuthorsSelect<false> | AuthorsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    tenants: TenantsSelect<false> | TenantsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     search: SearchSelect<false> | SearchSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
@@ -131,6 +133,7 @@ export interface UserAuthOperations {
  */
 export interface Page {
   id: string;
+  tenant?: (string | null) | Tenant;
   title: string;
   slug: string;
   content?: {
@@ -153,10 +156,21 @@ export interface Page {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tenants".
+ */
+export interface Tenant {
+  id: string;
+  name: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "posts".
  */
 export interface Post {
   id: string;
+  tenant?: (string | null) | Tenant;
   title: string;
   slug: string;
   author: string | Author;
@@ -213,6 +227,12 @@ export interface Media {
  */
 export interface User {
   id: string;
+  tenants?:
+    | {
+        tenant: string | Tenant;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -259,6 +279,7 @@ export interface Search {
         relationTo: 'media';
         value: string | Media;
       };
+  tenant?: (string | null) | Tenant;
   updatedAt: string;
   createdAt: string;
 }
@@ -301,6 +322,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media';
         value: string | Media;
+      } | null)
+    | ({
+        relationTo: 'tenants';
+        value: string | Tenant;
       } | null)
     | ({
         relationTo: 'users';
@@ -357,6 +382,7 @@ export interface PayloadMigration {
  * via the `definition` "pages_select".
  */
 export interface PagesSelect<T extends boolean = true> {
+  tenant?: T;
   title?: T;
   slug?: T;
   content?: T;
@@ -368,6 +394,7 @@ export interface PagesSelect<T extends boolean = true> {
  * via the `definition` "posts_select".
  */
 export interface PostsSelect<T extends boolean = true> {
+  tenant?: T;
   title?: T;
   slug?: T;
   author?: T;
@@ -404,9 +431,24 @@ export interface MediaSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tenants_select".
+ */
+export interface TenantsSelect<T extends boolean = true> {
+  name?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
+  tenants?:
+    | T
+    | {
+        tenant?: T;
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   email?: T;
@@ -432,6 +474,7 @@ export interface SearchSelect<T extends boolean = true> {
   title?: T;
   priority?: T;
   doc?: T;
+  tenant?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/admin-search/dev/src/app/(payload)/admin/importMap.js
+++ b/admin-search/dev/src/app/(payload)/admin/importMap.js
@@ -1,3 +1,4 @@
+import { TenantField as TenantField_1d0591e3cf4f332c83a86da13a0de59a } from '@payloadcms/plugin-multi-tenant/client'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -21,13 +22,18 @@ import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93
 import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { AssignTenantFieldTrigger as AssignTenantFieldTrigger_1d0591e3cf4f332c83a86da13a0de59a } from '@payloadcms/plugin-multi-tenant/client'
+import { WatchTenantCollection as WatchTenantCollection_1d0591e3cf4f332c83a86da13a0de59a } from '@payloadcms/plugin-multi-tenant/client'
 import { LinkToDoc as LinkToDoc_aead06e4cbf6b2620c5c51c9ab283634 } from '@payloadcms/plugin-search/client'
 import { ReindexButton as ReindexButton_aead06e4cbf6b2620c5c51c9ab283634 } from '@payloadcms/plugin-search/client'
-import { SearchWrapper as SearchWrapper_5400ac5ea24f4363783c781edd0c24e3 } from '@jhb.software/payload-admin-search/client'
+import { SearchWrapper as SearchWrapper_4673c6559b6614751678035d06bfbc63 } from '@jhb.software/payload-admin-search/rsc'
+import { TenantSelector as TenantSelector_d6d5f193a167989e2ee7d14202901e62 } from '@payloadcms/plugin-multi-tenant/rsc'
+import { TenantSelectionProvider as TenantSelectionProvider_d6d5f193a167989e2ee7d14202901e62 } from '@payloadcms/plugin-multi-tenant/rsc'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 /** @type import('payload').ImportMap */
 export const importMap = {
+  "@payloadcms/plugin-multi-tenant/client#TenantField": TenantField_1d0591e3cf4f332c83a86da13a0de59a,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -51,8 +57,12 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/plugin-multi-tenant/client#AssignTenantFieldTrigger": AssignTenantFieldTrigger_1d0591e3cf4f332c83a86da13a0de59a,
+  "@payloadcms/plugin-multi-tenant/client#WatchTenantCollection": WatchTenantCollection_1d0591e3cf4f332c83a86da13a0de59a,
   "@payloadcms/plugin-search/client#LinkToDoc": LinkToDoc_aead06e4cbf6b2620c5c51c9ab283634,
   "@payloadcms/plugin-search/client#ReindexButton": ReindexButton_aead06e4cbf6b2620c5c51c9ab283634,
-  "@jhb.software/payload-admin-search/client#SearchWrapper": SearchWrapper_5400ac5ea24f4363783c781edd0c24e3,
+  "@jhb.software/payload-admin-search/rsc#SearchWrapper": SearchWrapper_4673c6559b6614751678035d06bfbc63,
+  "@payloadcms/plugin-multi-tenant/rsc#TenantSelector": TenantSelector_d6d5f193a167989e2ee7d14202901e62,
+  "@payloadcms/plugin-multi-tenant/rsc#TenantSelectionProvider": TenantSelectionProvider_d6d5f193a167989e2ee7d14202901e62,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/admin-search/dev/src/collections/tenants.ts
+++ b/admin-search/dev/src/collections/tenants.ts
@@ -1,0 +1,15 @@
+import type { CollectionConfig } from 'payload'
+
+export const tenantsSchema: CollectionConfig = {
+  slug: 'tenants',
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/admin-search/dev/src/payload.config.ts
+++ b/admin-search/dev/src/payload.config.ts
@@ -5,6 +5,8 @@ import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
 import { searchPlugin } from '@payloadcms/plugin-search'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import path from 'path'
+import type { Where } from 'payload'
+
 import { buildConfig } from 'payload'
 import { de } from 'payload/i18n/de'
 import { en } from 'payload/i18n/en'
@@ -80,7 +82,7 @@ export default buildConfig({
       // Restricts search results to the tenant selected in the admin panel. Switch tenants
       // in the selector and the same query returns that tenant's documents only; with no
       // tenant selected the search stays unscoped, matching what the tenant selector shows.
-      baseFilter: ({ req }) => {
+      baseFilter: ({ req }): Where => {
         const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
 
         if (!tenant) {

--- a/admin-search/dev/src/payload.config.ts
+++ b/admin-search/dev/src/payload.config.ts
@@ -1,5 +1,7 @@
 import { adminSearchPlugin } from '@jhb.software/payload-admin-search'
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import { multiTenantPlugin } from '@payloadcms/plugin-multi-tenant'
+import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
 import { searchPlugin } from '@payloadcms/plugin-search'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import path from 'path'
@@ -12,6 +14,7 @@ import { authorsSchema } from './collections/authors'
 import { mediaSchema } from './collections/media'
 import { pagesSchema } from './collections/pages'
 import { postsSchema } from './collections/posts'
+import { tenantsSchema } from './collections/tenants'
 import { seed } from './seed'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -30,6 +33,7 @@ export default buildConfig({
     postsSchema,
     authorsSchema,
     mediaSchema,
+    tenantsSchema,
     {
       slug: 'users',
       auth: true,
@@ -72,7 +76,21 @@ export default buildConfig({
   },
 
   plugins: [
-    adminSearchPlugin({ headerSearchComponentStyle: 'bar' }),
+    adminSearchPlugin({
+      // Restricts search results to the tenant selected in the admin panel. Switch tenants
+      // in the selector and the same query returns that tenant's documents only; with no
+      // tenant selected the search stays unscoped, matching what the tenant selector shows.
+      baseFilter: ({ req }) => {
+        const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
+
+        return tenant ? { tenant: { equals: tenant } } : {}
+      },
+      headerSearchComponentStyle: 'bar',
+    }),
+    multiTenantPlugin({
+      collections: { pages: {}, posts: {} },
+      userHasAccessToAllTenants: () => true,
+    }),
     searchPlugin({
       // The `search` collection defaults to public read (`read: () => true`). This dev
       // app restricts it to authenticated users; set access to match your app's needs.
@@ -80,10 +98,16 @@ export default buildConfig({
         access: {
           read: ({ req }) => Boolean(req.user),
         },
+        // The base filter constrains `tenant`, so the search collection has to carry it.
+        fields: ({ defaultFields }) => [
+          ...defaultFields,
+          { name: 'tenant', type: 'relationship', index: true, relationTo: 'tenants' },
+        ],
       },
       beforeSync: ({ originalDoc, searchDoc }) => {
         return {
           ...searchDoc,
+          tenant: originalDoc.tenant ?? null,
           title:
             searchDoc.doc.relationTo === 'authors'
               ? originalDoc.name

--- a/admin-search/dev/src/payload.config.ts
+++ b/admin-search/dev/src/payload.config.ts
@@ -83,7 +83,14 @@ export default buildConfig({
       baseFilter: ({ req }) => {
         const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
 
-        return tenant ? { tenant: { equals: tenant } } : {}
+        if (!tenant) {
+          return {}
+        }
+
+        // Only `pages` and `posts` are tenant-scoped below, but `authors` and `media` are
+        // indexed too. The `exists: false` branch keeps those in the results; without it,
+        // picking a tenant makes every author and media item disappear from the search.
+        return { or: [{ tenant: { equals: tenant } }, { tenant: { exists: false } }] }
       },
       headerSearchComponentStyle: 'bar',
     }),

--- a/admin-search/dev/src/seed.ts
+++ b/admin-search/dev/src/seed.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, Payload } from 'payload'
+import type { CollectionSlug, DefaultDocumentIDType, Payload } from 'payload'
 
 import { devUser } from './helpers/credentials'
 
@@ -33,6 +33,29 @@ export const seed = async (payload: Payload) => {
       collection: 'users',
       data: devUser,
     })
+  }
+
+  // Two tenants, so the admin panel shows the tenant selector and the search plugin's
+  // baseFilter has something to scope by.
+  const tenantIds: DefaultDocumentIDType[] = []
+
+  for (const name of ['Acme', 'Globex']) {
+    const { docs: existing } = await payload.find({
+      collection: 'tenants' as CollectionSlug,
+      depth: 0,
+      where: { name: { equals: name } },
+    })
+
+    tenantIds.push(
+      existing.length
+        ? existing[0].id
+        : (
+            await payload.create({
+              collection: 'tenants' as CollectionSlug,
+              data: { name },
+            })
+          ).id,
+    )
   }
 
   const authors: AuthorSeedData[] = [
@@ -113,7 +136,8 @@ export const seed = async (payload: Payload) => {
     },
   ]
 
-  for (const pageData of pages) {
+  // Alternating tenants, so the same query returns different documents per tenant.
+  for (const [index, pageData] of pages.entries()) {
     const { totalDocs: existingPage } = await payload.count({
       collection: 'pages' as CollectionSlug,
       where: { slug: { equals: pageData.slug } },
@@ -122,7 +146,7 @@ export const seed = async (payload: Payload) => {
     if (!existingPage) {
       await payload.create({
         collection: 'pages' as CollectionSlug,
-        data: pageData,
+        data: { ...pageData, tenant: tenantIds[index % tenantIds.length] as string },
       })
     }
   }
@@ -205,7 +229,7 @@ export const seed = async (payload: Payload) => {
     },
   ]
 
-  for (const postData of posts) {
+  for (const [index, postData] of posts.entries()) {
     const { totalDocs: existingPost } = await payload.count({
       collection: 'posts' as CollectionSlug,
       where: { slug: { equals: postData.slug } },
@@ -214,7 +238,7 @@ export const seed = async (payload: Payload) => {
     if (!existingPost) {
       await payload.create({
         collection: 'posts' as CollectionSlug,
-        data: postData,
+        data: { ...postData, tenant: tenantIds[index % tenantIds.length] as string },
       })
     }
   }

--- a/admin-search/package.json
+++ b/admin-search/package.json
@@ -16,8 +16,8 @@
   "types": "./src/index.ts",
   "scripts": {
     "build": "pnpm copyfiles && pnpm build:types && pnpm build:swc",
-    "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
-    "build:types": "tsc --outDir dist --rootDir ./src",
+    "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths --ignore '**/*.test.ts,**/*.test.tsx'",
+    "build:types": "tsc --project tsconfig.build.json --outDir dist --rootDir ./src",
     "copyfiles": "copyfiles -u 1 \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist/",
     "clean": "rimraf --glob {dist,*.tsbuildinfo}",
     "dev": "tsc -w",
@@ -25,8 +25,9 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "node --experimental-strip-types --test test/*.test.ts",
-    "typecheck": "tsc --noEmit"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@payloadcms/translations": "^3.88.0"
@@ -46,9 +47,12 @@
     "@types/react-dom": "^19.2.4",
     "copyfiles": "^2.4.1",
     "eslint": "^9.39.4",
+    "payload": "^3.88.0",
     "prettier": "3.9.6",
     "rimraf": "^6.1.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.2.1",
+    "vitest": "^4.1.10"
   },
   "files": [
     "dist"
@@ -66,6 +70,11 @@
         "import": "./dist/exports/client.js",
         "types": "./dist/exports/client.d.ts",
         "default": "./dist/exports/client.js"
+      },
+      "./rsc": {
+        "import": "./dist/exports/rsc.js",
+        "types": "./dist/exports/rsc.d.ts",
+        "default": "./dist/exports/rsc.js"
       }
     }
   },
@@ -79,6 +88,11 @@
       "import": "./src/exports/client.ts",
       "types": "./src/exports/client.ts",
       "default": "./src/exports/client.ts"
+    },
+    "./rsc": {
+      "import": "./src/exports/rsc.ts",
+      "types": "./src/exports/rsc.ts",
+      "default": "./src/exports/rsc.ts"
     }
   },
   "engines": {

--- a/admin-search/pnpm-lock.yaml
+++ b/admin-search/pnpm-lock.yaml
@@ -30,13 +30,10 @@ importers:
         version: 3.88.0
       '@payloadcms/ui':
         specifier: ^3.88.0
-        version: 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       next:
         specifier: 16.3.0
-        version: 16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
-      payload:
-        specifier: ^3.88.0
-        version: 3.88.0(graphql@16.12.0)(typescript@6.0.3)
+        version: 16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -65,6 +62,9 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4
+      payload:
+        specifier: ^3.88.0
+        version: 3.88.0(graphql@16.12.0)(typescript@6.0.3)
       prettier:
         specifier: 3.9.6
         version: 3.9.6
@@ -74,6 +74,12 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.77.4)(tsx@4.23.12)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.2.0)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.77.4)(tsx@4.23.12))
 
   dev:
     dependencies:
@@ -85,22 +91,25 @@ importers:
         version: 3.88.0(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))
       '@payloadcms/next':
         specifier: ^3.88.0
-        version: 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@payloadcms/plugin-multi-tenant':
+        specifier: ^3.88.0
+        version: 3.88.0(@payloadcms/ui@3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))
       '@payloadcms/plugin-search':
         specifier: ^3.88.0
-        version: 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@payloadcms/richtext-lexical':
         specifier: ^3.88.0
-        version: 3.88.0(@faceless-ui/modal@3.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@payloadcms/next@3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.27)
+        version: 3.88.0(@faceless-ui/modal@3.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@payloadcms/next@3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.27)
       '@payloadcms/translations':
         specifier: ^3.88.0
         version: 3.88.0
       '@payloadcms/ui':
         specifier: ^3.88.0
-        version: 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       next:
         specifier: 16.3.0
-        version: 16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
+        version: 16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
       payload:
         specifier: ^3.88.0
         version: 3.88.0(graphql@16.12.0)(typescript@6.0.3)
@@ -996,6 +1005,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-project/types@0.144.0':
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
+
   '@payloadcms/db-mongodb@3.88.0':
     resolution: {integrity: sha512-bjXWm7DvUQYLCTe3zJ9Pr57gEX5pQOtH+SgAhJBhh2fMYy/bE7pLf0DJG8z1E6N9Z8b1EX3kWkE1bhTYnR5Gxg==}
     peerDependencies:
@@ -1020,6 +1032,12 @@ packages:
     peerDependencies:
       graphql: ^16.8.1
       next: 16.3.0
+      payload: 3.88.0
+
+  '@payloadcms/plugin-multi-tenant@3.88.0':
+    resolution: {integrity: sha512-dykHQ3bqXYUzm1RM/1DAjgiL3DdJctTi0GKYlwvMnYVoQtsc78zOajFOQDkp9yXG3yMqvoQc48r9yxRStUe6wA==}
+    peerDependencies:
+      '@payloadcms/ui': 3.88.0
       payload: 3.88.0
 
   '@payloadcms/plugin-search@3.88.0':
@@ -1058,6 +1076,99 @@ packages:
   '@preact/signals-core@1.14.4':
     resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
 
+  '@rolldown/binding-android-arm64@1.2.4':
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -1068,6 +1179,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/cli@0.8.1':
     resolution: {integrity: sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ==}
@@ -1189,8 +1303,14 @@ packages:
   '@types/busboy@1.5.4':
     resolution: {integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
@@ -1321,6 +1441,35 @@ packages:
     resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@xhmikosr/archive-type@8.1.0':
     resolution: {integrity: sha512-EXOjEbnZFE5c/nFMf4FOrEURVanzHpnkPYmnmr78u02/8hAhE0FMq8p9TK1IM0/bFr5VcyBUY0gfLm8f7dKy+Q==}
     engines: {node: '>=20'}
@@ -1415,6 +1564,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1558,6 +1711,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1639,6 +1796,9 @@ packages:
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   copyfiles@2.4.1:
     resolution: {integrity: sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==}
@@ -1806,6 +1966,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -2025,6 +2188,9 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2039,6 +2205,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   ext-list@2.2.2:
     resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
@@ -2603,6 +2773,80 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2630,6 +2874,9 @@ packages:
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
@@ -2926,6 +3173,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -3013,6 +3264,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   payload@3.88.0:
     resolution: {integrity: sha512-O7zuS80bvEGLte+7xZjwN05+ox5BCsGcQT2M6+CTote07JQOOvHJoiuoyQFw6cUElcFTWGMC5dy03w7J7sTYGg==}
     engines: {node: ^18.20.2 || >=20.9.0}
@@ -3061,6 +3315,10 @@ packages:
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3231,6 +3489,11 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
@@ -3340,6 +3603,9 @@ packages:
   sift@17.1.3:
     resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3393,8 +3659,14 @@ packages:
   stable-hash@0.0.4:
     resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3524,9 +3796,20 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3686,6 +3969,90 @@ packages:
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
@@ -3720,6 +4087,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4654,6 +5026,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
+  '@oxc-project/types@0.144.0': {}
+
   '@payloadcms/db-mongodb@3.88.0(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))':
     dependencies:
       mongoose: 8.24.1
@@ -4743,14 +5117,14 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@payloadcms/next@3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+  '@payloadcms/next@3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@dnd-kit/modifiers': 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@payloadcms/graphql': 3.88.0(graphql@16.12.0)(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(typescript@6.0.3)
       '@payloadcms/translations': 3.88.0
-      '@payloadcms/ui': 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@payloadcms/ui': 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       busboy: 1.6.0
       dequal: 2.0.3
       file-type: 21.3.4
@@ -4758,7 +5132,7 @@ snapshots:
       graphql-http: 1.23.0(graphql@16.12.0)
       graphql-playground-html: 1.6.30
       http-status: 2.1.0
-      next: 16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
+      next: 16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
       path-to-regexp: 6.3.0
       payload: 3.88.0(graphql@16.12.0)(typescript@6.0.3)
       qs-esm: 8.0.1
@@ -4772,10 +5146,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@payloadcms/plugin-search@3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+  '@payloadcms/plugin-multi-tenant@3.88.0(@payloadcms/ui@3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))':
     dependencies:
-      '@payloadcms/next': 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
-      '@payloadcms/ui': 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@payloadcms/ui': 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      payload: 3.88.0(graphql@16.12.0)(typescript@6.0.3)
+
+  '@payloadcms/plugin-search@3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+    dependencies:
+      '@payloadcms/next': 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@payloadcms/ui': 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       payload: 3.88.0(graphql@16.12.0)(typescript@6.0.3)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -4787,7 +5166,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@payloadcms/richtext-lexical@3.88.0(@faceless-ui/modal@3.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@payloadcms/next@3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.27)':
+  '@payloadcms/richtext-lexical@3.88.0(@faceless-ui/modal@3.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@payloadcms/next@3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(yjs@13.6.27)':
     dependencies:
       '@faceless-ui/modal': 3.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@faceless-ui/scroll-info': 2.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4802,9 +5181,9 @@ snapshots:
       '@lexical/selection': 0.41.0
       '@lexical/table': 0.41.0
       '@lexical/utils': 0.41.0
-      '@payloadcms/next': 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@payloadcms/next': 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       '@payloadcms/translations': 3.88.0
-      '@payloadcms/ui': 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@payloadcms/ui': 3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       acorn: 8.16.0
       bson-objectid: 2.0.4
       csstype: 3.1.3
@@ -4836,7 +5215,7 @@ snapshots:
     dependencies:
       date-fns: 4.1.0
 
-  '@payloadcms/ui@3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
+  '@payloadcms/ui@3.88.0(@types/react@19.2.18)(monaco-editor@0.54.0)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)':
     dependencies:
       '@date-fns/tz': 1.2.0
       '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4851,7 +5230,7 @@ snapshots:
       date-fns: 4.1.0
       dequal: 2.0.3
       md5: 2.3.0
-      next: 16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
+      next: 16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
       object-to-formdata: 4.5.1
       payload: 3.88.0(graphql@16.12.0)(typescript@6.0.3)
       qs-esm: 8.0.1
@@ -4875,11 +5254,57 @@ snapshots:
 
   '@preact/signals-core@1.14.4': {}
 
+  '@rolldown/binding-android-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/is@7.2.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/cli@0.8.1(@swc/core@1.15.47)':
     dependencies:
@@ -4979,9 +5404,16 @@ snapshots:
     dependencies:
       '@types/node': 26.2.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
@@ -5213,6 +5645,47 @@ snapshots:
       '@typescript-eslint/types': 8.67.0
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.77.4)(tsx@4.23.12))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.77.4)(tsx@4.23.12)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@xhmikosr/archive-type@8.1.0':
     dependencies:
       file-type: 21.3.4
@@ -5381,6 +5854,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -5501,6 +5976,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -5569,6 +6046,8 @@ snapshots:
   convert-hrtime@5.0.0: {}
 
   convert-source-map@1.9.0: {}
+
+  convert-source-map@2.0.0: {}
 
   copyfiles@2.4.1:
     dependencies:
@@ -5673,8 +6152,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   devlop@1.1.0:
     dependencies:
@@ -5787,6 +6265,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -6134,6 +6614,10 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   events-universal@1.0.1:
@@ -6168,6 +6652,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.2.0
+
+  expect-type@1.4.0: {}
 
   ext-list@2.2.2:
     dependencies:
@@ -6705,6 +7191,55 @@ snapshots:
     dependencies:
       isomorphic.js: 0.2.5
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lines-and-columns@1.2.4: {}
 
   locate-path@6.0.0:
@@ -6724,6 +7259,10 @@ snapshots:
   lowercase-keys@3.0.0: {}
 
   lru-cache@11.5.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-asynchronous@1.1.0:
     dependencies:
@@ -7059,7 +7598,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4):
+  next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -7079,7 +7618,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.3.0
       '@next/swc-win32-x64-msvc': 16.3.0
       sass: 1.77.4
-      sharp: 0.35.3
+      sharp: 0.35.3(@types/node@26.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -7147,6 +7686,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
+
+  obug@2.1.4: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -7233,6 +7774,8 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   payload@3.88.0(graphql@16.12.0)(typescript@6.0.3):
     dependencies:
@@ -7327,6 +7870,12 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.23:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1
@@ -7517,6 +8066,26 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
+  rolldown@1.2.4:
+    dependencies:
+      '@oxc-project/types': 0.144.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
+
   safe-array-concat@1.1.4:
     dependencies:
       call-bind: 1.0.9
@@ -7598,7 +8167,7 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.35.3:
+  sharp@0.35.3(@types/node@26.2.0):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
@@ -7629,6 +8198,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 26.2.0
     optional: true
 
   shebang-command@2.0.0:
@@ -7666,6 +8236,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   sift@17.1.3: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -7706,7 +8278,11 @@ snapshots:
 
   stable-hash@0.0.4: {}
 
+  stackback@0.0.2: {}
+
   state-local@1.0.7: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7849,10 +8425,16 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8026,6 +8608,48 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
 
+  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.77.4)(tsx@4.23.12):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      esbuild: 0.28.2
+      fsevents: 2.3.3
+      sass: 1.77.4
+      tsx: 4.23.12
+
+  vitest@4.1.10(@types/node@26.2.0)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.77.4)(tsx@4.23.12)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.77.4)(tsx@4.23.12))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.77.4)(tsx@4.23.12)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+      happy-dom: 20.11.2
+    transitivePeerDependencies:
+      - msw
+
   web-worker@1.5.0: {}
 
   webidl-conversions@7.0.0: {}
@@ -8081,6 +8705,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/admin-search/src/components/SearchBar/SearchBar.tsx
+++ b/admin-search/src/components/SearchBar/SearchBar.tsx
@@ -2,7 +2,7 @@
 import type React from 'react'
 
 import { Button, Pill, SearchIcon, useHotkey, useTranslation } from '@payloadcms/ui'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 
 import type {
   PluginAdminSearchTranslationKeys,
@@ -16,7 +16,11 @@ import './SearchBar.css'
 
 const baseClass = 'admin-search-plugin-bar'
 
-export function SearchBar({ baseFilter }: { baseFilter: BaseFilterState }): React.ReactElement {
+export function SearchBar({
+  baseFilterPromise,
+}: {
+  baseFilterPromise: Promise<BaseFilterState>
+}): React.ReactElement {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [shortcut, setShortcut] = useState('')
   const { t } = useTranslation<PluginAdminSearchTranslations, PluginAdminSearchTranslationKeys>()
@@ -54,7 +58,14 @@ export function SearchBar({ baseFilter }: { baseFilter: BaseFilterState }): Reac
         </div>
       </Button>
       {isModalOpen && (
-        <SearchModal baseFilter={baseFilter} handleClose={() => setIsModalOpen(false)} />
+        // The modal is the first thing that needs the filter, so the wait for it — if any
+        // is left by the time the modal opens — happens here rather than in the header.
+        <Suspense fallback={null}>
+          <SearchModal
+            baseFilterPromise={baseFilterPromise}
+            handleClose={() => setIsModalOpen(false)}
+          />
+        </Suspense>
       )}
     </>
   )

--- a/admin-search/src/components/SearchBar/SearchBar.tsx
+++ b/admin-search/src/components/SearchBar/SearchBar.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { Where } from 'payload'
 import type React from 'react'
 
 import { Button, Pill, SearchIcon, useHotkey, useTranslation } from '@payloadcms/ui'
@@ -9,6 +8,7 @@ import type {
   PluginAdminSearchTranslationKeys,
   PluginAdminSearchTranslations,
 } from '../../translations/index.js'
+import type { BaseFilterState } from '../../types/BaseFilterState.js'
 
 import { getSearchShortcut } from '../../utils/getSearchShortcut.js'
 import { SearchModal } from '../SearchModal/SearchModal.js'
@@ -16,7 +16,7 @@ import './SearchBar.css'
 
 const baseClass = 'admin-search-plugin-bar'
 
-export function SearchBar({ baseFilter }: { baseFilter?: Where }): React.ReactElement {
+export function SearchBar({ baseFilter }: { baseFilter: BaseFilterState }): React.ReactElement {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [shortcut, setShortcut] = useState('')
   const { t } = useTranslation<PluginAdminSearchTranslations, PluginAdminSearchTranslationKeys>()

--- a/admin-search/src/components/SearchBar/SearchBar.tsx
+++ b/admin-search/src/components/SearchBar/SearchBar.tsx
@@ -1,4 +1,5 @@
 'use client'
+import type { Where } from 'payload'
 import type React from 'react'
 
 import { Button, Pill, SearchIcon, useHotkey, useTranslation } from '@payloadcms/ui'
@@ -15,7 +16,7 @@ import './SearchBar.css'
 
 const baseClass = 'admin-search-plugin-bar'
 
-export function SearchBar(): React.ReactElement {
+export function SearchBar({ baseFilter }: { baseFilter?: Where }): React.ReactElement {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [shortcut, setShortcut] = useState('')
   const { t } = useTranslation<PluginAdminSearchTranslations, PluginAdminSearchTranslationKeys>()
@@ -52,7 +53,9 @@ export function SearchBar(): React.ReactElement {
           <Pill className="admin-search-plugin-bar__shortcut">{shortcut || '⌘K'}</Pill>
         </div>
       </Button>
-      {isModalOpen && <SearchModal handleClose={() => setIsModalOpen(false)} />}
+      {isModalOpen && (
+        <SearchModal baseFilter={baseFilter} handleClose={() => setIsModalOpen(false)} />
+      )}
     </>
   )
 }

--- a/admin-search/src/components/SearchButton/SearchButton.tsx
+++ b/admin-search/src/components/SearchButton/SearchButton.tsx
@@ -1,5 +1,4 @@
 'use client'
-import type { Where } from 'payload'
 import type React from 'react'
 
 import { Button, SearchIcon, useHotkey, useTranslation } from '@payloadcms/ui'
@@ -9,11 +8,12 @@ import type {
   PluginAdminSearchTranslationKeys,
   PluginAdminSearchTranslations,
 } from '../../translations/index.js'
+import type { BaseFilterState } from '../../types/BaseFilterState.js'
 
 import { getSearchShortcut } from '../../utils/getSearchShortcut.js'
 import { SearchModal } from '../SearchModal/SearchModal.js'
 
-export function SearchButton({ baseFilter }: { baseFilter?: Where }): React.ReactElement {
+export function SearchButton({ baseFilter }: { baseFilter: BaseFilterState }): React.ReactElement {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { t } = useTranslation<PluginAdminSearchTranslations, PluginAdminSearchTranslationKeys>()
 

--- a/admin-search/src/components/SearchButton/SearchButton.tsx
+++ b/admin-search/src/components/SearchButton/SearchButton.tsx
@@ -1,4 +1,5 @@
 'use client'
+import type { Where } from 'payload'
 import type React from 'react'
 
 import { Button, SearchIcon, useHotkey, useTranslation } from '@payloadcms/ui'
@@ -12,7 +13,7 @@ import type {
 import { getSearchShortcut } from '../../utils/getSearchShortcut.js'
 import { SearchModal } from '../SearchModal/SearchModal.js'
 
-export function SearchButton(): React.ReactElement {
+export function SearchButton({ baseFilter }: { baseFilter?: Where }): React.ReactElement {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { t } = useTranslation<PluginAdminSearchTranslations, PluginAdminSearchTranslationKeys>()
 
@@ -41,7 +42,9 @@ export function SearchButton(): React.ReactElement {
         <SearchIcon />
       </Button>
 
-      {isModalOpen && <SearchModal handleClose={() => setIsModalOpen(false)} />}
+      {isModalOpen && (
+        <SearchModal baseFilter={baseFilter} handleClose={() => setIsModalOpen(false)} />
+      )}
     </>
   )
 }

--- a/admin-search/src/components/SearchButton/SearchButton.tsx
+++ b/admin-search/src/components/SearchButton/SearchButton.tsx
@@ -2,7 +2,7 @@
 import type React from 'react'
 
 import { Button, SearchIcon, useHotkey, useTranslation } from '@payloadcms/ui'
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
 
 import type {
   PluginAdminSearchTranslationKeys,
@@ -13,7 +13,11 @@ import type { BaseFilterState } from '../../types/BaseFilterState.js'
 import { getSearchShortcut } from '../../utils/getSearchShortcut.js'
 import { SearchModal } from '../SearchModal/SearchModal.js'
 
-export function SearchButton({ baseFilter }: { baseFilter: BaseFilterState }): React.ReactElement {
+export function SearchButton({
+  baseFilterPromise,
+}: {
+  baseFilterPromise: Promise<BaseFilterState>
+}): React.ReactElement {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { t } = useTranslation<PluginAdminSearchTranslations, PluginAdminSearchTranslationKeys>()
 
@@ -43,7 +47,14 @@ export function SearchButton({ baseFilter }: { baseFilter: BaseFilterState }): R
       </Button>
 
       {isModalOpen && (
-        <SearchModal baseFilter={baseFilter} handleClose={() => setIsModalOpen(false)} />
+        // The modal is the first thing that needs the filter, so the wait for it — if any
+        // is left by the time the modal opens — happens here rather than in the header.
+        <Suspense fallback={null}>
+          <SearchModal
+            baseFilterPromise={baseFilterPromise}
+            handleClose={() => setIsModalOpen(false)}
+          />
+        </Suspense>
       )}
     </>
   )

--- a/admin-search/src/components/SearchModal/SearchModal.tsx
+++ b/admin-search/src/components/SearchModal/SearchModal.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import type { Where } from 'payload'
+
 import { Banner, SearchIcon, useConfig, useTranslation } from '@payloadcms/ui'
 import { useRouter } from 'next/navigation.js'
 import { formatAdminURL } from 'payload/shared'
@@ -17,11 +19,14 @@ import './SearchModal.css'
 import { useSearch } from './useSearch.js'
 
 interface SearchModalProps {
+  baseFilter?: Where
   handleClose: () => void
 }
 
-export const SearchModal: React.FC<SearchModalProps> = ({ handleClose }) => {
-  const { displayedQuery, isError, isLoading, query, results, resultsLimit, setQuery } = useSearch()
+export const SearchModal: React.FC<SearchModalProps> = ({ baseFilter, handleClose }) => {
+  const { displayedQuery, isError, isLoading, query, results, resultsLimit, setQuery } = useSearch({
+    baseFilter,
+  })
   const [selectedIndex, setSelectedIndex] = useState(-1)
   const [isKeyboardNav, setIsKeyboardNav] = useState(false)
 

--- a/admin-search/src/components/SearchModal/SearchModal.tsx
+++ b/admin-search/src/components/SearchModal/SearchModal.tsx
@@ -3,7 +3,7 @@
 import { Banner, SearchIcon, useConfig, useTranslation } from '@payloadcms/ui'
 import { useRouter } from 'next/navigation.js'
 import { formatAdminURL } from 'payload/shared'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { use, useCallback, useEffect, useRef, useState } from 'react'
 
 import type {
   PluginAdminSearchTranslationKeys,
@@ -18,11 +18,15 @@ import './SearchModal.css'
 import { useSearch } from './useSearch.js'
 
 interface SearchModalProps {
-  baseFilter: BaseFilterState
+  baseFilterPromise: Promise<BaseFilterState>
   handleClose: () => void
 }
 
-export const SearchModal: React.FC<SearchModalProps> = ({ baseFilter, handleClose }) => {
+export const SearchModal: React.FC<SearchModalProps> = ({ baseFilterPromise, handleClose }) => {
+  // Resolved on the server while the admin page rendered, so by the time the modal opens this
+  // has almost always settled — the wait happens here rather than blocking the header.
+  const baseFilter = use(baseFilterPromise)
+
   const { displayedQuery, isError, isLoading, query, results, resultsLimit, setQuery } = useSearch({
     baseFilter,
   })

--- a/admin-search/src/components/SearchModal/SearchModal.tsx
+++ b/admin-search/src/components/SearchModal/SearchModal.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import type { Where } from 'payload'
-
 import { Banner, SearchIcon, useConfig, useTranslation } from '@payloadcms/ui'
 import { useRouter } from 'next/navigation.js'
 import { formatAdminURL } from 'payload/shared'
@@ -11,6 +9,7 @@ import type {
   PluginAdminSearchTranslationKeys,
   PluginAdminSearchTranslations,
 } from '../../translations/index.js'
+import type { BaseFilterState } from '../../types/BaseFilterState.js'
 import type { SearchResult } from '../../types/SearchResult.js'
 
 import { SearchResultItem } from '../SearchResultItem/SearchResultItem.js'
@@ -19,7 +18,7 @@ import './SearchModal.css'
 import { useSearch } from './useSearch.js'
 
 interface SearchModalProps {
-  baseFilter?: Where
+  baseFilter: BaseFilterState
   handleClose: () => void
 }
 

--- a/admin-search/src/components/SearchModal/buildSearchQuery.test.ts
+++ b/admin-search/src/components/SearchModal/buildSearchQuery.test.ts
@@ -37,6 +37,20 @@ describe('buildSearchQuery', () => {
       and: [{ title: { like: 'pricing' } }],
     })
   })
+
+  it('matches no document when the base filter could not be evaluated, so the query is scoped out even if it is sent', () => {
+    // Every document has an id, so this constraint is unsatisfiable — the intended scope is
+    // unknown, and answering with the whole collection would leak what the filter was for.
+    expect(
+      buildSearchQuery({ baseFilter: { status: 'unavailable' }, query: 'pricing' }).where,
+    ).toEqual({ and: [{ title: { like: 'pricing' } }, { id: { exists: false } }] })
+  })
+
+  it('matches no document when the base filter could not be evaluated and nothing was typed', () => {
+    expect(buildSearchQuery({ baseFilter: { status: 'unavailable' } }).where).toEqual({
+      and: [{ id: { exists: false } }],
+    })
+  })
 })
 
 describe('buildSearchURL', () => {

--- a/admin-search/src/components/SearchModal/buildSearchQuery.test.ts
+++ b/admin-search/src/components/SearchModal/buildSearchQuery.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSearchQuery } from './buildSearchQuery.js'
+
+describe('buildSearchQuery', () => {
+  it('lists everything when there is neither a query nor a base filter', () => {
+    expect(buildSearchQuery({})).not.toHaveProperty('where')
+  })
+
+  it('matches documents whose title contains the query', () => {
+    expect(buildSearchQuery({ query: 'pricing' }).where).toEqual({
+      and: [{ title: { like: 'pricing' } }],
+    })
+  })
+
+  it('restricts an empty query to the base filter, so an unqueried search only lists documents in scope', () => {
+    expect(buildSearchQuery({ baseFilter: { tenant: { equals: 'acme' } } }).where).toEqual({
+      and: [{ tenant: { equals: 'acme' } }],
+    })
+  })
+
+  it('requires both the query and the base filter to match, so a document outside the scope never surfaces', () => {
+    expect(
+      buildSearchQuery({ baseFilter: { tenant: { equals: 'acme' } }, query: 'pricing' }).where,
+    ).toEqual({
+      and: [{ title: { like: 'pricing' } }, { tenant: { equals: 'acme' } }],
+    })
+  })
+
+  it('ignores a base filter with no constraints', () => {
+    expect(buildSearchQuery({ baseFilter: {}, query: 'pricing' }).where).toEqual({
+      and: [{ title: { like: 'pricing' } }],
+    })
+  })
+})

--- a/admin-search/src/components/SearchModal/buildSearchQuery.test.ts
+++ b/admin-search/src/components/SearchModal/buildSearchQuery.test.ts
@@ -1,35 +1,50 @@
+import type { Where } from 'payload'
+
 import { describe, expect, it } from 'vitest'
 
-import { buildSearchQuery } from './buildSearchQuery.js'
+import { buildSearchQuery, buildSearchURL } from './buildSearchQuery.js'
+
+const resolved = (filter?: Where) => ({ filter, status: 'resolved' }) as const
 
 describe('buildSearchQuery', () => {
   it('lists everything when there is neither a query nor a base filter', () => {
-    expect(buildSearchQuery({})).not.toHaveProperty('where')
+    expect(buildSearchQuery({ baseFilter: resolved() })).not.toHaveProperty('where')
   })
 
   it('matches documents whose title contains the query', () => {
-    expect(buildSearchQuery({ query: 'pricing' }).where).toEqual({
+    expect(buildSearchQuery({ baseFilter: resolved(), query: 'pricing' }).where).toEqual({
       and: [{ title: { like: 'pricing' } }],
     })
   })
 
   it('restricts an empty query to the base filter, so an unqueried search only lists documents in scope', () => {
-    expect(buildSearchQuery({ baseFilter: { tenant: { equals: 'acme' } } }).where).toEqual({
-      and: [{ tenant: { equals: 'acme' } }],
-    })
+    expect(
+      buildSearchQuery({ baseFilter: resolved({ tenant: { equals: 'acme' } }) }).where,
+    ).toEqual({ and: [{ tenant: { equals: 'acme' } }] })
   })
 
   it('requires both the query and the base filter to match, so a document outside the scope never surfaces', () => {
     expect(
-      buildSearchQuery({ baseFilter: { tenant: { equals: 'acme' } }, query: 'pricing' }).where,
+      buildSearchQuery({ baseFilter: resolved({ tenant: { equals: 'acme' } }), query: 'pricing' })
+        .where,
     ).toEqual({
       and: [{ title: { like: 'pricing' } }, { tenant: { equals: 'acme' } }],
     })
   })
 
   it('ignores a base filter with no constraints', () => {
-    expect(buildSearchQuery({ baseFilter: {}, query: 'pricing' }).where).toEqual({
+    expect(buildSearchQuery({ baseFilter: resolved({}), query: 'pricing' }).where).toEqual({
       and: [{ title: { like: 'pricing' } }],
     })
+  })
+})
+
+describe('buildSearchURL', () => {
+  it('queries the search collection when the base filter resolved', () => {
+    expect(buildSearchURL({ apiRoute: '/api', baseFilter: resolved() })).toBe('/api/search')
+  })
+
+  it('has nowhere to query when the base filter could not be resolved, so no request goes out and no document can surface', () => {
+    expect(buildSearchURL({ apiRoute: '/api', baseFilter: { status: 'unavailable' } })).toBe('')
   })
 })

--- a/admin-search/src/components/SearchModal/buildSearchQuery.ts
+++ b/admin-search/src/components/SearchModal/buildSearchQuery.ts
@@ -1,8 +1,6 @@
 import type { Where } from 'payload'
 
-const SEARCH_RESULTS_LIMIT = 5
-
-export { SEARCH_RESULTS_LIMIT }
+export const SEARCH_RESULTS_LIMIT = 5
 
 /**
  * Builds the query the search modal sends to the search collection. The base filter and the

--- a/admin-search/src/components/SearchModal/buildSearchQuery.ts
+++ b/admin-search/src/components/SearchModal/buildSearchQuery.ts
@@ -18,9 +18,20 @@ export const buildSearchURL = ({
 }): string => (baseFilter.status === 'unavailable' ? '' : `${apiRoute}/search`)
 
 /**
+ * A constraint no document can satisfy: every document has an id. Used when the scope a
+ * configured filter would have applied is unknown, so that the query itself is scoped out
+ * rather than relying on the request never being sent.
+ */
+const MATCHES_NOTHING: Where = { id: { exists: false } }
+
+/**
  * Builds the query the search modal sends to the search collection. The base filter and the
  * typed query are combined with `and`, so results always stay inside the filter's scope —
  * including when nothing has been typed yet.
+ *
+ * A filter that could not be evaluated yields a query that matches nothing. `buildSearchURL`
+ * already stops the request from going out at all; this is the second of the two, so that a
+ * query which does reach the API still cannot answer with documents outside the scope.
  */
 export const buildSearchQuery = ({
   baseFilter,
@@ -29,7 +40,7 @@ export const buildSearchQuery = ({
   baseFilter: BaseFilterState
   query?: string
 }): { depth: number; limit: number; sort: string; where?: Where } => {
-  const filter = baseFilter.status === 'resolved' ? baseFilter.filter : undefined
+  const filter = baseFilter.status === 'resolved' ? baseFilter.filter : MATCHES_NOTHING
 
   const constraints: Where[] = [
     ...(query ? [{ title: { like: query } }] : []),

--- a/admin-search/src/components/SearchModal/buildSearchQuery.ts
+++ b/admin-search/src/components/SearchModal/buildSearchQuery.ts
@@ -1,0 +1,30 @@
+import type { Where } from 'payload'
+
+const SEARCH_RESULTS_LIMIT = 5
+
+export { SEARCH_RESULTS_LIMIT }
+
+/**
+ * Builds the query the search modal sends to the search collection. The base filter and the
+ * typed query are combined with `and`, so results always stay inside the filter's scope —
+ * including when nothing has been typed yet.
+ */
+export const buildSearchQuery = ({
+  baseFilter,
+  query,
+}: {
+  baseFilter?: Where
+  query?: string
+}): { depth: number; limit: number; sort: string; where?: Where } => {
+  const constraints: Where[] = [
+    ...(query ? [{ title: { like: query } }] : []),
+    ...(baseFilter && Object.keys(baseFilter).length > 0 ? [baseFilter] : []),
+  ]
+
+  return {
+    depth: 0,
+    limit: SEARCH_RESULTS_LIMIT,
+    sort: '-priority',
+    ...(constraints.length > 0 && { where: { and: constraints } }),
+  }
+}

--- a/admin-search/src/components/SearchModal/buildSearchQuery.ts
+++ b/admin-search/src/components/SearchModal/buildSearchQuery.ts
@@ -1,6 +1,21 @@
 import type { Where } from 'payload'
 
+import type { BaseFilterState } from '../../types/BaseFilterState.js'
+
 export const SEARCH_RESULTS_LIMIT = 5
+
+/**
+ * The URL the search modal queries, or an empty one when the base filter could not be
+ * resolved. `usePayloadAPI` skips the request entirely for an empty URL, so an unresolvable
+ * filter yields no documents at all rather than an unscoped list of them.
+ */
+export const buildSearchURL = ({
+  apiRoute,
+  baseFilter,
+}: {
+  apiRoute: string
+  baseFilter: BaseFilterState
+}): string => (baseFilter.status === 'unavailable' ? '' : `${apiRoute}/search`)
 
 /**
  * Builds the query the search modal sends to the search collection. The base filter and the
@@ -11,12 +26,14 @@ export const buildSearchQuery = ({
   baseFilter,
   query,
 }: {
-  baseFilter?: Where
+  baseFilter: BaseFilterState
   query?: string
 }): { depth: number; limit: number; sort: string; where?: Where } => {
+  const filter = baseFilter.status === 'resolved' ? baseFilter.filter : undefined
+
   const constraints: Where[] = [
     ...(query ? [{ title: { like: query } }] : []),
-    ...(baseFilter && Object.keys(baseFilter).length > 0 ? [baseFilter] : []),
+    ...(filter && Object.keys(filter).length > 0 ? [filter] : []),
   ]
 
   return {

--- a/admin-search/src/components/SearchModal/useSearch.ts
+++ b/admin-search/src/components/SearchModal/useSearch.ts
@@ -1,7 +1,5 @@
 'use client'
 
-import type { Where } from 'payload'
-
 import { getTranslation } from '@payloadcms/translations'
 import {
   useConfig,
@@ -12,9 +10,10 @@ import {
 } from '@payloadcms/ui'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import type { BaseFilterState } from '../../types/BaseFilterState.js'
 import type { SearchResult, SearchResultDocument } from '../../types/SearchResult.js'
 
-import { buildSearchQuery, SEARCH_RESULTS_LIMIT } from './buildSearchQuery.js'
+import { buildSearchQuery, buildSearchURL, SEARCH_RESULTS_LIMIT } from './buildSearchQuery.js'
 
 const SEARCH_DEBOUNCE_MS = 300
 
@@ -28,7 +27,7 @@ export interface UseSearchReturn {
   setQuery: (query: string) => void
 }
 
-export const useSearch = ({ baseFilter }: { baseFilter?: Where } = {}): UseSearchReturn => {
+export const useSearch = ({ baseFilter }: { baseFilter: BaseFilterState }): UseSearchReturn => {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
   const [displayedQuery, setDisplayedQuery] = useState('')
@@ -59,10 +58,14 @@ export const useSearch = ({ baseFilter }: { baseFilter?: Where } = {}): UseSearc
 
   // The base filter scopes every request, so re-memoize whenever its constraints change
   // rather than whenever the caller happens to hand over a new object.
-  const baseFilterKey = JSON.stringify(baseFilter ?? null)
+  const baseFilterKey = JSON.stringify(baseFilter)
+
+  // An unresolvable filter empties the URL, which stops `usePayloadAPI` from requesting
+  // anything at all — no document can surface while the intended scope is unknown.
+  const isBaseFilterUnavailable = baseFilter.status === 'unavailable'
 
   const [{ data, isError, isLoading }, { setParams }] = usePayloadAPI(
-    `${config.routes.api}/search`,
+    buildSearchURL({ apiRoute: config.routes.api, baseFilter }),
     {
       // Scoped as well, so the results shown before anything is typed stay inside the filter.
       initialParams: { ...buildSearchQuery({ baseFilter }), pagination: false },
@@ -143,7 +146,9 @@ export const useSearch = ({ baseFilter }: { baseFilter?: Where } = {}): UseSearc
 
   return {
     displayedQuery,
-    isError,
+    // Surfaced as an error rather than as an empty result list: an admin who cannot search
+    // should be told so, not left guessing why their documents stopped showing up.
+    isError: isError || isBaseFilterUnavailable,
     isLoading,
     query,
     results,

--- a/admin-search/src/components/SearchModal/useSearch.ts
+++ b/admin-search/src/components/SearchModal/useSearch.ts
@@ -1,5 +1,7 @@
 'use client'
 
+import type { Where } from 'payload'
+
 import { getTranslation } from '@payloadcms/translations'
 import {
   useConfig,
@@ -12,8 +14,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { SearchResult, SearchResultDocument } from '../../types/SearchResult.js'
 
+import { buildSearchQuery, SEARCH_RESULTS_LIMIT } from './buildSearchQuery.js'
+
 const SEARCH_DEBOUNCE_MS = 300
-const SEARCH_RESULTS_LIMIT = 5
 
 export interface UseSearchReturn {
   displayedQuery: string
@@ -25,7 +28,7 @@ export interface UseSearchReturn {
   setQuery: (query: string) => void
 }
 
-export const useSearch = (): UseSearchReturn => {
+export const useSearch = ({ baseFilter }: { baseFilter?: Where } = {}): UseSearchReturn => {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
   const [displayedQuery, setDisplayedQuery] = useState('')
@@ -54,32 +57,21 @@ export const useSearch = (): UseSearchReturn => {
     return { collections, globals }
   }, [config.collections, config.globals, i18n])
 
+  // The base filter scopes every request, so re-memoize whenever its constraints change
+  // rather than whenever the caller happens to hand over a new object.
+  const baseFilterKey = JSON.stringify(baseFilter ?? null)
+
   const [{ data, isError, isLoading }, { setParams }] = usePayloadAPI(
     `${config.routes.api}/search`,
     {
-      initialParams: {
-        depth: 0,
-        limit: 10,
-        pagination: false,
-        sort: '-priority',
-      },
+      // Scoped as well, so the results shown before anything is typed stay inside the filter.
+      initialParams: { ...buildSearchQuery({ baseFilter }), pagination: false },
     },
   )
 
   const getSearchParams = useCallback(
-    (searchQuery?: string) => ({
-      depth: 0,
-      limit: SEARCH_RESULTS_LIMIT,
-      sort: '-priority',
-      ...(searchQuery && {
-        where: {
-          title: {
-            like: searchQuery,
-          },
-        },
-      }),
-    }),
-    [],
+    (searchQuery?: string) => buildSearchQuery({ baseFilter, query: searchQuery }),
+    [baseFilterKey],
   )
 
   const triggerSearch = useCallback(

--- a/admin-search/src/components/SearchModal/useSearch.ts
+++ b/admin-search/src/components/SearchModal/useSearch.ts
@@ -71,6 +71,9 @@ export const useSearch = ({ baseFilter }: { baseFilter?: Where } = {}): UseSearc
 
   const getSearchParams = useCallback(
     (searchQuery?: string) => buildSearchQuery({ baseFilter, query: searchQuery }),
+    // Deliberately keyed on the serialized filter rather than on `baseFilter` itself: the
+    // server hands over a fresh object on every render, so depending on it directly would
+    // rebuild this callback each time and re-fire the search effect in a loop.
     [baseFilterKey],
   )
 

--- a/admin-search/src/components/SearchWrapper/SearchWrapper.tsx
+++ b/admin-search/src/components/SearchWrapper/SearchWrapper.tsx
@@ -1,6 +1,8 @@
 import type { PayloadRequest, ServerProps } from 'payload'
 import type React from 'react'
 
+import type { BaseFilterState } from '../../types/BaseFilterState.js'
+
 import { resolveBaseFilter } from './resolveBaseFilter.js'
 import { SearchWrapperClient } from './SearchWrapperClient.js'
 
@@ -23,7 +25,12 @@ export async function SearchWrapper({
   req,
   style = 'button',
 }: SearchWrapperProps): Promise<React.ReactElement> {
-  const baseFilter = payload ? await resolveBaseFilter({ payload, req }) : undefined
+  // Without `payload` the plugin cannot read its own options back off the config, so whether
+  // a filter is configured at all is unknowable. Treating that as `unavailable` would break
+  // the search for everyone who never configured one, so leave it unscoped instead.
+  const baseFilter: BaseFilterState = payload
+    ? await resolveBaseFilter({ payload, req })
+    : { status: 'resolved' }
 
   return <SearchWrapperClient baseFilter={baseFilter} style={style} />
 }

--- a/admin-search/src/components/SearchWrapper/SearchWrapper.tsx
+++ b/admin-search/src/components/SearchWrapper/SearchWrapper.tsx
@@ -17,20 +17,26 @@ export type SearchWrapperProps = {
 } & Partial<ServerProps>
 
 /**
- * Resolves the configured `baseFilter` on the server and hands the resulting constraint to
- * the search UI, so results stay inside the scope of the current request.
+ * Starts resolving the configured `baseFilter` for this request and hands the pending result
+ * to the search UI, so results stay inside the scope of the current request.
+ *
+ * Deliberately not `async`: this component is rendered from the admin template's actions on
+ * every page, with no Suspense boundary around it, so awaiting a filter that reads the
+ * database would put that read on the critical path of every admin page render. The search
+ * button needs no filter to render — only a search does — so the promise travels to the
+ * client and is awaited inside the modal instead.
  */
-export async function SearchWrapper({
+export function SearchWrapper({
   payload,
   req,
   style = 'button',
-}: SearchWrapperProps): Promise<React.ReactElement> {
+}: SearchWrapperProps): React.ReactElement {
   // Without `payload` the plugin cannot read its own options back off the config, so whether
   // a filter is configured at all is unknowable. Treating that as `unavailable` would break
   // the search for everyone who never configured one, so leave it unscoped instead.
-  const baseFilter: BaseFilterState = payload
-    ? await resolveBaseFilter({ payload, req })
-    : { status: 'resolved' }
+  const baseFilterPromise: Promise<BaseFilterState> = payload
+    ? resolveBaseFilter({ payload, req })
+    : Promise.resolve({ status: 'resolved' })
 
-  return <SearchWrapperClient baseFilter={baseFilter} style={style} />
+  return <SearchWrapperClient baseFilterPromise={baseFilterPromise} style={style} />
 }

--- a/admin-search/src/components/SearchWrapper/SearchWrapper.tsx
+++ b/admin-search/src/components/SearchWrapper/SearchWrapper.tsx
@@ -1,16 +1,36 @@
-'use client'
+import type { PayloadRequest, ServerProps } from 'payload'
 import type React from 'react'
 
-import { SearchBar } from '../SearchBar/SearchBar.js'
-import { SearchButton } from '../SearchButton/SearchButton.js'
+import { headers as nextHeaders } from 'next/headers.js'
 
-interface SearchWrapperProps {
+import { resolveBaseFilter } from './resolveBaseFilter.js'
+import { SearchWrapperClient } from './SearchWrapperClient.js'
+
+export type SearchWrapperProps = {
   style?: 'bar' | 'button'
-}
+} & Partial<ServerProps>
 
-export function SearchWrapper({ style = 'button' }: SearchWrapperProps): React.ReactElement {
-  if (style === 'bar') {
-    return <SearchBar />
-  }
-  return <SearchButton />
+/**
+ * Resolves the configured `baseFilter` on the server and hands the resulting constraint to
+ * the search UI, so results stay inside the scope of the current request.
+ */
+export async function SearchWrapper({
+  i18n,
+  payload,
+  style = 'button',
+  user,
+}: SearchWrapperProps): Promise<React.ReactElement> {
+  const baseFilter = payload
+    ? await resolveBaseFilter({
+        headers: await nextHeaders(),
+        // Admin components carry the client-facing subset of the translations; reusing it
+        // spares a full translation init per render, at the cost of the server-only keys
+        // that a base filter has no reason to reach for.
+        i18n: i18n as PayloadRequest['i18n'],
+        payload,
+        user,
+      })
+    : undefined
+
+  return <SearchWrapperClient baseFilter={baseFilter} style={style} />
 }

--- a/admin-search/src/components/SearchWrapper/SearchWrapper.tsx
+++ b/admin-search/src/components/SearchWrapper/SearchWrapper.tsx
@@ -1,12 +1,16 @@
 import type { PayloadRequest, ServerProps } from 'payload'
 import type React from 'react'
 
-import { headers as nextHeaders } from 'next/headers.js'
-
 import { resolveBaseFilter } from './resolveBaseFilter.js'
 import { SearchWrapperClient } from './SearchWrapperClient.js'
 
 export type SearchWrapperProps = {
+  /**
+   * The request Payload is rendering the admin panel for. Payload passes this to admin
+   * components at runtime but does not list it on `ServerProps`, so it is declared here.
+   * See `serverProps` in `@payloadcms/next`'s default template.
+   */
+  req?: PayloadRequest
   style?: 'bar' | 'button'
 } & Partial<ServerProps>
 
@@ -15,22 +19,11 @@ export type SearchWrapperProps = {
  * the search UI, so results stay inside the scope of the current request.
  */
 export async function SearchWrapper({
-  i18n,
   payload,
+  req,
   style = 'button',
-  user,
 }: SearchWrapperProps): Promise<React.ReactElement> {
-  const baseFilter = payload
-    ? await resolveBaseFilter({
-        headers: await nextHeaders(),
-        // Admin components carry the client-facing subset of the translations; reusing it
-        // spares a full translation init per render, at the cost of the server-only keys
-        // that a base filter has no reason to reach for.
-        i18n: i18n as PayloadRequest['i18n'],
-        payload,
-        user,
-      })
-    : undefined
+  const baseFilter = payload ? await resolveBaseFilter({ payload, req }) : undefined
 
   return <SearchWrapperClient baseFilter={baseFilter} style={style} />
 }

--- a/admin-search/src/components/SearchWrapper/SearchWrapperClient.tsx
+++ b/admin-search/src/components/SearchWrapper/SearchWrapperClient.tsx
@@ -7,16 +7,17 @@ import { SearchBar } from '../SearchBar/SearchBar.js'
 import { SearchButton } from '../SearchButton/SearchButton.js'
 
 export interface SearchWrapperClientProps {
-  baseFilter: BaseFilterState
+  /** Resolved on the server; awaited in the modal, which is the first thing that needs it. */
+  baseFilterPromise: Promise<BaseFilterState>
   style?: 'bar' | 'button'
 }
 
 export function SearchWrapperClient({
-  baseFilter,
+  baseFilterPromise,
   style = 'button',
 }: SearchWrapperClientProps): React.ReactElement {
   if (style === 'bar') {
-    return <SearchBar baseFilter={baseFilter} />
+    return <SearchBar baseFilterPromise={baseFilterPromise} />
   }
-  return <SearchButton baseFilter={baseFilter} />
+  return <SearchButton baseFilterPromise={baseFilterPromise} />
 }

--- a/admin-search/src/components/SearchWrapper/SearchWrapperClient.tsx
+++ b/admin-search/src/components/SearchWrapper/SearchWrapperClient.tsx
@@ -1,0 +1,21 @@
+'use client'
+import type { Where } from 'payload'
+import type React from 'react'
+
+import { SearchBar } from '../SearchBar/SearchBar.js'
+import { SearchButton } from '../SearchButton/SearchButton.js'
+
+export interface SearchWrapperClientProps {
+  baseFilter?: Where
+  style?: 'bar' | 'button'
+}
+
+export function SearchWrapperClient({
+  baseFilter,
+  style = 'button',
+}: SearchWrapperClientProps): React.ReactElement {
+  if (style === 'bar') {
+    return <SearchBar baseFilter={baseFilter} />
+  }
+  return <SearchButton baseFilter={baseFilter} />
+}

--- a/admin-search/src/components/SearchWrapper/SearchWrapperClient.tsx
+++ b/admin-search/src/components/SearchWrapper/SearchWrapperClient.tsx
@@ -1,12 +1,13 @@
 'use client'
-import type { Where } from 'payload'
 import type React from 'react'
+
+import type { BaseFilterState } from '../../types/BaseFilterState.js'
 
 import { SearchBar } from '../SearchBar/SearchBar.js'
 import { SearchButton } from '../SearchButton/SearchButton.js'
 
 export interface SearchWrapperClientProps {
-  baseFilter?: Where
+  baseFilter: BaseFilterState
   style?: 'bar' | 'button'
 }
 

--- a/admin-search/src/components/SearchWrapper/resolveBaseFilter.test.ts
+++ b/admin-search/src/components/SearchWrapper/resolveBaseFilter.test.ts
@@ -6,13 +6,14 @@ import type { AdminSearchPluginConfig } from '../../types/AdminSearchPluginConfi
 
 import { resolveBaseFilter } from './resolveBaseFilter.js'
 
-const payloadWith = (pluginConfig?: AdminSearchPluginConfig) =>
+const payloadWith = (pluginConfig?: AdminSearchPluginConfig, logged: unknown[] = []) =>
   ({
     config: {
       admin: { user: 'users' },
       custom: pluginConfig ? { adminSearchPluginConfig: pluginConfig } : {},
       i18n: { fallbackLanguage: 'en' },
     },
+    logger: { error: (...args: unknown[]) => logged.push(args) },
   }) as unknown as Payload
 
 /** Stands in for the admin panel's i18n, which the resolver reuses instead of building one. */
@@ -48,5 +49,36 @@ describe('resolveBaseFilter', () => {
     })
 
     expect(filter).toEqual({ owner: { equals: 'user-1' } })
+  })
+
+  it('falls back to an unscoped search when the filter throws, instead of failing the render', async () => {
+    const logged: unknown[] = []
+
+    await expect(
+      resolveBaseFilter({
+        headers: new Headers(),
+        i18n,
+        payload: payloadWith(
+          {
+            baseFilter: () => {
+              throw new Error('tenant cookie was malformed')
+            },
+          },
+          logged,
+        ),
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(logged).toHaveLength(1)
+  })
+
+  it('falls back to an unscoped search when an async filter rejects', async () => {
+    await expect(
+      resolveBaseFilter({
+        headers: new Headers(),
+        i18n,
+        payload: payloadWith({ baseFilter: () => Promise.reject(new Error('db unreachable')) }),
+      }),
+    ).resolves.toBeUndefined()
   })
 })

--- a/admin-search/src/components/SearchWrapper/resolveBaseFilter.test.ts
+++ b/admin-search/src/components/SearchWrapper/resolveBaseFilter.test.ts
@@ -29,7 +29,7 @@ describe('resolveBaseFilter', () => {
   it('leaves the search unscoped when no base filter is configured', async () => {
     await expect(
       resolveBaseFilter({ payload: payloadWith({}), req: requestWith() }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ status: 'resolved' })
   })
 
   it('scopes by the tenant cookie the admin panel was requested with', async () => {
@@ -42,7 +42,7 @@ describe('resolveBaseFilter', () => {
       req: requestWith({ cookie: 'payload-tenant=acme' }),
     })
 
-    expect(filter).toEqual({ tenant: { equals: 'acme' } })
+    expect(filter).toEqual({ filter: { tenant: { equals: 'acme' } }, status: 'resolved' })
   })
 
   it('scopes by the signed-in user', async () => {
@@ -51,7 +51,7 @@ describe('resolveBaseFilter', () => {
       req: requestWith({ user: { id: 'user-1' } }),
     })
 
-    expect(filter).toEqual({ owner: { equals: 'user-1' } })
+    expect(filter).toEqual({ filter: { owner: { equals: 'user-1' } }, status: 'resolved' })
   })
 
   it('gives the filter the locale the admin panel is being viewed in, not the default one', async () => {
@@ -60,10 +60,10 @@ describe('resolveBaseFilter', () => {
       req: requestWith({ locale: 'de' }),
     })
 
-    expect(filter).toEqual({ language: { equals: 'de' } })
+    expect(filter).toEqual({ filter: { language: { equals: 'de' } }, status: 'resolved' })
   })
 
-  it('falls back to an unscoped search when the filter throws, instead of failing the render', async () => {
+  it('matches nothing when the filter throws, rather than widening to documents the filter would have hidden', async () => {
     const logged: unknown[] = []
 
     await expect(
@@ -78,21 +78,21 @@ describe('resolveBaseFilter', () => {
         ),
         req: requestWith(),
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ status: 'unavailable' })
 
     expect(logged).toHaveLength(1)
   })
 
-  it('falls back to an unscoped search when an async filter rejects', async () => {
+  it('matches nothing when an async filter rejects', async () => {
     await expect(
       resolveBaseFilter({
         payload: payloadWith({ baseFilter: () => Promise.reject(new Error('db unreachable')) }),
         req: requestWith(),
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ status: 'unavailable' })
   })
 
-  it('reports a configured filter that could not run because no request was passed', async () => {
+  it('matches nothing when a filter is configured but no request was passed to evaluate it with', async () => {
     const logged: unknown[] = []
 
     await expect(
@@ -100,7 +100,7 @@ describe('resolveBaseFilter', () => {
         payload: payloadWith({ baseFilter: () => ({ tenant: { equals: 'acme' } }) }, logged),
         req: undefined,
       }),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({ status: 'unavailable' })
 
     expect(logged).toHaveLength(1)
   })
@@ -108,7 +108,9 @@ describe('resolveBaseFilter', () => {
   it('stays quiet when no request is passed and no filter is configured', async () => {
     const logged: unknown[] = []
 
-    await resolveBaseFilter({ payload: payloadWith({}, logged), req: undefined })
+    await expect(
+      resolveBaseFilter({ payload: payloadWith({}, logged), req: undefined }),
+    ).resolves.toEqual({ status: 'resolved' })
 
     expect(logged).toHaveLength(0)
   })

--- a/admin-search/src/components/SearchWrapper/resolveBaseFilter.test.ts
+++ b/admin-search/src/components/SearchWrapper/resolveBaseFilter.test.ts
@@ -1,4 +1,4 @@
-import type { Payload } from 'payload'
+import type { Payload, PayloadRequest } from 'payload'
 
 import { describe, expect, it } from 'vitest'
 
@@ -8,47 +8,59 @@ import { resolveBaseFilter } from './resolveBaseFilter.js'
 
 const payloadWith = (pluginConfig?: AdminSearchPluginConfig, logged: unknown[] = []) =>
   ({
-    config: {
-      admin: { user: 'users' },
-      custom: pluginConfig ? { adminSearchPluginConfig: pluginConfig } : {},
-      i18n: { fallbackLanguage: 'en' },
-    },
+    config: { custom: pluginConfig ? { adminSearchPluginConfig: pluginConfig } : {} },
     logger: { error: (...args: unknown[]) => logged.push(args) },
   }) as unknown as Payload
 
-/** Stands in for the admin panel's i18n, which the resolver reuses instead of building one. */
-const i18n = { language: 'en', t: (key: string) => key } as never
+/**
+ * Stands in for the request Payload renders the admin panel with. Only the parts a filter
+ * reads are modelled: the incoming cookies, the signed-in user and the resolved locale.
+ */
+const requestWith = (
+  parts: { cookie?: string; locale?: string; user?: { id: string } } = {},
+): PayloadRequest =>
+  ({
+    headers: new Headers(parts.cookie ? { cookie: parts.cookie } : {}),
+    locale: parts.locale,
+    user: parts.user,
+  }) as unknown as PayloadRequest
 
 describe('resolveBaseFilter', () => {
   it('leaves the search unscoped when no base filter is configured', async () => {
     await expect(
-      resolveBaseFilter({ headers: new Headers(), i18n, payload: payloadWith({}) }),
+      resolveBaseFilter({ payload: payloadWith({}), req: requestWith() }),
     ).resolves.toBeUndefined()
   })
 
-  it('gives the filter a request carrying the incoming cookies, so it can scope by the selected tenant', async () => {
+  it('scopes by the tenant cookie the admin panel was requested with', async () => {
     const filter = await resolveBaseFilter({
-      headers: new Headers({ cookie: 'payload-tenant=acme' }),
-      i18n,
       payload: payloadWith({
         baseFilter: ({ req }) => ({
           tenant: { equals: req.headers.get('cookie')?.split('payload-tenant=')[1] },
         }),
       }),
+      req: requestWith({ cookie: 'payload-tenant=acme' }),
     })
 
     expect(filter).toEqual({ tenant: { equals: 'acme' } })
   })
 
-  it('gives the filter the signed-in user, so it can scope by who is searching', async () => {
+  it('scopes by the signed-in user', async () => {
     const filter = await resolveBaseFilter({
-      headers: new Headers(),
-      i18n,
       payload: payloadWith({ baseFilter: ({ req }) => ({ owner: { equals: req.user?.id } }) }),
-      user: { id: 'user-1', collection: 'users' },
+      req: requestWith({ user: { id: 'user-1' } }),
     })
 
     expect(filter).toEqual({ owner: { equals: 'user-1' } })
+  })
+
+  it('gives the filter the locale the admin panel is being viewed in, not the default one', async () => {
+    const filter = await resolveBaseFilter({
+      payload: payloadWith({ baseFilter: ({ req }) => ({ language: { equals: req.locale } }) }),
+      req: requestWith({ locale: 'de' }),
+    })
+
+    expect(filter).toEqual({ language: { equals: 'de' } })
   })
 
   it('falls back to an unscoped search when the filter throws, instead of failing the render', async () => {
@@ -56,8 +68,6 @@ describe('resolveBaseFilter', () => {
 
     await expect(
       resolveBaseFilter({
-        headers: new Headers(),
-        i18n,
         payload: payloadWith(
           {
             baseFilter: () => {
@@ -66,6 +76,7 @@ describe('resolveBaseFilter', () => {
           },
           logged,
         ),
+        req: requestWith(),
       }),
     ).resolves.toBeUndefined()
 
@@ -75,10 +86,30 @@ describe('resolveBaseFilter', () => {
   it('falls back to an unscoped search when an async filter rejects', async () => {
     await expect(
       resolveBaseFilter({
-        headers: new Headers(),
-        i18n,
         payload: payloadWith({ baseFilter: () => Promise.reject(new Error('db unreachable')) }),
+        req: requestWith(),
       }),
     ).resolves.toBeUndefined()
+  })
+
+  it('reports a configured filter that could not run because no request was passed', async () => {
+    const logged: unknown[] = []
+
+    await expect(
+      resolveBaseFilter({
+        payload: payloadWith({ baseFilter: () => ({ tenant: { equals: 'acme' } }) }, logged),
+        req: undefined,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(logged).toHaveLength(1)
+  })
+
+  it('stays quiet when no request is passed and no filter is configured', async () => {
+    const logged: unknown[] = []
+
+    await resolveBaseFilter({ payload: payloadWith({}, logged), req: undefined })
+
+    expect(logged).toHaveLength(0)
   })
 })

--- a/admin-search/src/components/SearchWrapper/resolveBaseFilter.test.ts
+++ b/admin-search/src/components/SearchWrapper/resolveBaseFilter.test.ts
@@ -1,0 +1,52 @@
+import type { Payload } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import type { AdminSearchPluginConfig } from '../../types/AdminSearchPluginConfig.js'
+
+import { resolveBaseFilter } from './resolveBaseFilter.js'
+
+const payloadWith = (pluginConfig?: AdminSearchPluginConfig) =>
+  ({
+    config: {
+      admin: { user: 'users' },
+      custom: pluginConfig ? { adminSearchPluginConfig: pluginConfig } : {},
+      i18n: { fallbackLanguage: 'en' },
+    },
+  }) as unknown as Payload
+
+/** Stands in for the admin panel's i18n, which the resolver reuses instead of building one. */
+const i18n = { language: 'en', t: (key: string) => key } as never
+
+describe('resolveBaseFilter', () => {
+  it('leaves the search unscoped when no base filter is configured', async () => {
+    await expect(
+      resolveBaseFilter({ headers: new Headers(), i18n, payload: payloadWith({}) }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('gives the filter a request carrying the incoming cookies, so it can scope by the selected tenant', async () => {
+    const filter = await resolveBaseFilter({
+      headers: new Headers({ cookie: 'payload-tenant=acme' }),
+      i18n,
+      payload: payloadWith({
+        baseFilter: ({ req }) => ({
+          tenant: { equals: req.headers.get('cookie')?.split('payload-tenant=')[1] },
+        }),
+      }),
+    })
+
+    expect(filter).toEqual({ tenant: { equals: 'acme' } })
+  })
+
+  it('gives the filter the signed-in user, so it can scope by who is searching', async () => {
+    const filter = await resolveBaseFilter({
+      headers: new Headers(),
+      i18n,
+      payload: payloadWith({ baseFilter: ({ req }) => ({ owner: { equals: req.user?.id } }) }),
+      user: { id: 'user-1', collection: 'users' },
+    })
+
+    expect(filter).toEqual({ owner: { equals: 'user-1' } })
+  })
+})

--- a/admin-search/src/components/SearchWrapper/resolveBaseFilter.ts
+++ b/admin-search/src/components/SearchWrapper/resolveBaseFilter.ts
@@ -1,0 +1,36 @@
+import type { Payload, PayloadRequest, TypedUser, Where } from 'payload'
+
+import type { AdminSearchPluginConfig } from '../../types/AdminSearchPluginConfig.js'
+
+/**
+ * Evaluates the configured `baseFilter` against the current admin request.
+ *
+ * Admin components receive `payload` and `user`, but no request — so one is built from the
+ * incoming headers, which is what carries the scope a filter reads (e.g. the `payload-tenant`
+ * cookie set by the multi-tenant plugin).
+ */
+export const resolveBaseFilter = async ({
+  headers,
+  i18n,
+  payload,
+  user,
+}: {
+  headers: Headers
+  i18n?: PayloadRequest['i18n']
+  payload: Payload
+  user?: TypedUser
+}): Promise<undefined | Where> => {
+  const baseFilter = (
+    payload.config.custom?.adminSearchPluginConfig as AdminSearchPluginConfig | undefined
+  )?.baseFilter
+
+  if (!baseFilter) {
+    return undefined
+  }
+
+  const { createLocalReq } = await import('payload')
+  // Reuse the admin panel's i18n rather than letting createLocalReq initialize its own.
+  const req = await createLocalReq({ req: { headers, i18n }, user }, payload)
+
+  return baseFilter({ req })
+}

--- a/admin-search/src/components/SearchWrapper/resolveBaseFilter.ts
+++ b/admin-search/src/components/SearchWrapper/resolveBaseFilter.ts
@@ -1,6 +1,7 @@
-import type { Payload, PayloadRequest, Where } from 'payload'
+import type { Payload, PayloadRequest } from 'payload'
 
 import type { AdminSearchPluginConfig } from '../../types/AdminSearchPluginConfig.js'
+import type { BaseFilterState } from '../../types/BaseFilterState.js'
 
 /**
  * Evaluates the configured `baseFilter` against the request the admin panel is rendering.
@@ -8,6 +9,10 @@ import type { AdminSearchPluginConfig } from '../../types/AdminSearchPluginConfi
  * The request is not built here: Payload already builds one for this render (see `initReq`
  * in `@payloadcms/next`, which resolves the locale on top of it) and passes it to admin
  * components as a server prop. Rebuilding it would drop that resolved locale.
+ *
+ * A configured filter that cannot be evaluated resolves to `unavailable`, which stops the
+ * search from running at all. Widening to every document instead would leak exactly what the
+ * filter exists to hide — across tenants, in the case it was built for.
  */
 export const resolveBaseFilter = async ({
   payload,
@@ -15,38 +20,37 @@ export const resolveBaseFilter = async ({
 }: {
   payload: Payload
   req?: PayloadRequest
-}): Promise<undefined | Where> => {
+}): Promise<BaseFilterState> => {
   const baseFilter = (
     payload.config.custom?.adminSearchPluginConfig as AdminSearchPluginConfig | undefined
   )?.baseFilter
 
   if (!baseFilter) {
-    return undefined
+    return { status: 'resolved' }
   }
 
   if (!req) {
     // `req` is not part of Payload's exported `ServerProps` type, only of what it passes at
-    // runtime. If a future version stops passing it, the search silently widens to every
-    // document — so say so loudly rather than letting it pass unnoticed.
+    // runtime. If a future version stops passing it, no filter can be evaluated at all, so
+    // name the cause — a search that returns nothing is otherwise hard to trace back to here.
     payload.logger.error(
-      'admin-search: no request was passed to the search component, so `baseFilter` could not be evaluated. The search is unscoped.',
+      'admin-search: no request was passed to the search component, so `baseFilter` could not be evaluated. The search returns no results.',
     )
 
-    return undefined
+    return { status: 'unavailable' }
   }
 
   try {
-    return await baseFilter({ req })
+    return { filter: await baseFilter({ req }), status: 'resolved' }
   } catch (error) {
     // The filter runs while the admin panel renders, so letting it throw would replace the
-    // whole page with an error, not just the search. It narrows a query rather than granting
-    // access, so falling back to an unscoped search is the lesser failure — but a silent one,
-    // hence the log.
+    // whole page with an error, not just the search. Failing the search alone is the lesser
+    // failure — but a silent one, hence the log.
     payload.logger.error(
       { err: error },
-      'admin-search: baseFilter threw, falling back to an unscoped search.',
+      'admin-search: baseFilter threw, so the search returns no results.',
     )
 
-    return undefined
+    return { status: 'unavailable' }
   }
 }

--- a/admin-search/src/components/SearchWrapper/resolveBaseFilter.ts
+++ b/admin-search/src/components/SearchWrapper/resolveBaseFilter.ts
@@ -32,5 +32,18 @@ export const resolveBaseFilter = async ({
   // Reuse the admin panel's i18n rather than letting createLocalReq initialize its own.
   const req = await createLocalReq({ req: { headers, i18n }, user }, payload)
 
-  return baseFilter({ req })
+  try {
+    return await baseFilter({ req })
+  } catch (error) {
+    // The filter runs while the admin panel renders, so letting it throw would replace the
+    // whole page with an error, not just the search. It narrows a query rather than granting
+    // access, so falling back to an unscoped search is the lesser failure — but a silent one,
+    // hence the log.
+    payload.logger.error(
+      { err: error },
+      'admin-search: baseFilter threw, falling back to an unscoped search.',
+    )
+
+    return undefined
+  }
 }

--- a/admin-search/src/components/SearchWrapper/resolveBaseFilter.ts
+++ b/admin-search/src/components/SearchWrapper/resolveBaseFilter.ts
@@ -1,24 +1,20 @@
-import type { Payload, PayloadRequest, TypedUser, Where } from 'payload'
+import type { Payload, PayloadRequest, Where } from 'payload'
 
 import type { AdminSearchPluginConfig } from '../../types/AdminSearchPluginConfig.js'
 
 /**
- * Evaluates the configured `baseFilter` against the current admin request.
+ * Evaluates the configured `baseFilter` against the request the admin panel is rendering.
  *
- * Admin components receive `payload` and `user`, but no request — so one is built from the
- * incoming headers, which is what carries the scope a filter reads (e.g. the `payload-tenant`
- * cookie set by the multi-tenant plugin).
+ * The request is not built here: Payload already builds one for this render (see `initReq`
+ * in `@payloadcms/next`, which resolves the locale on top of it) and passes it to admin
+ * components as a server prop. Rebuilding it would drop that resolved locale.
  */
 export const resolveBaseFilter = async ({
-  headers,
-  i18n,
   payload,
-  user,
+  req,
 }: {
-  headers: Headers
-  i18n?: PayloadRequest['i18n']
   payload: Payload
-  user?: TypedUser
+  req?: PayloadRequest
 }): Promise<undefined | Where> => {
   const baseFilter = (
     payload.config.custom?.adminSearchPluginConfig as AdminSearchPluginConfig | undefined
@@ -28,9 +24,16 @@ export const resolveBaseFilter = async ({
     return undefined
   }
 
-  const { createLocalReq } = await import('payload')
-  // Reuse the admin panel's i18n rather than letting createLocalReq initialize its own.
-  const req = await createLocalReq({ req: { headers, i18n }, user }, payload)
+  if (!req) {
+    // `req` is not part of Payload's exported `ServerProps` type, only of what it passes at
+    // runtime. If a future version stops passing it, the search silently widens to every
+    // document — so say so loudly rather than letting it pass unnoticed.
+    payload.logger.error(
+      'admin-search: no request was passed to the search component, so `baseFilter` could not be evaluated. The search is unscoped.',
+    )
+
+    return undefined
+  }
 
   try {
     return await baseFilter({ req })

--- a/admin-search/src/exports/client.ts
+++ b/admin-search/src/exports/client.ts
@@ -1,3 +1,3 @@
 export { SearchBar } from '../components/SearchBar/SearchBar.js'
 export { SearchButton } from '../components/SearchButton/SearchButton.js'
-export { SearchWrapper } from '../components/SearchWrapper/SearchWrapper.js'
+export { SearchWrapperClient } from '../components/SearchWrapper/SearchWrapperClient.js'

--- a/admin-search/src/exports/rsc.ts
+++ b/admin-search/src/exports/rsc.ts
@@ -1,0 +1,1 @@
+export { SearchWrapper } from '../components/SearchWrapper/SearchWrapper.js'

--- a/admin-search/src/plugin.test.ts
+++ b/admin-search/src/plugin.test.ts
@@ -1,0 +1,43 @@
+import type { Config } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { adminSearchPlugin } from './plugin.js'
+
+/** A config skeleton; the plugin only reads `admin`, `custom` and `i18n` off it. */
+const baseConfig = (config: Partial<Config> = {}) => ({ collections: [], ...config }) as Config
+
+describe('adminSearchPlugin', () => {
+  it('keeps the custom config other plugins put on the config, rather than replacing it', () => {
+    const result = adminSearchPlugin({})(
+      baseConfig({ custom: { someOtherPlugin: { setting: 'kept' } } }),
+    )
+
+    expect(result.custom?.someOtherPlugin).toEqual({ setting: 'kept' })
+  })
+
+  it('stores the options on the config, so the search server component can read the base filter back', () => {
+    const baseFilter = () => ({ tenant: { equals: 'acme' } })
+
+    const result = adminSearchPlugin({ baseFilter })(baseConfig())
+
+    expect(result.custom?.adminSearchPluginConfig).toMatchObject({ baseFilter })
+  })
+
+  it('leaves the config untouched when the plugin is disabled', () => {
+    const incoming = baseConfig({ custom: { someOtherPlugin: { setting: 'kept' } } })
+
+    expect(adminSearchPlugin({ enabled: false })(incoming)).toBe(incoming)
+  })
+
+  it('appends the search action instead of dropping the actions already configured', () => {
+    const result = adminSearchPlugin({})(
+      baseConfig({ admin: { components: { actions: ['some/other#Action'] } } }),
+    )
+
+    expect(result.admin?.components?.actions).toEqual([
+      'some/other#Action',
+      expect.objectContaining({ path: '@jhb.software/payload-admin-search/rsc#SearchWrapper' }),
+    ])
+  })
+})

--- a/admin-search/src/plugin.ts
+++ b/admin-search/src/plugin.ts
@@ -23,13 +23,21 @@ export const adminSearchPlugin =
           actions: [
             ...(incomingConfig.admin?.components?.actions || []),
             {
-              clientProps: {
+              // A server component, so it can evaluate `baseFilter` against the request
+              // before handing the resulting constraint to the client search UI.
+              path: '@jhb.software/payload-admin-search/rsc#SearchWrapper',
+              serverProps: {
                 style: headerSearchComponentStyle,
               },
-              path: '@jhb.software/payload-admin-search/client#SearchWrapper',
             },
           ],
         },
+      },
+      // The action component is referenced by path and cannot close over the options, so
+      // the server component reads them back from here.
+      custom: {
+        ...incomingConfig.custom,
+        adminSearchPluginConfig: pluginOptions,
       },
       i18n: {
         ...incomingConfig.i18n,

--- a/admin-search/src/types/AdminSearchPluginConfig.ts
+++ b/admin-search/src/types/AdminSearchPluginConfig.ts
@@ -1,4 +1,23 @@
+import type { PayloadRequest, Where } from 'payload'
+
 export type AdminSearchPluginConfig = {
+  /**
+   * Restricts document results to those matching a constraint resolved against the current
+   * request — e.g. the tenant selected in a multi-tenant admin panel, whose id the
+   * multi-tenant plugin keeps in the `payload-tenant` cookie:
+   *
+   * ```ts
+   * baseFilter: ({ req }) => ({
+   *   tenant: { equals: getTenantFromCookie(req.headers, req.payload.db.defaultIDType) },
+   * })
+   * ```
+   *
+   * The search collection must carry the field the filter constrains. This scopes what the
+   * search offers; it does not replace access control on the search collection itself.
+   */
+  baseFilter?: (args: { req: PayloadRequest }) => Promise<Where> | Where
+
   enabled?: boolean
+
   headerSearchComponentStyle?: 'bar' | 'button'
 }

--- a/admin-search/src/types/BaseFilterState.ts
+++ b/admin-search/src/types/BaseFilterState.ts
@@ -1,0 +1,10 @@
+import type { Where } from 'payload'
+
+/**
+ * The outcome of resolving the configured `baseFilter` for the current request.
+ *
+ * `unavailable` is not the same as an absent filter: a filter was configured but could not be
+ * evaluated, so the scope it would have applied is unknown. The search then matches nothing
+ * rather than widening to every document.
+ */
+export type BaseFilterState = { filter?: Where; status: 'resolved' } | { status: 'unavailable' }

--- a/admin-search/tsconfig.build.json
+++ b/admin-search/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["./src/**/*.test.ts", "./src/**/*.test.tsx"]
+}

--- a/admin-search/vitest.config.ts
+++ b/admin-search/vitest.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
     jsx: 'automatic',
   },
   test: {
-    // Only the sources — `dist` holds compiled copies of the same tests.
+    // Only the sources. `dist` never holds tests (the build excludes them), so this keeps
+    // a stray build output from being picked up as a second, stale copy of the suite.
     include: ['src/**/*.test.{ts,tsx}'],
   },
 })

--- a/admin-search/vitest.config.ts
+++ b/admin-search/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  oxc: {
+    jsx: 'automatic',
+  },
+  test: {
+    // Only the sources — `dist` holds compiled copies of the same tests.
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+})


### PR DESCRIPTION
## What

Adds a `baseFilter` option (`({ req }) => Where | Promise<Where>`) that restricts search results to a constraint resolved against the current request. The filter runs on the server and is combined with the typed query using `and`, so results stay in scope even before anything is typed.

The main use is multi-tenancy: scoping the search to the tenant selected in the admin panel.

```ts
adminSearchPlugin({
  baseFilter: ({ req }) => {
    const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
    return tenant ? { tenant: { equals: tenant } } : {}
  },
})
```

This scopes what the search offers, not what the API permits — it is not access control. The README points at `searchOverrides.access.read` for constraining `GET /api/search` server-side.

## BREAKING

The header component is now a server component so it can evaluate `baseFilter` before rendering. It moved:

- `@jhb.software/payload-admin-search/client#SearchWrapper` → `@jhb.software/payload-admin-search/rsc#SearchWrapper`
- the `/client` export now provides `SearchWrapperClient` in place of `SearchWrapper`

**Consumers must run `payload generate:importmap` after upgrading**, otherwise the search component resolves to nothing and disappears from the admin header.

Per the repo's breaking-change policy this is a `minor` bump (plugin is pre-1.0).

## Tests

- `src/components/SearchWrapper/resolveBaseFilter.test.ts`
- `src/components/SearchModal/buildSearchQuery.test.ts` — the base filter and the typed query are combined with `and`

Vitest is newly configured for this plugin (`vitest.config.ts`).

## Dev app demonstration

`dev/` gains a `tenants` collection, multi-tenant plugin wiring in `dev/src/payload.config.ts`, a `baseFilter` example in the plugin invocation, and seeded per-tenant documents. Switching tenants in the admin panel changes what the search returns.
