### PR TITLE
feat(alt-text)!: scope the health report per request via healthCheck.baseFilter

### DIFF
--- a/alt-text/.gitignore
+++ b/alt-text/.gitignore
@@ -368,6 +368,8 @@ $RECYCLE.BIN/
 
 # Custom
 /media
+# Dev app upload directory of the `images` collection
+dev/images
 *.db
 *.d.ts
 tsconfig.tsbuildinfo

--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- feat: add `healthCheck.baseFilter`, a `({ collection, req }) => Where` narrowing what the health report counts — in a multi-tenant CMS, to the tenant the request is for. It is resolved per collection, so collections without the constraining field can return `{}`, and the scan's cache key is derived from the resolved filters, so a scoped scan never serves one scope's counts to another.
+- feat!: **BREAKING**: `healthCheck` no longer accepts a function. Move the access check to `healthCheck: { access: ({ req }) => ... }`; the function form now throws at config load. `healthCheck: true` / `false` are unchanged.
+
 ## 0.10.0
 
 - feat: add `mistralResolver`, a resolver for Mistral's vision models (default `mistral-medium-latest`). It downloads the image and sends the bytes instead of passing the thumbnail URL to the provider: Mistral's fetcher requires a publicly reachable file — never true in local development, not true for private buckets — and some hosts refuse it with `File could not be fetched from url` (error 3310). All requested locales are generated in a single request.

--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- feat: add `healthCheck.baseFilter`, a `({ collection, req }) => Where` narrowing what the health report counts — in a multi-tenant CMS, to the tenant the request is for. It is resolved per collection, so collections without the constraining field can return `{}`, and the scan's cache key is derived from the resolved filters, so a scoped scan never serves one scope's counts to another.
-- feat!: **BREAKING**: `healthCheck` no longer accepts a function. Move the access check to `healthCheck: { access: ({ req }) => ... }`; the function form now throws at config load. `healthCheck: true` / `false` are unchanged.
+- feat: add `healthCheck.baseFilter`, a `({ collection, req }) => Where` narrowing what the health report counts — in a multi-tenant CMS, to the tenant the request is for. Resolved per collection, so collections without the constraining field can return `{}`. The scan's cache key is derived from the resolved filters, so one scope's counts are never served to another.
+- **BREAKING**: `healthCheck` no longer accepts a function. Move the access check to `healthCheck: { access: ({ req }) => ... }`; the function form now throws at config load. `healthCheck: true` / `false` are unchanged.
 
 ## 0.10.0
 

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -11,6 +11,7 @@ A [Payload CMS](https://payloadcms.com/) plugin that adds AI-powered alt text ge
 - Bulk generation for processing multiple images at once
 - Full localization support
 - Dashboard health widget with cached coverage insights across all configured upload collections
+- Multi-tenant aware: the health report can be scoped to the tenant the request is for
 
 When the plugin is enabled for an upload collection, it will:
 
@@ -207,9 +208,11 @@ Set `healthCheck: false` in the plugin config to disable the REST endpoint, cach
 
 #### Gating and scoping the report
 
-`healthCheck` also takes an object:
+`healthCheck` also takes an object. The main use of `baseFilter` is multi-tenancy: scope the report to the tenant selected in the admin panel, whose id [@payloadcms/plugin-multi-tenant](https://payloadcms.com/docs/plugins/multi-tenant) keeps in the `payload-tenant` cookie.
 
 ```ts
+import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
+
 healthCheck: {
   // Restrict the collection-wide report more strictly than the per-document
   // generate endpoints. Gates the REST endpoint and hides the widget.

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -226,7 +226,7 @@ healthCheck: {
 }
 ```
 
-`baseFilter` returns a `Where` that is ANDed onto the scan's MIME type filter. It is resolved once per configured collection, so a collection that does not carry the constraining field — a media library shared across tenants, say — can return `{}` and be scanned whole. Returning `{}` or `undefined` for every collection is the default behaviour.
+`baseFilter` returns a `Where` that is ANDed onto the scan's MIME type filter. It is resolved once per configured collection, so a collection that does not carry the constraining field — a media library shared across tenants, say — can return `{}` and be scanned whole. Returning `{}` for every collection is the default behaviour.
 
 The scan is cached across requests, and its cache key is derived from the resolved filters: a narrowed scan always gets its own cache entry, so one tenant's counts can never be served to another. Cache invalidation stays per collection, so a write in one tenant refreshes the report for all of them.
 

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -77,19 +77,19 @@ This is also the recommended escape hatch if you hit Payload's Postgres SQL-buil
 
 ### Plugin Options
 
-| Option                       | Type                                       | Required | Description                                                                                                                                                                                                                                                                                                               |
-| ---------------------------- | ------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `collections`                | `(CollectionSlug \| CollectionObj)[]`      | Yes      | Collections to enable alt text generation for (see [Per-collection options](#per-collection-options))                                                                                                                                                                                                                     |
-| `resolver`                   | `AltTextResolver`                          | Yes      | Alt text resolver to use (e.g., `openAIResolver`)                                                                                                                                                                                                                                                                         |
-| `getImageThumbnail`          | `Function`                                 | Yes      | Function to get the thumbnail URL from an image document                                                                                                                                                                                                                                                                  |
-| `enabled`                    | `boolean`                                  | No       | Whether to enable the plugin                                                                                                                                                                                                                                                                                              |
-| `access`                     | `({ req }) => boolean \| Promise<boolean>` | No       | Access control for the plugin's REST endpoints. Defaults to `({ req }) => !!req.user` (any authenticated user) — see [Authentication](#authentication)                                                                                                                                                                    |
-| `locale`                     | `string`                                   | No       | Locale for alt text generation (required when localization is disabled)                                                                                                                                                                                                                                                   |
-| `maxBulkGenerateConcurrency` | `number`                                   | No       | Maximum concurrent API requests for bulk operations (default: 16)                                                                                                                                                                                                                                                         |
-| `maxBulkGenerateIds`         | `number`                                   | No       | Maximum number of image IDs accepted per bulk generate request; larger requests are rejected with `400`. Duplicate IDs are collapsed before the limit is applied (default: 100)                                                                                                                                           |
-| `fieldsOverride`             | `Function`                                 | No       | Override the default fields inserted by the plugin                                                                                                                                                                                                                                                                        |
-| `healthCheck`                | `boolean \| Function`                      | No       | Alt text health tracking (REST endpoint, cache revalidation hooks, dashboard widget). `false` disables it; `true` enables it gated by `access`; a `({ req }) => boolean` function enables it and gates both the endpoint and the widget — use it to restrict the collection-wide report, e.g. to admins (default: `true`) |
-| `imageThumbnailMimeType`     | `string`                                   | No       | The MIME type `getImageThumbnail` delivers. Set it when your thumbnail URL transcodes the image, so the stored format no longer decides whether generation is possible (see [Transcoding thumbnails](#transcoding-thumbnails))                                                                                            |
+| Option                       | Type                                       | Required | Description                                                                                                                                                                                                                                                                                           |
+| ---------------------------- | ------------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `collections`                | `(CollectionSlug \| CollectionObj)[]`      | Yes      | Collections to enable alt text generation for (see [Per-collection options](#per-collection-options))                                                                                                                                                                                                 |
+| `resolver`                   | `AltTextResolver`                          | Yes      | Alt text resolver to use (e.g., `openAIResolver`)                                                                                                                                                                                                                                                     |
+| `getImageThumbnail`          | `Function`                                 | Yes      | Function to get the thumbnail URL from an image document                                                                                                                                                                                                                                              |
+| `enabled`                    | `boolean`                                  | No       | Whether to enable the plugin                                                                                                                                                                                                                                                                          |
+| `access`                     | `({ req }) => boolean \| Promise<boolean>` | No       | Access control for the plugin's REST endpoints. Defaults to `({ req }) => !!req.user` (any authenticated user) — see [Authentication](#authentication)                                                                                                                                                |
+| `locale`                     | `string`                                   | No       | Locale for alt text generation (required when localization is disabled)                                                                                                                                                                                                                               |
+| `maxBulkGenerateConcurrency` | `number`                                   | No       | Maximum concurrent API requests for bulk operations (default: 16)                                                                                                                                                                                                                                     |
+| `maxBulkGenerateIds`         | `number`                                   | No       | Maximum number of image IDs accepted per bulk generate request; larger requests are rejected with `400`. Duplicate IDs are collapsed before the limit is applied (default: 100)                                                                                                                       |
+| `fieldsOverride`             | `Function`                                 | No       | Override the default fields inserted by the plugin                                                                                                                                                                                                                                                    |
+| `healthCheck`                | `boolean \| AltTextHealthCheckConfig`      | No       | Alt text health tracking (REST endpoint, cache revalidation hooks, dashboard widget). `false` disables it; `true` enables it for every document, gated by `access`; an object enables it and configures its `access` gate and `baseFilter` (see [Health report](#dashboard-widget)) (default: `true`) |
+| `imageThumbnailMimeType`     | `string`                                   | No       | The MIME type `getImageThumbnail` delivers. Set it when your thumbnail URL transcodes the image, so the stored format no longer decides whether generation is possible (see [Transcoding thumbnails](#transcoding-thumbnails))                                                                        |
 
 `getImageThumbnail` receives the document and `{ collection, req }`, so a single function can build different URLs per collection:
 
@@ -205,6 +205,30 @@ buildConfig({
 
 Set `healthCheck: false` in the plugin config to disable the REST endpoint, cache revalidation hooks, and dashboard widget. If your project replaces the default dashboard via `admin.components.views.dashboard`, you need to integrate the widget into your custom dashboard yourself.
 
+#### Gating and scoping the report
+
+`healthCheck` also takes an object:
+
+```ts
+healthCheck: {
+  // Restrict the collection-wide report more strictly than the per-document
+  // generate endpoints. Gates the REST endpoint and hides the widget.
+  access: ({ req }) => req.user?.role === 'admin',
+  // Narrow what the report counts, e.g. to the tenant selected in the admin panel.
+  baseFilter: ({ collection, req }) => {
+    const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
+
+    return tenant ? { tenant: { equals: tenant } } : {}
+  },
+}
+```
+
+`baseFilter` returns a `Where` that is ANDed onto the scan's MIME type filter. It is resolved once per configured collection, so a collection that does not carry the constraining field — a media library shared across tenants, say — can return `{}` and be scanned whole. Returning `{}` or `undefined` for every collection is the default behaviour.
+
+The scan is cached across requests, and its cache key is derived from the resolved filters: a narrowed scan always gets its own cache entry, so one tenant's counts can never be served to another. Cache invalidation stays per collection, so a write in one tenant refreshes the report for all of them.
+
+This scopes what the report counts, not who may see it — use `access` for that. Independently of both, the report always omits the collections the requesting user cannot read.
+
 #### Skipping cache revalidation for individual writes
 
 The plugin invalidates the cached health scan via `afterChange` and `afterDelete` hooks. For writes that don't need to invalidate the cache — typically seed data created from `payload.onInit`, batch imports, or migrations — pass `context: { disableRevalidate: true }` to skip the revalidation:
@@ -314,7 +338,7 @@ That default fits a setup where every Payload user is trusted staff. Generating 
 access: ({ req }) => req.user?.role === 'editor'
 ```
 
-Beyond that gate, the generate endpoints enforce each collection's own access control on the documents they read and write, and the health endpoint reports only the collections the requesting user can read (and can be gated separately via the `healthCheck` function).
+Beyond that gate, the generate endpoints enforce each collection's own access control on the documents they read and write, and the health endpoint reports only the collections the requesting user can read (and can be gated separately via `healthCheck.access`).
 
 ### `POST /api/alt-text/generate`
 

--- a/alt-text/dev/package.json
+++ b/alt-text/dev/package.json
@@ -20,6 +20,7 @@
     "@jhb.software/payload-alt-text-plugin": "workspace:*",
     "@payloadcms/db-mongodb": "^3.88.0",
     "@payloadcms/next": "^3.88.0",
+    "@payloadcms/plugin-multi-tenant": "^3.88.0",
     "@payloadcms/translations": "^3.88.0",
     "@payloadcms/ui": "^3.88.0",
     "next": "16.3.0",

--- a/alt-text/dev/src/app/(payload)/admin/importMap.js
+++ b/alt-text/dev/src/app/(payload)/admin/importMap.js
@@ -1,18 +1,28 @@
+import { TenantField as TenantField_1d0591e3cf4f332c83a86da13a0de59a } from '@payloadcms/plugin-multi-tenant/client'
 import { AltTextField as AltTextField_0a0a871430f540863f89f94882312cf1 } from '@jhb.software/payload-alt-text-plugin/client'
 import { BulkGenerateAltTextsButton as BulkGenerateAltTextsButton_0a0a871430f540863f89f94882312cf1 } from '@jhb.software/payload-alt-text-plugin/client'
+import { AssignTenantFieldTrigger as AssignTenantFieldTrigger_1d0591e3cf4f332c83a86da13a0de59a } from '@payloadcms/plugin-multi-tenant/client'
 import { FolderTableCell as FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 import { FolderField as FolderField_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
+import { WatchTenantCollection as WatchTenantCollection_1d0591e3cf4f332c83a86da13a0de59a } from '@payloadcms/plugin-multi-tenant/client'
 import { FolderTypeField as FolderTypeField_2b8867833a34864a02ddf429b0728a40 } from '@payloadcms/next/client'
+import { TenantSelector as TenantSelector_d6d5f193a167989e2ee7d14202901e62 } from '@payloadcms/plugin-multi-tenant/rsc'
+import { TenantSelectionProvider as TenantSelectionProvider_d6d5f193a167989e2ee7d14202901e62 } from '@payloadcms/plugin-multi-tenant/rsc'
 import { AltTextHealthWidget as AltTextHealthWidget_a35949d21b38efe8500764b5b0b3638b } from '@jhb.software/payload-alt-text-plugin/server'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 /** @type import('payload').ImportMap */
 export const importMap = {
+  "@payloadcms/plugin-multi-tenant/client#TenantField": TenantField_1d0591e3cf4f332c83a86da13a0de59a,
   "@jhb.software/payload-alt-text-plugin/client#AltTextField": AltTextField_0a0a871430f540863f89f94882312cf1,
   "@jhb.software/payload-alt-text-plugin/client#BulkGenerateAltTextsButton": BulkGenerateAltTextsButton_0a0a871430f540863f89f94882312cf1,
+  "@payloadcms/plugin-multi-tenant/client#AssignTenantFieldTrigger": AssignTenantFieldTrigger_1d0591e3cf4f332c83a86da13a0de59a,
   "@payloadcms/next/rsc#FolderTableCell": FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1,
   "@payloadcms/next/rsc#FolderField": FolderField_f9c02e79a4aed9a3924487c0cd4cafb1,
+  "@payloadcms/plugin-multi-tenant/client#WatchTenantCollection": WatchTenantCollection_1d0591e3cf4f332c83a86da13a0de59a,
   "@payloadcms/next/client#FolderTypeField": FolderTypeField_2b8867833a34864a02ddf429b0728a40,
+  "@payloadcms/plugin-multi-tenant/rsc#TenantSelector": TenantSelector_d6d5f193a167989e2ee7d14202901e62,
+  "@payloadcms/plugin-multi-tenant/rsc#TenantSelectionProvider": TenantSelectionProvider_d6d5f193a167989e2ee7d14202901e62,
   "@jhb.software/payload-alt-text-plugin/server#AltTextHealthWidget": AltTextHealthWidget_a35949d21b38efe8500764b5b0b3638b,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/alt-text/dev/src/collections/Tenants.ts
+++ b/alt-text/dev/src/collections/Tenants.ts
@@ -1,0 +1,15 @@
+import type { CollectionConfig } from 'payload'
+
+export const Tenants: CollectionConfig = {
+  slug: 'tenants',
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+  ],
+}

--- a/alt-text/dev/src/payload-types.ts
+++ b/alt-text/dev/src/payload-types.ts
@@ -71,6 +71,7 @@ export interface Config {
     media: Media;
     images: Image;
     'media-with-folders': MediaWithFolder;
+    tenants: Tenant;
     'payload-kv': PayloadKv;
     'payload-folders': FolderInterface;
     'payload-locked-documents': PayloadLockedDocument;
@@ -87,6 +88,7 @@ export interface Config {
     media: MediaSelect<false> | MediaSelect<true>;
     images: ImagesSelect<false> | ImagesSelect<true>;
     'media-with-folders': MediaWithFoldersSelect<false> | MediaWithFoldersSelect<true>;
+    tenants: TenantsSelect<false> | TenantsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-folders': PayloadFoldersSelect<false> | PayloadFoldersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -134,6 +136,12 @@ export interface UserAuthOperations {
  */
 export interface User {
   id: string;
+  tenants?:
+    | {
+        tenant: string | Tenant;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -155,10 +163,21 @@ export interface User {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tenants".
+ */
+export interface Tenant {
+  id: string;
+  name: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "media".
  */
 export interface Media {
   id: string;
+  tenant?: (string | null) | Tenant;
   alt: string;
   /**
    * Keywords which describe the image. Used when searching for the image.
@@ -182,6 +201,7 @@ export interface Media {
  */
 export interface Image {
   id: string;
+  tenant?: (string | null) | Tenant;
   alt: string;
   /**
    * Keywords which describe the image. Used when searching for the image.
@@ -290,6 +310,10 @@ export interface PayloadLockedDocument {
         value: string | MediaWithFolder;
       } | null)
     | ({
+        relationTo: 'tenants';
+        value: string | Tenant;
+      } | null)
+    | ({
         relationTo: 'payload-folders';
         value: string | FolderInterface;
       } | null);
@@ -340,6 +364,12 @@ export interface PayloadMigration {
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
+  tenants?:
+    | T
+    | {
+        tenant?: T;
+        id?: T;
+      };
   updatedAt?: T;
   createdAt?: T;
   email?: T;
@@ -362,6 +392,7 @@ export interface UsersSelect<T extends boolean = true> {
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
+  tenant?: T;
   alt?: T;
   keywords?: T;
   updatedAt?: T;
@@ -381,6 +412,7 @@ export interface MediaSelect<T extends boolean = true> {
  * via the `definition` "images_select".
  */
 export interface ImagesSelect<T extends boolean = true> {
+  tenant?: T;
   alt?: T;
   keywords?: T;
   updatedAt?: T;
@@ -414,6 +446,15 @@ export interface MediaWithFoldersSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tenants_select".
+ */
+export interface TenantsSelect<T extends boolean = true> {
+  name?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/alt-text/dev/src/payload.config.ts
+++ b/alt-text/dev/src/payload.config.ts
@@ -5,14 +5,18 @@ import {
   validateAltText,
 } from '@jhb.software/payload-alt-text-plugin'
 import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import { multiTenantPlugin } from '@payloadcms/plugin-multi-tenant'
+import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
 import { de } from '@payloadcms/translations/languages/de'
 import { en } from '@payloadcms/translations/languages/en'
 import path from 'path'
+import type { Where } from 'payload'
 import { buildConfig } from 'payload'
 import { fileURLToPath } from 'url'
 import { Media } from './collections/Media'
 import { Images } from './collections/Images'
 import { MediaWithFolders } from './collections/MediaWithFolders'
+import { Tenants } from './collections/Tenants'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -61,6 +65,7 @@ export default buildConfig({
     Media,
     Images,
     MediaWithFolders,
+    Tenants,
   ],
   db: mongooseAdapter({
     url: process.env.MONGODB_URL!,
@@ -70,6 +75,10 @@ export default buildConfig({
     outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
   plugins: [
+    multiTenantPlugin({
+      collections: { images: {}, media: {} },
+      userHasAccessToAllTenants: () => true,
+    }),
     payloadAltTextPlugin({
       collections: [
         // `media` accepts both images and videos — restrict alt text tracking to images only.
@@ -114,10 +123,28 @@ export default buildConfig({
       // Selecting more than this in the list view returns a 400 instead of
       // fanning out into an unbounded number of paid resolver calls.
       maxBulkGenerateIds: 25,
-      // The function form gates the collection-wide health report (endpoint and
-      // widget) more strictly than the per-document generate endpoints, which
-      // allow any authenticated user: here only the designated admin sees it.
-      healthCheck: ({ req }) => req.user?.email === 'dev@payloadcms.com',
+      healthCheck: {
+        // Gates the collection-wide health report (endpoint and widget) more
+        // strictly than the per-document generate endpoints, which allow any
+        // authenticated user: here only the designated admin sees it.
+        access: ({ req }) => req.user?.email === 'dev@payloadcms.com',
+        // Counts only the images of the tenant selected in the admin panel.
+        // Switch tenants in the selector and the widget's numbers follow.
+        baseFilter: ({ collection, req }): Where => {
+          // `media-with-folders` is shared across tenants, so it carries no
+          // `tenant` field — scoping it would be an error. This is why the
+          // filter is resolved per collection.
+          if (collection === 'media-with-folders') {
+            return {}
+          }
+
+          const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
+
+          // No tenant selected: report every document, matching what the tenant
+          // selector shows.
+          return tenant ? { tenant: { equals: tenant } } : {}
+        },
+      },
       // `media` and `images` are the website's images: they are served through
       // an image CDN that always emits WebP, whatever was uploaded. Declaring
       // that delivered format takes the stored mime type out of the decision
@@ -173,6 +200,38 @@ export default buildConfig({
         },
         filePath: path.resolve(dirname, '../seed/sample-image.png'),
       })
+    }
+
+    // Two tenants with deliberately different alt text coverage, so the health
+    // widget's numbers visibly change when the tenant selector is switched:
+    // Acme has one complete image, Globex has two images with none.
+    const existingTenants = await payload.find({ collection: 'tenants', limit: 1 })
+
+    if (existingTenants.docs.length === 0) {
+      const seedImage = path.resolve(dirname, '../seed/sample-image.png')
+
+      const acme = await payload.create({
+        collection: 'tenants',
+        data: { name: 'Acme' },
+      })
+      const globex = await payload.create({
+        collection: 'tenants',
+        data: { name: 'Globex' },
+      })
+
+      const images: { alt: string; tenant: string }[] = [
+        { alt: 'An Acme product photo', tenant: acme.id as string },
+        { alt: '', tenant: globex.id as string },
+        { alt: '', tenant: globex.id as string },
+      ]
+
+      for (const { alt, tenant } of images) {
+        await payload.create({
+          collection: 'images',
+          data: { alt, tenant },
+          filePath: seedImage,
+        })
+      }
     }
   },
 })

--- a/alt-text/pnpm-lock.yaml
+++ b/alt-text/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@payloadcms/next':
         specifier: ^3.88.0
         version: 3.88.0(@types/react@19.2.18)(graphql@16.12.0)(monaco-editor@0.55.1)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      '@payloadcms/plugin-multi-tenant':
+        specifier: ^3.88.0
+        version: 3.88.0(@payloadcms/ui@3.88.0(@types/react@19.2.18)(monaco-editor@0.55.1)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))
       '@payloadcms/translations':
         specifier: ^3.88.0
         version: 3.88.0
@@ -1014,6 +1017,12 @@ packages:
     peerDependencies:
       graphql: ^16.8.1
       next: 16.3.0
+      payload: 3.88.0
+
+  '@payloadcms/plugin-multi-tenant@3.88.0':
+    resolution: {integrity: sha512-dykHQ3bqXYUzm1RM/1DAjgiL3DdJctTi0GKYlwvMnYVoQtsc78zOajFOQDkp9yXG3yMqvoQc48r9yxRStUe6wA==}
+    peerDependencies:
+      '@payloadcms/ui': 3.88.0
       payload: 3.88.0
 
   '@payloadcms/translations@3.88.0':
@@ -2057,6 +2066,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -4746,6 +4756,11 @@ snapshots:
       - react-dom
       - supports-color
       - typescript
+
+  '@payloadcms/plugin-multi-tenant@3.88.0(@payloadcms/ui@3.88.0(@types/react@19.2.18)(monaco-editor@0.55.1)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))':
+    dependencies:
+      '@payloadcms/ui': 3.88.0(@types/react@19.2.18)(monaco-editor@0.55.1)(next@16.3.0(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(payload@3.88.0(graphql@16.12.0)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+      payload: 3.88.0(graphql@16.12.0)(typescript@6.0.3)
 
   '@payloadcms/translations@3.88.0':
     dependencies:

--- a/alt-text/src/index.ts
+++ b/alt-text/src/index.ts
@@ -5,6 +5,8 @@ export { openAIResolver } from './resolvers/openAI.js'
 export * from './resolvers/types.js'
 export type {
   AltTextCollectionConfig,
+  AltTextHealthBaseFilter,
+  AltTextHealthCheckConfig,
   GetImageThumbnail,
   IncomingAltTextPluginConfig as AltTextPluginConfig,
 } from './types/AltTextPluginConfig.js'

--- a/alt-text/src/plugin.ts
+++ b/alt-text/src/plugin.ts
@@ -83,12 +83,20 @@ export const payloadAltTextPlugin =
 
     const access = incomingPluginConfig.access ?? (({ req }) => !!req.user)
 
-    // A function form of `healthCheck` doubles as the health report's access
-    // gate; otherwise it falls back to the shared `access`.
-    const healthCheckAccess =
-      typeof incomingPluginConfig.healthCheck === 'function'
-        ? incomingPluginConfig.healthCheck
-        : access
+    // The former function form was the health report's access gate. Accepting it
+    // silently would widen that gate to the plugin's `access`, so it fails at boot.
+    if (typeof incomingPluginConfig.healthCheck === 'function') {
+      throw new Error(
+        'The alt-text plugin no longer accepts a function for `healthCheck`. ' +
+          'Move the access check to `healthCheck: { access: ({ req }) => ... }`.',
+      )
+    }
+
+    const healthCheckConfig =
+      typeof incomingPluginConfig.healthCheck === 'object' ? incomingPluginConfig.healthCheck : {}
+
+    // The health report's own gate, falling back to the shared `access`.
+    const healthCheckAccess = healthCheckConfig.access ?? access
 
     const pluginConfig: AltTextPluginConfig = {
       access,
@@ -98,6 +106,7 @@ export const payloadAltTextPlugin =
       getImageThumbnail: incomingPluginConfig.getImageThumbnail,
       healthCheck: enableHealthCheck,
       healthCheckAccess,
+      healthCheckBaseFilter: healthCheckConfig.baseFilter,
       locale: incomingPluginConfig.locale,
       locales,
       maxBulkGenerateConcurrency: incomingPluginConfig.maxBulkGenerateConcurrency ?? 16,

--- a/alt-text/src/types/AltTextPluginConfig.ts
+++ b/alt-text/src/types/AltTextPluginConfig.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, Field, PayloadRequest } from 'payload'
+import type { CollectionSlug, Field, PayloadRequest, Where } from 'payload'
 
 import type { AltTextResolver } from '../resolvers/types.js'
 import type {
@@ -25,6 +25,48 @@ export type GetImageThumbnail = (
   doc: Record<string, unknown>,
   args: { collection: CollectionSlug; req: PayloadRequest },
 ) => Promise<string> | string
+
+/**
+ * Narrows the health scan of one collection to a subset of its documents — in a
+ * multi-tenant CMS, to the tenant the request is for. The returned constraint is
+ * ANDed onto the scan's MIME type filter.
+ *
+ * Called once per configured collection, so collections that do not carry the
+ * constraining field (a media library shared across tenants, say) can return `{}`
+ * instead of being queried for a field they do not have.
+ *
+ * Return `{}` or `undefined` to scan the collection whole.
+ *
+ * @param args.collection The slug of the collection being scanned.
+ * @param args.req The request the scan runs for.
+ */
+export type AltTextHealthBaseFilter = (args: {
+  collection: CollectionSlug
+  req: PayloadRequest
+}) => Promise<undefined | Where> | undefined | Where
+
+/** Configuration of the alt text health feature. */
+export type AltTextHealthCheckConfig = {
+  /**
+   * Access control for the health report — both the REST endpoint and the dashboard
+   * widget, which hides itself when this denies.
+   *
+   * Use it to restrict the collection-wide report more strictly than the
+   * per-document generate endpoints (e.g. to admins).
+   *
+   * @default the plugin's `access`
+   */
+  access?: (args: { req: PayloadRequest }) => boolean | Promise<boolean>
+
+  /**
+   * Narrows what the report counts. See {@link AltTextHealthBaseFilter}.
+   *
+   * This is not access control: it scopes the aggregate, it does not decide who
+   * may see it. Use `access` for that, and note the report is always filtered to
+   * the collections the requesting user can read.
+   */
+  baseFilter?: AltTextHealthBaseFilter
+}
 
 /** Configuration options for the alt text plugin. */
 export type IncomingAltTextPluginConfig = {
@@ -74,17 +116,12 @@ export type IncomingAltTextPluginConfig = {
    * Controls the alt text health feature (REST endpoint, cache revalidation hooks, and dashboard widget).
    *
    * - `false` disables the entire feature.
-   * - `true` enables it, gated by `access`.
-   * - A function enables it and gates both the endpoint and the dashboard widget
-   *   with that access check — use this to restrict the collection-wide report
-   *   more strictly than the per-document generate endpoints (e.g. to admins).
-   *
-   * Regardless of the gate, the report is always filtered to the collections the
-   * requesting user can read.
+   * - `true` enables it, gated by `access` and covering every document.
+   * - An object enables it and configures it. See {@link AltTextHealthCheckConfig}.
    *
    * @default true
    */
-  healthCheck?: ((args: { req: PayloadRequest }) => boolean | Promise<boolean>) | boolean
+  healthCheck?: AltTextHealthCheckConfig | boolean
 
   /**
    * The MIME type `getImageThumbnail` delivers, for every configured collection.
@@ -154,6 +191,9 @@ export type AltTextPluginConfig = {
 
   /** Access control for the health endpoint. Defaults to `access`. */
   healthCheckAccess: (args: { req: PayloadRequest }) => boolean | Promise<boolean>
+
+  /** Narrows what the health report counts. See {@link AltTextHealthBaseFilter}. */
+  healthCheckBaseFilter?: AltTextHealthBaseFilter
 
   /** The locale to generate alt texts in when localization is disabled. */
   locale?: string

--- a/alt-text/src/types/AltTextPluginConfig.ts
+++ b/alt-text/src/types/AltTextPluginConfig.ts
@@ -35,7 +35,7 @@ export type GetImageThumbnail = (
  * constraining field (a media library shared across tenants, say) can return `{}`
  * instead of being queried for a field they do not have.
  *
- * Return `{}` or `undefined` to scan the collection whole.
+ * Return `{}` to scan the collection whole.
  *
  * @param args.collection The slug of the collection being scanned.
  * @param args.req The request the scan runs for.
@@ -43,7 +43,7 @@ export type GetImageThumbnail = (
 export type AltTextHealthBaseFilter = (args: {
   collection: CollectionSlug
   req: PayloadRequest
-}) => Promise<undefined | Where> | undefined | Where
+}) => Promise<Where> | Where
 
 /** Configuration of the alt text health feature. */
 export type AltTextHealthCheckConfig = {

--- a/alt-text/src/utilities/altTextHealth.ts
+++ b/alt-text/src/utilities/altTextHealth.ts
@@ -1,4 +1,4 @@
-import type { Payload, PayloadRequest } from 'payload'
+import type { Payload, PayloadRequest, Where } from 'payload'
 
 import { unstable_cache } from 'next/cache.js'
 
@@ -6,10 +6,12 @@ import type {
   AltTextPluginConfig,
   NormalizedAltTextCollectionConfig,
 } from '../types/AltTextPluginConfig.js'
+import type { AltTextHealthCacheFactory } from './altTextHealthCache.js'
 
 import { createCachedAltTextHealthScan } from './altTextHealthCache.js'
 import { localesFromConfig } from './localesFromConfig.js'
 import { buildMimeTypeWhere } from './mimeTypes.js'
+import { stableStringify } from './stableStringify.js'
 import { summarizeCollection } from './summarizeCollection.js'
 
 export const ALT_TEXT_HEALTH_PLUGIN_SLUG = 'alt-text'
@@ -17,7 +19,9 @@ export const ALT_TEXT_HEALTH_CACHE_TTL = 3600
 export const ALT_TEXT_HEALTH_GLOBAL_TAG = 'alt-text-health'
 
 export type AltTextHealthErrorCode =
-  'ALT_TEXT_COLLECTION_READ_FAILED' | 'ALT_TEXT_PLUGIN_CONFIG_MISSING'
+  | 'ALT_TEXT_BASE_FILTER_FAILED'
+  | 'ALT_TEXT_COLLECTION_READ_FAILED'
+  | 'ALT_TEXT_PLUGIN_CONFIG_MISSING'
 
 export type AltTextHealthError = {
   code: AltTextHealthErrorCode
@@ -53,6 +57,8 @@ export type AltTextHealthWidgetData = {
 }
 
 type AltTextHealthComputationArgs = {
+  /** The resolved base filter per collection slug, if one is configured. */
+  baseFilters: Record<string, undefined | Where>
   collections: NormalizedAltTextCollectionConfig[]
   isLocalized: boolean
   localeCodes: string[]
@@ -84,16 +90,24 @@ const createCollectionReadError = (collection: string, message: string) => ({
 
 const PAGE_SIZE = 500
 
+const isEmptyWhere = (where: undefined | Where): boolean =>
+  !where || Object.keys(where).length === 0
+
 async function fetchAllDocs(
   payload: Payload,
   collection: string,
   isLocalized: boolean,
   mimeTypes: readonly string[],
+  baseFilter: undefined | Where,
 ): Promise<{ alt: unknown; id: number | string }[]> {
-  const where = buildMimeTypeWhere(mimeTypes)
-  if (!where) {
+  const mimeTypeWhere = buildMimeTypeWhere(mimeTypes)
+  if (!mimeTypeWhere) {
     return []
   }
+
+  // The scan runs with `overrideAccess: true`, so a narrowing constraint has to be
+  // part of the query itself — this is what keeps the aggregate within one tenant.
+  const where = isEmptyWhere(baseFilter) ? mimeTypeWhere : { and: [mimeTypeWhere, baseFilter!] }
 
   const docs: { alt: unknown; id: number | string }[] = []
   let page = 1
@@ -129,6 +143,7 @@ async function fetchAllDocs(
 }
 
 async function computeAltTextHealthScan({
+  baseFilters,
   collections,
   isLocalized,
   localeCodes,
@@ -137,7 +152,7 @@ async function computeAltTextHealthScan({
   const collectionSummaries = await Promise.all(
     collections.map(async ({ slug, mimeTypes }): Promise<AltTextHealthScanCollection> => {
       try {
-        const docs = await fetchAllDocs(payload, slug, isLocalized, mimeTypes)
+        const docs = await fetchAllDocs(payload, slug, isLocalized, mimeTypes, baseFilters[slug])
 
         return summarizeCollection({
           collection: slug,
@@ -186,7 +201,55 @@ async function computeAltTextHealthScan({
 export const getAltTextHealthCollectionTag = (collectionSlug: string): string =>
   `${ALT_TEXT_HEALTH_GLOBAL_TAG}:${collectionSlug}`
 
-async function getAltTextHealthScan(req: PayloadRequest): Promise<AltTextHealthScan> {
+/**
+ * Resolves the configured base filter for every scanned collection.
+ *
+ * A throwing filter (a tenant cookie pointing at a deleted tenant, say) must not
+ * take the dashboard down, and must never fall back to an unfiltered scan — so it
+ * ends the scan with an error the widget and the endpoint report. The error carries
+ * the slug in its message rather than in `collection`, so it survives the read-access
+ * filter that drops errors for collections the caller cannot read.
+ */
+async function resolveBaseFilters(
+  req: PayloadRequest,
+  collections: NormalizedAltTextCollectionConfig[],
+  baseFilter: AltTextPluginConfig['healthCheckBaseFilter'],
+): Promise<{ baseFilters: Record<string, undefined | Where> } | { error: AltTextHealthError }> {
+  const baseFilters: Record<string, undefined | Where> = {}
+
+  if (!baseFilter) {
+    return { baseFilters }
+  }
+
+  for (const { slug } of collections) {
+    try {
+      baseFilters[slug] = await baseFilter({ collection: slug, req })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+
+      req.payload.logger.error({
+        collection: slug,
+        err: error,
+        msg: 'Alt text health check failed while resolving the base filter.',
+        plugin: ALT_TEXT_HEALTH_PLUGIN_SLUG,
+      })
+
+      return {
+        error: {
+          code: 'ALT_TEXT_BASE_FILTER_FAILED',
+          message: `Failed to resolve the alt text health base filter for the "${slug}" collection: ${message}`,
+        },
+      }
+    }
+  }
+
+  return { baseFilters }
+}
+
+export async function getAltTextHealthScan(
+  req: PayloadRequest,
+  cacheFactory: AltTextHealthCacheFactory<AltTextHealthScan> = unstable_cache,
+): Promise<AltTextHealthScan> {
   const { payload } = req
   const pluginConfig = payload.config.custom?.altTextPluginConfig as AltTextPluginConfig | undefined
   const localeCodes =
@@ -206,6 +269,14 @@ async function getAltTextHealthScan(req: PayloadRequest): Promise<AltTextHealthS
 
   const collections = pluginConfig.collections
 
+  const resolved = await resolveBaseFilters(req, collections, pluginConfig.healthCheckBaseFilter)
+
+  if ('error' in resolved) {
+    return createUnknownScan({ error: resolved.error, isLocalized, localeCodes })
+  }
+
+  const { baseFilters } = resolved
+
   const cacheKeyParts = [
     ALT_TEXT_HEALTH_GLOBAL_TAG,
     [...collections]
@@ -213,6 +284,11 @@ async function getAltTextHealthScan(req: PayloadRequest): Promise<AltTextHealthS
       .sort()
       .join(','),
     localeCodes.join(','),
+    // The scan is shared across requests, so a scoped scan needs a scoped cache
+    // entry. Deriving the key from the resolved filters — rather than taking one
+    // from the caller — makes it impossible to narrow the scan without also
+    // narrowing its cache, which would serve one tenant's counts to another.
+    `filter:${stableStringify(baseFilters)}`,
   ]
 
   const tags = [
@@ -221,10 +297,11 @@ async function getAltTextHealthScan(req: PayloadRequest): Promise<AltTextHealthS
   ]
 
   const getCachedHealthScan = createCachedAltTextHealthScan({
-    cacheFactory: unstable_cache,
+    cacheFactory,
     cacheKeyParts,
     compute: async () =>
       computeAltTextHealthScan({
+        baseFilters,
         collections,
         isLocalized,
         localeCodes,

--- a/alt-text/src/utilities/stableStringify.ts
+++ b/alt-text/src/utilities/stableStringify.ts
@@ -1,0 +1,24 @@
+/**
+ * Serializes a value with object keys sorted, so two structurally equal values
+ * produce the same string regardless of the order their keys were written in.
+ *
+ * The health scan uses it to derive a cache key from the resolved base filter:
+ * narrowing the scan then always narrows its cache entry, which no amount of
+ * documentation can guarantee for a caller-supplied key.
+ */
+export function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+
+    return `{${entries.join(',')}}`
+  }
+
+  return JSON.stringify(value) ?? 'null'
+}

--- a/alt-text/test/altTextHealthBaseFilter.test.ts
+++ b/alt-text/test/altTextHealthBaseFilter.test.ts
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict'
+
+import type { PayloadRequest, Where } from 'payload'
+
+import { describe, test } from 'vitest'
+
+import type { AltTextHealthScan } from '../src/utilities/altTextHealth.ts'
+import type { AltTextHealthCacheFactory } from '../src/utilities/altTextHealthCache.ts'
+
+import { getAltTextHealthScan } from '../src/utilities/altTextHealth.ts'
+
+/**
+ * `healthCheck.baseFilter` narrows the scan, which runs with `overrideAccess: true`
+ * and is shared through the cache. Both halves matter: the query has to be narrowed,
+ * and the cache entry has to be narrowed with it — otherwise one tenant is served
+ * another tenant's counts.
+ */
+
+type Doc = { alt: unknown; id: string; mimeType: string; tenant?: string }
+
+const DOCS: Record<string, Doc[]> = {
+  'shared-media': [
+    { id: 's1', alt: '', mimeType: 'image/png' },
+    { id: 's2', alt: 'A shared logo', mimeType: 'image/png' },
+  ],
+  images: [
+    { id: 'a1', alt: '', mimeType: 'image/png', tenant: 'acme' },
+    { id: 'a2', alt: 'An Acme photo', mimeType: 'image/png', tenant: 'acme' },
+    { id: 'a3', alt: '', mimeType: 'video/mp4', tenant: 'acme' },
+    { id: 'g1', alt: '', mimeType: 'image/png', tenant: 'globex' },
+  ],
+}
+
+function matches(doc: Doc, where: Where): boolean {
+  return Object.entries(where).every(([key, constraint]) => {
+    if (key === 'and') {
+      return (constraint as Where[]).every((clause) => matches(doc, clause))
+    }
+    if (key === 'or') {
+      return (constraint as Where[]).some((clause) => matches(doc, clause))
+    }
+
+    const value = doc[key as keyof Doc]
+    const operators = constraint as Record<string, unknown>
+
+    if ('equals' in operators) {
+      return value === operators.equals
+    }
+    if ('in' in operators) {
+      return (operators.in as unknown[]).includes(value)
+    }
+    if ('like' in operators) {
+      return typeof value === 'string' && value.startsWith(operators.like as string)
+    }
+
+    throw new Error(`Unsupported operator in test matcher: ${JSON.stringify(operators)}`)
+  })
+}
+
+/** Records every query the scan issues, so the cache's effect is observable. */
+function createPayload() {
+  const queries: { collection: string; where: Where }[] = []
+
+  const payload = {
+    collections: {},
+    config: {
+      custom: {},
+      localization: undefined,
+    },
+    find: ({ collection, where }: { collection: string; where: Where }) => {
+      queries.push({ collection, where })
+      const docs = (DOCS[collection] ?? []).filter((doc) => matches(doc, where))
+
+      return Promise.resolve({ docs, hasNextPage: false })
+    },
+    logger: { error: () => {} },
+  }
+
+  return { payload, queries }
+}
+
+/**
+ * Behavioural stand-in for `unstable_cache`: memoizes on the joined key parts, which
+ * is the property the scan relies on for correctness across requests.
+ */
+function createCacheFactory(): AltTextHealthCacheFactory<AltTextHealthScan> {
+  const entries = new Map<string, Promise<AltTextHealthScan>>()
+
+  return (compute, cacheKeyParts) => {
+    return () => {
+      const key = cacheKeyParts.join('|')
+      const cached = entries.get(key)
+
+      if (cached) {
+        return cached
+      }
+
+      const pending = compute()
+      entries.set(key, pending)
+
+      return pending
+    }
+  }
+}
+
+function createRequest(
+  payload: ReturnType<typeof createPayload>['payload'],
+  baseFilter?: (args: { collection: string; req: PayloadRequest }) => Promise<Where> | Where,
+): PayloadRequest {
+  payload.config.custom = {
+    altTextPluginConfig: {
+      collections: [
+        { slug: 'images', mimeTypes: ['image/*'] },
+        { slug: 'shared-media', mimeTypes: ['image/*'] },
+      ],
+      healthCheck: true,
+      healthCheckBaseFilter: baseFilter,
+      locale: 'en',
+    },
+  }
+
+  return { payload } as unknown as PayloadRequest
+}
+
+const countsFor = (scan: AltTextHealthScan, collection: string) =>
+  scan.collections.find((entry) => entry.collection === collection)!
+
+describe('healthCheck.baseFilter', () => {
+  test('counts only the documents the filter admits', async () => {
+    const { payload } = createPayload()
+    const req = createRequest(payload, () => ({ tenant: { equals: 'acme' } }))
+
+    const scan = await getAltTextHealthScan(req, createCacheFactory())
+
+    const images = countsFor(scan, 'images')
+    assert.equal(images.totalDocs, 2)
+    assert.equal(images.missingDocs, 1)
+    assert.deepEqual(images.invalidDocIds, ['a1'])
+  })
+
+  test('scans every document when no filter is configured', async () => {
+    const { payload } = createPayload()
+
+    const scan = await getAltTextHealthScan(createRequest(payload), createCacheFactory())
+
+    assert.equal(countsFor(scan, 'images').totalDocs, 3)
+  })
+
+  test('applies a per-collection filter, so collections without the field stay whole', async () => {
+    const { payload } = createPayload()
+    const req = createRequest(payload, ({ collection }): Where =>
+      collection === 'shared-media' ? {} : { tenant: { equals: 'acme' } },
+    )
+
+    const scan = await getAltTextHealthScan(req, createCacheFactory())
+
+    assert.equal(countsFor(scan, 'images').totalDocs, 2)
+    assert.equal(countsFor(scan, 'shared-media').totalDocs, 2)
+  })
+
+  test('does not serve one filter’s cached scan to another', async () => {
+    const cacheFactory = createCacheFactory()
+    const { payload } = createPayload()
+
+    const acme = await getAltTextHealthScan(
+      createRequest(payload, () => ({ tenant: { equals: 'acme' } })),
+      cacheFactory,
+    )
+    const globex = await getAltTextHealthScan(
+      createRequest(payload, () => ({ tenant: { equals: 'globex' } })),
+      cacheFactory,
+    )
+
+    assert.equal(countsFor(acme, 'images').totalDocs, 2)
+    assert.equal(countsFor(globex, 'images').totalDocs, 1)
+    assert.deepEqual(countsFor(globex, 'images').invalidDocIds, ['g1'])
+  })
+
+  test('reuses the cached scan when the filter resolves to the same constraint', async () => {
+    const cacheFactory = createCacheFactory()
+    const { payload, queries } = createPayload()
+    const baseFilter = () => ({ tenant: { equals: 'acme' } })
+
+    await getAltTextHealthScan(createRequest(payload, baseFilter), cacheFactory)
+    await getAltTextHealthScan(createRequest(payload, baseFilter), cacheFactory)
+
+    assert.equal(queries.filter((query) => query.collection === 'images').length, 1)
+  })
+
+  test('reports a throwing filter as a scan error instead of failing the request', async () => {
+    const { payload } = createPayload()
+    const req = createRequest(payload, () => {
+      throw new Error('tenant cookie points at a deleted tenant')
+    })
+
+    const scan = await getAltTextHealthScan(req, createCacheFactory())
+
+    assert.equal(scan.collections.length, 0)
+    assert.equal(scan.errors.length, 1)
+    assert.equal(scan.errors[0].code, 'ALT_TEXT_BASE_FILTER_FAILED')
+    assert.match(scan.errors[0].message, /deleted tenant/)
+    // Errors carrying a `collection` are dropped for users who cannot read it; this one
+    // names the collection in its message so it survives to the widget.
+    assert.equal(scan.errors[0].collection, undefined)
+    assert.match(scan.errors[0].message, /images/)
+  })
+})

--- a/alt-text/test/healthEndpointAccess.test.ts
+++ b/alt-text/test/healthEndpointAccess.test.ts
@@ -13,8 +13,8 @@ import { canViewHealthReport } from '../src/utilities/altTextHealth.ts'
 /**
  * The health report exposes a collection-wide overview, so operators must be
  * able to gate it independently of the per-document generate access. The
- * function form of `healthCheck` guards both the health endpoint and the
- * dashboard widget; the boolean form falls back to the shared `access`.
+ * `healthCheck.access` guards both the health endpoint and the dashboard widget;
+ * without it, both fall back to the shared `access`.
  */
 
 const baseConfig = {
@@ -47,7 +47,7 @@ function healthHandler(incoming: IncomingAltTextPluginConfig) {
 const req = { user: { id: 'user-1' } } as unknown as PayloadRequest
 
 describe('health endpoint access gate', () => {
-  test('is guarded by the healthCheck function, not the generate access', async () => {
+  test('is guarded by healthCheck.access, not the generate access', async () => {
     let generateAccessCalled = false
     let healthAccessCalled = false
 
@@ -57,9 +57,11 @@ describe('health endpoint access gate', () => {
           generateAccessCalled = true
           return true
         },
-        healthCheck: () => {
-          healthAccessCalled = true
-          return false
+        healthCheck: {
+          access: () => {
+            healthAccessCalled = true
+            return false
+          },
         },
       }),
     )
@@ -100,17 +102,17 @@ describe('health widget visibility', () => {
     } as unknown as PayloadRequest
   }
 
-  test('is hidden when the healthCheck function denies the user', async () => {
+  test('is hidden when healthCheck.access denies the user', async () => {
     const visible = await canViewHealthReport(
-      reqWithResolvedConfig(buildPluginConfig({ healthCheck: () => false })),
+      reqWithResolvedConfig(buildPluginConfig({ healthCheck: { access: () => false } })),
     )
 
     assert.equal(visible, false)
   })
 
-  test('is shown when the healthCheck function allows the user', async () => {
+  test('is shown when healthCheck.access allows the user', async () => {
     const visible = await canViewHealthReport(
-      reqWithResolvedConfig(buildPluginConfig({ healthCheck: () => true })),
+      reqWithResolvedConfig(buildPluginConfig({ healthCheck: { access: () => true } })),
     )
 
     assert.equal(visible, true)
@@ -122,5 +124,17 @@ describe('health widget visibility', () => {
     )
 
     assert.equal(visible, false)
+  })
+
+  test('rejects the removed function form of healthCheck at boot', () => {
+    assert.throws(
+      () =>
+        payloadAltTextPlugin(
+          buildPluginConfig({
+            healthCheck: (() => false) as unknown as IncomingAltTextPluginConfig['healthCheck'],
+          }),
+        )(baseConfig),
+      /healthCheck: \{ access:/,
+    )
   })
 })


### PR DESCRIPTION
## What

Adds `healthCheck.baseFilter`, a `({ collection, req }) => Where` that narrows what the alt text health report counts — in a multi-tenant CMS, to the tenant the request is for.

```ts
payloadAltTextPlugin({
  healthCheck: {
    access: ({ req }) => req.user?.role === 'admin',
    baseFilter: ({ collection, req }) => {
      // Shared across tenants, so it carries no `tenant` field.
      if (collection === 'shared-media') return {}

      const tenant = getTenantFromCookie(req.headers, req.payload.db.defaultIDType)
      return tenant ? { tenant: { equals: tenant } } : {}
    },
  },
})
```

The health scan is the only query in the plugin that runs with `overrideAccess: true`, so it is the only path that reports across tenants. The generate endpoints already run `overrideAccess: false` with `req.user` and stay scoped by each collection's own access control. That is why the filter sits under `healthCheck` rather than at the top level: it exists because the scan trades access control for cacheability, and it covers all three consumers of the scan — the dashboard widget, `GET /api/alt-text/health`, and the exported `getAltTextHealth`.

The filter is resolved **once per configured collection**, so a config can mix tenant-scoped and shared upload collections instead of forcing one constraint onto every collection.

## Cache correctness

The scan is cached across requests, so a narrowed scan needs a narrowed cache entry. The cache key is **derived** from the resolved filters (stable-stringified) rather than supplied by the caller: narrowing the scan then always narrows its cache, instead of relying on the caller to pass a matching key. Invalidation stays per collection, so a write in one tenant refreshes the report for all of them.

A filter that throws (a cookie pointing at a deleted tenant) never falls back to an unfiltered scan: it ends the scan with an `ALT_TEXT_BASE_FILTER_FAILED` error the widget and the endpoint report. The error names the collection in its message rather than in `error.collection`, so `filterScanByReadAccess` does not drop it and leave a blank widget.

This scopes what the report counts, not who may see it — `healthCheck.access` does that, and the report is still filtered to the collections the requesting user can read.

## BREAKING

`healthCheck` no longer accepts a function. Move the access check into the object:

```ts
// before
healthCheck: ({ req }) => req.user?.role === 'admin'
// after
healthCheck: { access: ({ req }) => req.user?.role === 'admin' }
```

`healthCheck: true` / `false` are unchanged. The function form throws at config load rather than being ignored, which would silently widen the report's gate to the plugin's `access`.

Per the repo's breaking-change policy this is a `minor` bump (plugin is pre-1.0).

## Tests

- `test/altTextHealthBaseFilter.test.ts` — the filter narrows the counts, is applied per collection, one scope's cached scan is never served to another, an unchanged filter still hits the cache, and a throwing filter surfaces as a scan error
- `test/healthEndpointAccess.test.ts` — migrated to `healthCheck.access`, plus the removed function form failing at boot

The suite could not run at first (`alt-text/node_modules/.pnpm` had dangling symlinks; a reinstall fixed it), so the new tests were checked by inverting the implementation instead: dropping the filter from the cache key fails the cross-scope test, dropping the `and` fails three.

## Dev app demonstration

`dev/` gains a `tenants` collection, `@payloadcms/plugin-multi-tenant` wiring, a `baseFilter` that reads the tenant cookie and returns `{}` for the shared `media-with-folders` collection, and seeded Acme / Globex images. Switching the tenant in the admin panel changes the widget's numbers while the shared collection stays constant:

| tenant | Images (scoped) | Media with Folders (shared) |
| --- | --- | --- |
| none | 7 | 2 |
| Acme | 1 | 2 |
| Globex | 2 | 2 |

`GET /api/alt-text/health` returns the same scoped counts.
