### PR TITLE
feat(alt-text): extract createVisionResolver and add an instructions option

### DIFF
--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -5,14 +5,11 @@
 - feat: add `healthCheck.baseFilter`, a `({ collection, req }) => Where` narrowing what the health report counts — in a multi-tenant CMS, to the tenant the request is for. Resolved per collection, so collections without the constraining field can return `{}`. The scan's cache key is derived from the resolved filters, so one scope's counts are never served to another.
 - **BREAKING**: `healthCheck` no longer accepts a function. Move the access check to `healthCheck: { access: ({ req }) => ... }`; the function form now throws at config load. `healthCheck: true` / `false` are unchanged.
 - feat: add `createVisionResolver`, a factory that owns the prompt, the per-locale response schema, the optional image download and the strict reading of the response, so a resolver for another LLM provider is only its provider call. Both bundled resolvers are built on it.
-- feat: add an `instructions` option to `openAIResolver` and `mistralResolver`, receiving the default instructions so a house style rule can be appended without restating the rules the plugin depends on
-- feat: add a `timeoutMs` option to `openAIResolver`, putting a ceiling on a generate request. Omitted by default, so the OpenAI client's own deadline and retries stay in charge.
-- fix: `openAIResolver` now rejects a blank alt text and a response missing one of the requested locales instead of writing it to the document, and reports a missing API key before spending a request
-- fix: a provider that stops mid-JSON because its token budget ran out is now reported as such, instead of surfacing in the admin panel as `Unexpected end of JSON input`
-- fix: generating for a single locale no longer receives half the token budget of a multi-locale generation
-- fix: `mistralResolver` falls back to the collection's `imageThumbnailMimeType` when the thumbnail host serves no `content-type` or a generic `application/octet-stream`, instead of rejecting the image as unreadable. When nothing is declared either, the error now names the type the host actually served and points at the option that fixes it.
-- change: `openAIResolver` asks for a locale-keyed response (`{ "en": { … } }`) for single-locale generations too, where it previously asked for a flat object with the locale named in the prompt. Generated wording may differ slightly from previous versions.
-- change: resolver errors are logged through `req.payload.logger` rather than `console.error`
+- feat: add an `instructions` option to `openAIResolver` and `mistralResolver`, receiving the default instructions so a house style rule can be appended without restating them
+- feat: add a `timeoutMs` option to `openAIResolver`. Omitted by default, leaving the OpenAI client's own deadline and retries in charge.
+- fix: `openAIResolver` rejects a blank alt text and a response missing one of the requested locales instead of writing it to the document, and reports a missing API key before spending a request. It now asks for a locale-keyed response for a single locale too, so generated wording may differ slightly from previous versions.
+- fix: a provider that ran out of tokens mid-JSON is reported as such instead of `Unexpected end of JSON input`, and a single-locale generation no longer gets half the token budget of a multi-locale one
+- fix: `mistralResolver` falls back to the collection's `imageThumbnailMimeType` when the thumbnail host serves no `content-type` or a generic `application/octet-stream`, instead of rejecting the image as unreadable. With nothing declared either, the error names what was served and points at that option.
 
 ## 0.10.0
 

--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - feat: add `healthCheck.baseFilter`, a `({ collection, req }) => Where` narrowing what the health report counts — in a multi-tenant CMS, to the tenant the request is for. Resolved per collection, so collections without the constraining field can return `{}`. The scan's cache key is derived from the resolved filters, so one scope's counts are never served to another.
 - **BREAKING**: `healthCheck` no longer accepts a function. Move the access check to `healthCheck: { access: ({ req }) => ... }`; the function form now throws at config load. `healthCheck: true` / `false` are unchanged.
+- feat: add `createVisionResolver`, a factory that owns the prompt, the per-locale response schema, the optional image download and the strict reading of the response, so a resolver for another LLM provider is only its provider call. Both bundled resolvers are built on it.
+- feat: add an `instructions` option to `openAIResolver` and `mistralResolver`, receiving the default instructions so a house style rule can be appended without restating the rules the plugin depends on
+- feat: add a `timeoutMs` option to `openAIResolver`, putting a ceiling on a generate request. Omitted by default, so the OpenAI client's own deadline and retries stay in charge.
+- fix: `openAIResolver` now rejects a blank alt text and a response missing one of the requested locales instead of writing it to the document, and reports a missing API key before spending a request
+- fix: a provider that stops mid-JSON because its token budget ran out is now reported as such, instead of surfacing in the admin panel as `Unexpected end of JSON input`
+- fix: generating for a single locale no longer receives half the token budget of a multi-locale generation
+- change: `openAIResolver` asks for a locale-keyed response (`{ "en": { … } }`) for single-locale generations too, where it previously asked for a flat object with the locale named in the prompt. Generated wording may differ slightly from previous versions.
+- change: resolver errors are logged through `req.payload.logger` rather than `console.error`
 
 ## 0.10.0
 

--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fix: `openAIResolver` now rejects a blank alt text and a response missing one of the requested locales instead of writing it to the document, and reports a missing API key before spending a request
 - fix: a provider that stops mid-JSON because its token budget ran out is now reported as such, instead of surfacing in the admin panel as `Unexpected end of JSON input`
 - fix: generating for a single locale no longer receives half the token budget of a multi-locale generation
+- fix: `mistralResolver` falls back to the collection's `imageThumbnailMimeType` when the thumbnail host serves no `content-type` or a generic `application/octet-stream`, instead of rejecting the image as unreadable
 - change: `openAIResolver` asks for a locale-keyed response (`{ "en": { … } }`) for single-locale generations too, where it previously asked for a flat object with the locale named in the prompt. Generated wording may differ slightly from previous versions.
 - change: resolver errors are logged through `req.payload.logger` rather than `console.error`
 

--- a/alt-text/CHANGELOG.md
+++ b/alt-text/CHANGELOG.md
@@ -10,7 +10,7 @@
 - fix: `openAIResolver` now rejects a blank alt text and a response missing one of the requested locales instead of writing it to the document, and reports a missing API key before spending a request
 - fix: a provider that stops mid-JSON because its token budget ran out is now reported as such, instead of surfacing in the admin panel as `Unexpected end of JSON input`
 - fix: generating for a single locale no longer receives half the token budget of a multi-locale generation
-- fix: `mistralResolver` falls back to the collection's `imageThumbnailMimeType` when the thumbnail host serves no `content-type` or a generic `application/octet-stream`, instead of rejecting the image as unreadable
+- fix: `mistralResolver` falls back to the collection's `imageThumbnailMimeType` when the thumbnail host serves no `content-type` or a generic `application/octet-stream`, instead of rejecting the image as unreadable. When nothing is declared either, the error now names the type the host actually served and points at the option that fixes it.
 - change: `openAIResolver` asks for a locale-keyed response (`{ "en": { … } }`) for single-locale generations too, where it previously asked for a flat object with the locale named in the prompt. Generated wording may differ slightly from previous versions.
 - change: resolver errors are logged through `req.payload.logger` rather than `console.error`
 

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -360,7 +360,7 @@ export const myResolver = ({ apiKey }: { apiKey: string }) =>
 For a provider that does not fit that shape at all, implement the
 `AltTextResolver` interface directly.
 
-Alongside `imageThumbnailUrl`, the resolver receives `imageThumbnailMimeType` — the format served at that URL, when the collection declares one via [`imageThumbnailMimeType`](#transcoding-thumbnails). Resolvers that hand the URL to the provider can ignore it. Resolvers that inline the bytes need it, because an explicit media type cannot be sniffed from a URL: Anthropic image blocks require `media_type` and Gemini's `inline_data` requires `mime_type`. It is `undefined` when nothing was declared.
+Alongside `imageThumbnailUrl`, the resolver receives `imageThumbnailMimeType` — the format served at that URL, when the collection declares one via [`imageThumbnailMimeType`](#transcoding-thumbnails). Resolvers that hand the URL to the provider can ignore it. Resolvers that inline the bytes need it, because an explicit media type cannot be sniffed from a URL: Anthropic image blocks require `media_type` and Gemini's `inline_data` requires `mime_type`. It is `undefined` when nothing was declared. Resolvers built on `createVisionResolver` get this for free: `image.mediaType` is the type the host actually served, with the declaration standing in when the host sent none or a generic `application/octet-stream`.
 
 ```ts
 import type { AltTextResolver } from '@jhb.software/payload-alt-text-plugin'

--- a/alt-text/README.md
+++ b/alt-text/README.md
@@ -267,6 +267,8 @@ openAIResolver({
 | `model`              | `string`   | No       | Model to use (default: `gpt-4.1-nano`)                                                                                                                                                      |
 | `baseUrl`            | `string`   | No       | Base URL for an OpenAI-compatible provider (e.g. Nebius, Azure)                                                                                                                             |
 | `supportedMimeTypes` | `string[]` | No       | Image formats the provider accepts (default: `['image/jpeg', 'image/png', 'image/gif', 'image/webp']`, per OpenAI's vision docs). Override it when using a `baseUrl` whose provider differs |
+| `timeoutMs`          | `number`   | No       | Ceiling on a generate request. Omitted by default, leaving the OpenAI client's own 10-minute deadline and its automatic retries in charge                                                   |
+| `instructions`       | `function` | No       | Customizes the prompt, see [Customizing the instructions](#customizing-the-instructions)                                                                                                    |
 
 #### Mistral Resolver
 
@@ -290,9 +292,73 @@ Because there is no image conversion step, `supportedMimeTypes` is limited to
 what the Mistral API accepts directly: JPEG, PNG, GIF and WebP. Documents in
 other formats — SVG or AVIF, for instance — keep their generate button disabled.
 
+| Option         | Type       | Required | Description                                                                              |
+| -------------- | ---------- | -------- | ---------------------------------------------------------------------------------------- |
+| `apiKey`       | `string`   | Yes      | API key for authentication                                                               |
+| `model`        | `string`   | No       | Model to use (default: `mistral-medium-latest`)                                          |
+| `baseUrl`      | `string`   | No       | Base URL of the Mistral API (default: `https://api.mistral.ai/v1`)                       |
+| `timeoutMs`    | `number`   | No       | Abort after this many milliseconds, image download included (default: `30000`)           |
+| `instructions` | `function` | No       | Customizes the prompt, see [Customizing the instructions](#customizing-the-instructions) |
+
+### Customizing the instructions
+
+Every bundled resolver accepts an `instructions` function that receives the
+instructions the resolver would send on its own, so a house style rule can be
+appended without restating the rules the plugin depends on:
+
+```ts
+openAIResolver({
+  apiKey: process.env.OPENAI_API_KEY!,
+  instructions: ({ defaultInstructions }) =>
+    `${defaultInstructions}\n\nName the product line when its packaging is legible. Never guess at a person's role.`,
+})
+```
+
+It is called once per generation and receives `{ defaultInstructions, locales, filename }`.
+Returning something entirely different is allowed — the image and the required
+response shape travel separately from the instructions, so a replacement cannot
+break the resolver's contract with its provider.
+
 ## Custom Resolver
 
-You can create your own resolver by implementing the `AltTextResolver` interface.
+For another LLM provider, `createVisionResolver` is usually the shortest path: it
+owns the prompt, the per-locale response schema, the optional image download and
+the strict reading of the response, leaving only the provider call to `generate`.
+All bundled resolvers are built on it.
+
+```ts
+import { createVisionResolver } from '@jhb.software/payload-alt-text-plugin'
+
+export const myResolver = ({ apiKey }: { apiKey: string }) =>
+  createVisionResolver({
+    apiKey,
+    // `image` is only present when `inlineImage` is set; otherwise pass
+    // `imageThumbnailUrl` to the provider and let it fetch the file.
+    generate: async ({ image, instructions, maxTokens, responseSchema, signal }) => {
+      if (!image) {
+        throw new Error('The image was not downloaded')
+      }
+
+      const response = await fetch('https://api.example.com/v1/vision', {
+        body: JSON.stringify({ instructions, image: image.dataUri, schema: responseSchema }),
+        headers: { Authorization: `Bearer ${apiKey}` },
+        method: 'POST',
+        signal,
+      })
+
+      // Return the parsed JSON object; throwing fails the generation and the
+      // message is shown in the admin panel.
+      return await response.json()
+    },
+    inlineImage: true,
+    key: 'my-provider',
+    label: 'My Provider',
+    supportedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
+  })
+```
+
+For a provider that does not fit that shape at all, implement the
+`AltTextResolver` interface directly.
 
 Alongside `imageThumbnailUrl`, the resolver receives `imageThumbnailMimeType` — the format served at that URL, when the collection declares one via [`imageThumbnailMimeType`](#transcoding-thumbnails). Resolvers that hand the URL to the provider can ignore it. Resolvers that inline the bytes need it, because an explicit media type cannot be sniffed from a URL: Anthropic image blocks require `media_type` and Gemini's `inline_data` requires `mime_type`. It is `undefined` when nothing was declared.
 

--- a/alt-text/dev/src/payload.config.ts
+++ b/alt-text/dev/src/payload.config.ts
@@ -33,6 +33,14 @@ async function signThumbnailUrl(url: string): Promise<string> {
   return await Promise.resolve(`${url}?expires=${expires}`)
 }
 
+/**
+ * A house style rule appended to the instructions every bundled resolver sends
+ * on its own. Deliberately observable in the output: an alt text generated with
+ * it names a dominant colour, one generated without it usually does not.
+ */
+const houseStyleInstructions = ({ defaultInstructions }: { defaultInstructions: string }) =>
+  `${defaultInstructions}\n\nAlways name the dominant colour of the main subject.`
+
 export default buildConfig({
   admin: {
     autoLogin: {
@@ -106,13 +114,20 @@ export default buildConfig({
       // image bytes as a data URI instead of handing the provider a URL — the
       // case `imageThumbnailMimeType` below exists for, since a media type
       // cannot be sniffed from a URL.
+      //
+      // Both resolvers take the same `instructions` extension point, so the
+      // house style rule below applies either way. Generate an alt text for the
+      // seeded sample image and the result names a colour — proof the appended
+      // rule reached the provider on top of the default instructions.
       resolver: process.env.MISTRAL_API_KEY
         ? mistralResolver({
             apiKey: process.env.MISTRAL_API_KEY,
+            instructions: houseStyleInstructions,
             model: 'mistral-medium-latest',
           })
         : openAIResolver({
             apiKey: process.env.OPENAI_API_KEY!,
+            instructions: houseStyleInstructions,
             model: 'gpt-4.1-mini',
             // Pointing `baseUrl` at another OpenAI-compatible provider? Declare
             // the formats that provider accepts instead of inheriting OpenAI's

--- a/alt-text/src/index.ts
+++ b/alt-text/src/index.ts
@@ -1,7 +1,16 @@
 export { payloadAltTextPlugin } from './plugin.js'
+export { createVisionResolver } from './resolvers/createVisionResolver.js'
+export type {
+  VisionGenerateArgs,
+  VisionImage,
+  VisionInstructions,
+  VisionInstructionsArgs,
+  VisionResolverConfig,
+} from './resolvers/createVisionResolver.js'
 export { mistralResolver } from './resolvers/mistral.js'
 export type { MistralResolverConfig } from './resolvers/mistral.js'
 export { openAIResolver } from './resolvers/openAI.js'
+export type { OpenAIResolverConfig } from './resolvers/openAI.js'
 export * from './resolvers/types.js'
 export type {
   AltTextCollectionConfig,

--- a/alt-text/src/resolvers/createVisionResolver.ts
+++ b/alt-text/src/resolvers/createVisionResolver.ts
@@ -40,7 +40,8 @@ export type VisionGenerateArgs = {
   /**
    * The format the collection declares `getImageThumbnail` delivers, or
    * undefined when nothing was declared. Resolvers that inline the bytes should
-   * prefer `image.mediaType`, which is what the URL actually served.
+   * use `image.mediaType`, which is what the URL actually served, with this
+   * declaration already standing in when the host named no usable type.
    */
   imageThumbnailMimeType?: string
   /** URL of the image thumbnail, for providers that fetch it themselves */
@@ -148,15 +149,20 @@ const buildDefaultInstructions = ({ locales }: { locales: string[] }): string =>
  *
  * The document's mime type is checked by the endpoint before the resolver runs,
  * but `getImageThumbnail` may point at a derivative in a different format, so
- * what was actually served is what counts.
+ * what was actually served is what counts. Only when the host names no usable
+ * type at all — no header, or a generic `application/octet-stream` as private
+ * buckets and signed URLs often send — does the collection's declared
+ * `imageThumbnailMimeType` stand in for it.
  */
 async function fetchImage({
+  declaredMediaType,
   label,
   maxImageBytes,
   signal,
   supportedMimeTypes,
   url,
 }: {
+  declaredMediaType?: string
   label: string
   maxImageBytes: number
   signal?: AbortSignal
@@ -177,7 +183,9 @@ async function fetchImage({
     return { error: `Could not download the image from ${url}: status ${response.status}` }
   }
 
-  const mediaType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase()
+  const served = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase()
+  const mediaType =
+    served && served !== 'application/octet-stream' ? served : declaredMediaType?.toLowerCase()
 
   if (!mediaType || (supportedMimeTypes && !supportedMimeTypes.includes(mediaType))) {
     return {
@@ -282,6 +290,7 @@ export const createVisionResolver = ({
 
     if (inlineImage) {
       const downloaded = await fetchImage({
+        declaredMediaType: imageThumbnailMimeType,
         label,
         maxImageBytes,
         signal,

--- a/alt-text/src/resolvers/createVisionResolver.ts
+++ b/alt-text/src/resolvers/createVisionResolver.ts
@@ -71,10 +71,11 @@ export type VisionResolverConfig = {
    */
   apiKey: string
   /**
-   * Sends one request to the provider and returns its parsed JSON response.
-   * Throwing fails the generation, so provider errors need no special handling.
+   * Sends one request to the provider and resolves with its parsed JSON
+   * response. Rejecting fails the generation, so provider errors need no
+   * special handling beyond throwing a readable message.
    */
-  generate: (args: VisionGenerateArgs) => unknown
+  generate: (args: VisionGenerateArgs) => Promise<unknown>
   /**
    * Download the thumbnail and hand `generate` the bytes rather than the URL.
    *
@@ -187,10 +188,28 @@ async function fetchImage({
   const mediaType =
     served && served !== 'application/octet-stream' ? served : declaredMediaType?.toLowerCase()
 
-  if (!mediaType || (supportedMimeTypes && !supportedMimeTypes.includes(mediaType))) {
+  if (!mediaType) {
     return {
-      error: `The image at ${url} was served as "${mediaType ?? 'an unknown type'}", which ${label} cannot read.${supportedMimeTypes ? ` Supported types: ${supportedMimeTypes.join(', ')}.` : ''}`,
+      error: `The image at ${url} was served as ${served ? `"${served}"` : 'no content type at all'}, which does not name an image format. Declare imageThumbnailMimeType for the collection so ${label} knows what it is reading.`,
     }
+  }
+
+  if (supportedMimeTypes && !supportedMimeTypes.includes(mediaType)) {
+    return {
+      error: `The image at ${url} was served as "${mediaType}", which ${label} cannot read. Supported types: ${supportedMimeTypes.join(', ')}.`,
+    }
+  }
+
+  const tooLarge = (byteLength: number) =>
+    `The image at ${url} is ${Math.round(byteLength / 1024 / 1024)} MB, above ${label}'s ${Math.round(maxImageBytes / 1024 / 1024)} MB limit. Point getImageThumbnail at a smaller image size.`
+
+  // Measuring by reading is work the header already answers, and the file is on
+  // its way to being rejected: `getImageThumbnail` may point at the original
+  // upload, which can be far above the provider's limit.
+  const declaredLength = Number(response.headers.get('content-length'))
+
+  if (Number.isInteger(declaredLength) && declaredLength > maxImageBytes) {
+    return { error: tooLarge(declaredLength) }
   }
 
   const bytes = Buffer.from(await response.arrayBuffer())
@@ -200,9 +219,7 @@ async function fetchImage({
   }
 
   if (bytes.byteLength > maxImageBytes) {
-    return {
-      error: `The image at ${url} is ${Math.round(bytes.byteLength / 1024 / 1024)} MB, above ${label}'s ${Math.round(maxImageBytes / 1024 / 1024)} MB limit. Point getImageThumbnail at a smaller image size.`,
-    }
+    return { error: tooLarge(bytes.byteLength) }
   }
 
   const base64 = bytes.toString('base64')

--- a/alt-text/src/resolvers/createVisionResolver.ts
+++ b/alt-text/src/resolvers/createVisionResolver.ts
@@ -1,0 +1,382 @@
+import type { PayloadRequest } from 'payload'
+
+import { z } from 'zod'
+
+import type {
+  AltTextBulkResolverArgs,
+  AltTextBulkResolverResponse,
+  AltTextResolver,
+  AltTextResolverArgs,
+  AltTextResolverResponse,
+  AltTextResult,
+} from './types.js'
+
+export type VisionInstructionsArgs = {
+  /** The instructions the resolver would send on its own, stating the rules the plugin depends on */
+  defaultInstructions: string
+  /** The uploaded file's name, when the endpoint could supply one */
+  filename?: string
+  /** The locales the response must cover, as configured in Payload */
+  locales: string[]
+}
+
+export type VisionInstructions = (args: VisionInstructionsArgs) => Promise<string> | string
+
+/** The thumbnail's bytes, handed to providers that declared `inlineImage`. */
+export type VisionImage = {
+  /** Base64-encoded bytes, without a data URI prefix */
+  base64: string
+  /** `data:<mediaType>;base64,<base64>`, for providers that take a data URI */
+  dataUri: string
+  /** The format actually served at the thumbnail URL, not the document's stored one */
+  mediaType: string
+}
+
+export type VisionGenerateArgs = {
+  /** The uploaded file's name, when the endpoint could supply one */
+  filename?: string
+  /** The downloaded thumbnail — present only when the resolver declared `inlineImage` */
+  image?: VisionImage
+  /**
+   * The format the collection declares `getImageThumbnail` delivers, or
+   * undefined when nothing was declared. Resolvers that inline the bytes should
+   * prefer `image.mediaType`, which is what the URL actually served.
+   */
+  imageThumbnailMimeType?: string
+  /** URL of the image thumbnail, for providers that fetch it themselves */
+  imageThumbnailUrl: string
+  /** The instructions to send, e.g. as the system prompt */
+  instructions: string
+  /** The locales the response must cover */
+  locales: string[]
+  /** Token budget for the response, scaled by the number of requested locales */
+  maxTokens: number
+  req: PayloadRequest
+  /** Draft-7 JSON Schema of the object the provider must return */
+  responseSchema: Record<string, unknown>
+  /**
+   * Aborts once `timeoutMs` has elapsed, already covering the image download.
+   * Undefined when the resolver declares no `timeoutMs`, leaving the deadline to
+   * the provider client.
+   */
+  signal?: AbortSignal
+}
+
+export type VisionResolverConfig = {
+  /**
+   * Checked before any work happens, so a plugin wired as
+   * `enabled: !!process.env.X_API_KEY` fails with a readable message instead of
+   * a provider error — or, worse, a paid-for image download.
+   */
+  apiKey: string
+  /**
+   * Sends one request to the provider and returns its parsed JSON response.
+   * Throwing fails the generation, so provider errors need no special handling.
+   */
+  generate: (args: VisionGenerateArgs) => unknown
+  /**
+   * Download the thumbnail and hand `generate` the bytes rather than the URL.
+   *
+   * Needed by every provider whose own fetcher requires a publicly reachable
+   * file — never true in local development, not true for private buckets.
+   */
+  inlineImage?: boolean
+  /**
+   * Builds the instructions from the default ones, e.g. to append a house style
+   * rule. Called once per generation. The image and the required response shape
+   * are not part of the instructions and cannot be altered here.
+   *
+   * @default ({ defaultInstructions }) => defaultInstructions
+   */
+  instructions?: VisionInstructions
+  /** Identifies the resolver, e.g. in log entries */
+  key: string
+  /** Provider name used in error messages shown in the admin UI */
+  label: string
+  /**
+   * Rejects an inlined image above this size before it is sent.
+   * @default 20971520 (20 MB)
+   */
+  maxImageBytes?: number
+  /**
+   * Token budget granted per requested locale. A ceiling, not a reservation, so
+   * headroom is free; the default keeps the pre-factory bulk budget of 300 for
+   * every locale count rather than only for two or more.
+   * @default 300
+   */
+  maxTokensPerLocale?: number
+  /** @see AltTextResolver.supportedMimeTypes */
+  supportedMimeTypes?: string[]
+  /**
+   * Abort after this many milliseconds, covering the image download and the
+   * provider call together. Omit it to impose no deadline of the factory's own —
+   * appropriate when the provider's own client already has one.
+   */
+  timeoutMs?: number
+}
+
+const altTextSchema = z.object({
+  altText: z.string().describe('A concise, descriptive alt text for the image'),
+  keywords: z.array(z.string()).describe('Keywords that describe the content of the image'),
+})
+
+/** One schema entry per requested locale, so the model must answer for all of them. */
+export const schemaForLocales = (locales: string[]) =>
+  z.object(Object.fromEntries(locales.map((locale) => [locale, altTextSchema])))
+
+/**
+ * Rules dictated by the plugin rather than by the provider: one entry per
+ * configured locale, describing what is visible rather than guessing at it.
+ */
+const buildDefaultInstructions = ({ locales }: { locales: string[] }): string =>
+  [
+    `You are an expert at analyzing images and creating descriptive image alt text.`,
+
+    `Please analyze the given image and provide the following in ${locales.join(', ')}:`,
+
+    `- A concise, localized descriptive alt text (1-2 sentences) as "altText". Focus on the subject, action, and setting. Avoid phrases like 'Image of', 'A picture of', or 'Photo showing'. Be specific and include relevant details like location or context if visible. Make no assumptions.`,
+
+    `- A localized list of keywords that describe the content (e.g., ["Camel", "Palm trees", "Desert"]) as "keywords"`,
+
+    `If a context is provided, use it to enhance the alt text.`,
+
+    `Format your response as a JSON object with ${locales.map((locale) => `"${locale}"`).join(', ')} keys, each containing "altText" and "keywords".`,
+  ].join('\n\n')
+
+/**
+ * Downloads the image and returns its bytes.
+ *
+ * The document's mime type is checked by the endpoint before the resolver runs,
+ * but `getImageThumbnail` may point at a derivative in a different format, so
+ * what was actually served is what counts.
+ */
+async function fetchImage({
+  label,
+  maxImageBytes,
+  signal,
+  supportedMimeTypes,
+  url,
+}: {
+  label: string
+  maxImageBytes: number
+  signal?: AbortSignal
+  supportedMimeTypes?: string[]
+  url: string
+}): Promise<{ error: string } | { image: VisionImage }> {
+  let response: Response
+
+  try {
+    response = await fetch(url, { signal })
+  } catch (error) {
+    return {
+      error: `Could not download the image from ${url}: ${error instanceof Error ? error.message : 'unknown error'}`,
+    }
+  }
+
+  if (!response.ok) {
+    return { error: `Could not download the image from ${url}: status ${response.status}` }
+  }
+
+  const mediaType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase()
+
+  if (!mediaType || (supportedMimeTypes && !supportedMimeTypes.includes(mediaType))) {
+    return {
+      error: `The image at ${url} was served as "${mediaType ?? 'an unknown type'}", which ${label} cannot read.${supportedMimeTypes ? ` Supported types: ${supportedMimeTypes.join(', ')}.` : ''}`,
+    }
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer())
+
+  if (bytes.byteLength === 0) {
+    return { error: `The image at ${url} was empty.` }
+  }
+
+  if (bytes.byteLength > maxImageBytes) {
+    return {
+      error: `The image at ${url} is ${Math.round(bytes.byteLength / 1024 / 1024)} MB, above ${label}'s ${Math.round(maxImageBytes / 1024 / 1024)} MB limit. Point getImageThumbnail at a smaller image size.`,
+    }
+  }
+
+  const base64 = bytes.toString('base64')
+
+  return { image: { base64, dataUri: `data:${mediaType};base64,${base64}`, mediaType } }
+}
+
+/**
+ * Reads the model's response.
+ *
+ * Deliberately strict about a blank `altText`: the field is required on the
+ * collection, so an empty string would satisfy that requirement while telling a
+ * screen reader nothing — and nobody looks at an alt text again once it is set.
+ */
+function parseResults(content: unknown, locales: string[]): null | Record<string, AltTextResult> {
+  const parsed = schemaForLocales(locales).safeParse(content)
+
+  if (!parsed.success) {
+    return null
+  }
+
+  const results: Record<string, AltTextResult> = {}
+
+  for (const locale of locales) {
+    const entry = parsed.data[locale]
+
+    if (entry.altText.trim().length === 0) {
+      return null
+    }
+
+    results[locale] = { altText: entry.altText.trim(), keywords: entry.keywords }
+  }
+
+  return results
+}
+
+/**
+ * Creates a resolver for a vision (LLM) provider, leaving only the provider call
+ * to `generate`: the prompt, the required response schema, the optional image
+ * download and the strict reading of the response are handled here.
+ *
+ * All locales go into a single call rather than one call each: the image is
+ * uploaded and analyzed once — the expensive part — and every language ends up
+ * describing the same reading of it. `resolve` is that same call with one
+ * locale.
+ */
+export const createVisionResolver = ({
+  apiKey,
+  generate,
+  inlineImage = false,
+  instructions = ({ defaultInstructions }) => defaultInstructions,
+  key,
+  label,
+  maxImageBytes = 20 * 1024 * 1024,
+  maxTokensPerLocale = 300,
+  supportedMimeTypes,
+  timeoutMs,
+}: VisionResolverConfig): AltTextResolver => {
+  const run = async ({
+    filename,
+    imageThumbnailMimeType,
+    imageThumbnailUrl,
+    locales,
+    req,
+  }: {
+    filename?: string
+    imageThumbnailMimeType?: string
+    imageThumbnailUrl: string
+    locales: string[]
+    req: PayloadRequest
+  }): Promise<
+    { error: string; success: false } | { results: Record<string, AltTextResult>; success: true }
+  > => {
+    if (!apiKey) {
+      return { error: `No ${label} API key configured`, success: false }
+    }
+
+    if (locales.length === 0) {
+      return { error: 'No locale requested', success: false }
+    }
+
+    const signal = timeoutMs === undefined ? undefined : AbortSignal.timeout(timeoutMs)
+
+    let image: undefined | VisionImage
+
+    if (inlineImage) {
+      const downloaded = await fetchImage({
+        label,
+        maxImageBytes,
+        signal,
+        supportedMimeTypes,
+        url: imageThumbnailUrl,
+      })
+
+      if ('error' in downloaded) {
+        return { error: downloaded.error, success: false }
+      }
+
+      image = downloaded.image
+    }
+
+    try {
+      const defaultInstructions = buildDefaultInstructions({ locales })
+
+      const content = await generate({
+        filename,
+        image,
+        imageThumbnailMimeType,
+        imageThumbnailUrl,
+        instructions: await instructions({ defaultInstructions, filename, locales }),
+        locales,
+        maxTokens: maxTokensPerLocale * locales.length,
+        req,
+        responseSchema: z.toJSONSchema(schemaForLocales(locales), { target: 'draft-7' }),
+        signal,
+      })
+
+      const results = parseResults(content, locales)
+
+      if (!results) {
+        return {
+          error: `${label} did not return a usable alt text for every requested locale (${locales.join(', ')})`,
+          success: false,
+        }
+      }
+
+      return { results, success: true }
+    } catch (error) {
+      req.payload.logger.error({
+        key,
+        message: 'An error occurred when trying to generate the alt text',
+        originalErr: error instanceof Error ? error.message : String(error),
+      })
+
+      return { error: error instanceof Error ? error.message : 'Unknown error', success: false }
+    }
+  }
+
+  return {
+    key,
+    resolve: async ({
+      filename,
+      imageThumbnailMimeType,
+      imageThumbnailUrl,
+      locale,
+      req,
+    }: AltTextResolverArgs): Promise<AltTextResolverResponse> => {
+      const result = await run({
+        filename,
+        imageThumbnailMimeType,
+        imageThumbnailUrl,
+        locales: [locale],
+        req,
+      })
+
+      if (!result.success) {
+        return { error: result.error, success: false }
+      }
+
+      return { result: result.results[locale], success: true }
+    },
+    resolveBulk: async ({
+      filename,
+      imageThumbnailMimeType,
+      imageThumbnailUrl,
+      locales,
+      req,
+    }: AltTextBulkResolverArgs): Promise<AltTextBulkResolverResponse> => {
+      const result = await run({
+        filename,
+        imageThumbnailMimeType,
+        imageThumbnailUrl,
+        locales,
+        req,
+      })
+
+      if (!result.success) {
+        return { error: result.error, success: false }
+      }
+
+      return { results: result.results, success: true }
+    },
+    supportedMimeTypes,
+  }
+}

--- a/alt-text/src/resolvers/mistral.ts
+++ b/alt-text/src/resolvers/mistral.ts
@@ -1,13 +1,7 @@
-import { z } from 'zod'
+import type { VisionInstructions } from './createVisionResolver.js'
+import type { AltTextResolver } from './types.js'
 
-import type {
-  AltTextBulkResolverArgs,
-  AltTextBulkResolverResponse,
-  AltTextResolver,
-  AltTextResolverArgs,
-  AltTextResolverResponse,
-  AltTextResult,
-} from './types.js'
+import { createVisionResolver } from './createVisionResolver.js'
 
 export type MistralResolverConfig = {
   /** Mistral API key for authentication */
@@ -17,6 +11,13 @@ export type MistralResolverConfig = {
    * @default 'https://api.mistral.ai/v1'
    */
   baseUrl?: string
+  /**
+   * Builds the instructions from the default ones, e.g. to append a house style
+   * rule. Sent as the system message, separately from the image.
+   *
+   * @default ({ defaultInstructions }) => defaultInstructions
+   */
+  instructions?: VisionInstructions
   /**
    * The vision-capable Mistral model to use for alt text generation.
    *
@@ -41,227 +42,18 @@ export type MistralResolverConfig = {
  * Narrower than what an upload collection may hold — SVG and AVIF are missing,
  * so the endpoint rejects those documents and their generate button stays
  * disabled instead of failing at the provider.
+ *
+ * @see https://docs.mistral.ai/capabilities/vision/
  */
 const SUPPORTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
 
-/** Mistral rejects images above 20 MB. */
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024
-
-const altTextSchema = z.object({
-  altText: z.string().describe('A concise, descriptive alt text for the image'),
-  keywords: z.array(z.string()).describe('Keywords that describe the content of the image'),
-})
-
-/** One schema entry per requested locale, so the model must answer for all of them. */
-const schemaForLocales = (locales: string[]) =>
-  z.object(Object.fromEntries(locales.map((locale) => [locale, altTextSchema])))
-
-/**
- * Downloads the image and returns it as a data URI.
- *
- * Mistral can fetch an image URL itself, but that path is not dependable for a
- * CMS. It requires the file to be reachable from the public internet — never
- * true in local development, and not true for private buckets — and some hosts
- * refuse Mistral's fetcher outright, which surfaces as `File could not be
- * fetched from url` (error 3310). Sending the bytes removes that whole class of
- * failure for the price of one extra download.
- */
-async function fetchImageAsDataUri(
-  url: string,
-  signal: AbortSignal,
-): Promise<{ dataUri: string } | { error: string }> {
-  let response: Response
-
-  try {
-    response = await fetch(url, { signal })
-  } catch (error) {
-    return {
-      error: `Could not download the image from ${url}: ${error instanceof Error ? error.message : 'unknown error'}`,
-    }
-  }
-
-  if (!response.ok) {
-    return { error: `Could not download the image from ${url}: status ${response.status}` }
-  }
-
-  // The document's mime type is checked by the endpoint before the resolver
-  // runs, but `getImageThumbnail` may point at a derivative in a different
-  // format, so trust what was actually served.
-  const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase()
-
-  if (!contentType || !SUPPORTED_MIME_TYPES.includes(contentType)) {
-    return {
-      error: `The image at ${url} was served as "${contentType ?? 'an unknown type'}", which Mistral cannot read. Supported types: ${SUPPORTED_MIME_TYPES.join(', ')}.`,
-    }
-  }
-
-  const bytes = Buffer.from(await response.arrayBuffer())
-
-  if (bytes.byteLength === 0) {
-    return { error: `The image at ${url} was empty.` }
-  }
-
-  if (bytes.byteLength > MAX_IMAGE_BYTES) {
-    return {
-      error: `The image at ${url} is ${Math.round(bytes.byteLength / 1024 / 1024)} MB, above Mistral's 20 MB limit. Point getImageThumbnail at a smaller image size.`,
-    }
-  }
-
-  return { dataUri: `data:${contentType};base64,${bytes.toString('base64')}` }
-}
-
-function buildPrompt(locales: string[]): string {
-  const languages = locales.join(', ')
-
-  return `
-      You are an expert at analyzing images and creating descriptive image alt text.
-
-      Please analyze the given image and provide the following in ${languages}:
-      - A concise, descriptive alt text (1-2 sentences) as "altText". Focus on the subject, action, and setting. Avoid phrases like 'Image of', 'A picture of', or 'Photo showing'. Be specific and include relevant details like location or context if visible. Make no assumptions.
-      - A list of keywords that describe the content (e.g., ["Camel", "Palm trees", "Desert"]) as "keywords"
-
-      If a context is provided, use it to enhance the alt text.
-
-      Format your response as a JSON object with ${locales.map((locale) => `"${locale}"`).join(', ')} keys, each containing "altText" and "keywords".
-    `
-}
-
-/**
- * Reads the model's response.
- *
- * Deliberately strict about a blank `altText`: the field is required on the
- * collection, so an empty string would satisfy that requirement while telling a
- * screen reader nothing — and nobody looks at an alt text again once it is set.
- */
-function parseResults(content: unknown, locales: string[]): null | Record<string, AltTextResult> {
-  const parsed = schemaForLocales(locales).safeParse(content)
-
-  if (!parsed.success) {
-    return null
-  }
-
-  const results: Record<string, AltTextResult> = {}
-
-  for (const locale of locales) {
-    const entry = parsed.data[locale]
-
-    if (entry.altText.trim().length === 0) {
-      return null
-    }
-
-    results[locale] = { altText: entry.altText.trim(), keywords: entry.keywords }
-  }
-
-  return results
-}
-
-/**
- * One request, one or more locales.
- *
- * All locales go into a single call rather than one call each: the image is
- * uploaded and analyzed once — the expensive part — and every language ends up
- * describing the same reading of it.
- */
-async function generate({
-  apiKey,
-  baseUrl,
-  filename,
-  imageThumbnailUrl,
-  locales,
-  model,
-  timeoutMs,
-}: {
-  apiKey: string
-  baseUrl: string
-  filename?: string
-  imageThumbnailUrl: string
-  locales: string[]
-  model: string
-  timeoutMs: number
-}): Promise<
-  { error: string; success: false } | { results: Record<string, AltTextResult>; success: true }
-> {
-  if (!apiKey) {
-    return { error: 'No Mistral API key configured', success: false }
-  }
-
-  if (locales.length === 0) {
-    return { error: 'No locale requested', success: false }
-  }
-
-  const signal = AbortSignal.timeout(timeoutMs)
-  const image = await fetchImageAsDataUri(imageThumbnailUrl, signal)
-
-  if ('error' in image) {
-    return { error: image.error, success: false }
-  }
-
-  try {
-    const response = await fetch(`${baseUrl}/chat/completions`, {
-      body: JSON.stringify({
-        max_tokens: 150 * locales.length,
-        messages: [
-          { content: buildPrompt(locales), role: 'system' },
-          {
-            content: [
-              { type: 'image_url', image_url: image.dataUri },
-              ...(filename ? [{ type: 'text', text: filename }] : []),
-            ],
-            role: 'user',
-          },
-        ],
-        model,
-        response_format: {
-          type: 'json_schema',
-          json_schema: {
-            name: 'data',
-            schema: z.toJSONSchema(schemaForLocales(locales), { target: 'draft-7' }),
-            strict: true,
-          },
-        },
-      }),
-      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
-      method: 'POST',
-      signal,
-    })
-
-    if (!response.ok) {
-      const body = await response.text().catch(() => '')
-
-      return {
-        error: `Mistral responded with status ${response.status}${body ? `: ${body}` : ''}`,
-        success: false,
-      }
-    }
-
-    const completion = (await response.json()) as {
-      choices?: { message?: { content?: unknown } }[]
-    }
-    const content = completion.choices?.[0]?.message?.content
-
-    if (typeof content !== 'string') {
-      return { error: 'No result from Mistral', success: false }
-    }
-
-    const results = parseResults(JSON.parse(content), locales)
-
-    if (!results) {
-      return {
-        error: `Mistral did not return a usable alt text for every requested locale (${locales.join(', ')})`,
-        success: false,
-      }
-    }
-
-    return { results, success: true }
-  } catch (error) {
-    console.error('Error generating alt text:', error)
-
-    return { error: error instanceof Error ? error.message : 'Unknown error', success: false }
-  }
-}
-
 /**
  * Creates a Mistral-based resolver for alt text generation.
+ *
+ * The image is downloaded and sent as bytes rather than handed to Mistral as a
+ * URL. Mistral's own fetcher requires a publicly reachable file — never true in
+ * local development, and not true for private buckets — and some hosts refuse it
+ * outright, which surfaces as `File could not be fetched from url` (error 3310).
  *
  * @example
  * ```typescript
@@ -273,59 +65,88 @@ async function generate({
  * })
  * ```
  */
-export const mistralResolver = (config: MistralResolverConfig): AltTextResolver => {
-  const {
+export const mistralResolver = ({
+  apiKey,
+  baseUrl = 'https://api.mistral.ai/v1',
+  instructions,
+  model = 'mistral-medium-latest',
+  timeoutMs = 30_000,
+}: MistralResolverConfig): AltTextResolver =>
+  createVisionResolver({
     apiKey,
-    baseUrl = 'https://api.mistral.ai/v1',
-    model = 'mistral-medium-latest',
-    timeoutMs = 30_000,
-  } = config
+    generate: async ({
+      filename,
+      image,
+      instructions: resolvedInstructions,
+      maxTokens,
+      responseSchema,
+      signal,
+    }) => {
+      if (!image) {
+        throw new Error('The image was not downloaded')
+      }
 
-  return {
+      const response = await fetch(`${baseUrl}/chat/completions`, {
+        body: JSON.stringify({
+          max_tokens: maxTokens,
+          messages: [
+            { content: resolvedInstructions, role: 'system' },
+            {
+              content: [
+                { type: 'image_url', image_url: image.dataUri },
+                ...(filename ? [{ type: 'text', text: filename }] : []),
+              ],
+              role: 'user',
+            },
+          ],
+          model,
+          response_format: {
+            type: 'json_schema',
+            json_schema: { name: 'data', schema: responseSchema, strict: true },
+          },
+        }),
+        headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+        method: 'POST',
+        signal,
+      })
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '')
+
+        throw new Error(
+          `Mistral responded with status ${response.status}${body ? `: ${body}` : ''}`,
+        )
+      }
+
+      const completion = (await response.json()) as {
+        choices?: { finish_reason?: string; message?: { content?: unknown } }[]
+      }
+      const choice = completion.choices?.[0]
+
+      if (choice?.finish_reason === 'length') {
+        throw new Error(
+          `Mistral ran out of tokens before finishing the alt text (max_tokens: ${maxTokens})`,
+        )
+      }
+
+      const content = choice?.message?.content
+
+      if (typeof content !== 'string') {
+        throw new Error('No result from Mistral')
+      }
+
+      try {
+        return JSON.parse(content)
+      } catch {
+        throw new Error('Mistral returned a response that was not valid JSON')
+      }
+    },
+    inlineImage: true,
+    instructions,
     key: 'mistral',
-    resolve: async ({
-      filename,
-      imageThumbnailUrl,
-      locale,
-    }: AltTextResolverArgs): Promise<AltTextResolverResponse> => {
-      const result = await generate({
-        apiKey,
-        baseUrl,
-        filename,
-        imageThumbnailUrl,
-        locales: [locale],
-        model,
-        timeoutMs,
-      })
-
-      if (!result.success) {
-        return { error: result.error, success: false }
-      }
-
-      return { result: result.results[locale], success: true }
-    },
-    resolveBulk: async ({
-      filename,
-      imageThumbnailUrl,
-      locales,
-    }: AltTextBulkResolverArgs): Promise<AltTextBulkResolverResponse> => {
-      const result = await generate({
-        apiKey,
-        baseUrl,
-        filename,
-        imageThumbnailUrl,
-        locales,
-        model,
-        timeoutMs,
-      })
-
-      if (!result.success) {
-        return { error: result.error, success: false }
-      }
-
-      return { results: result.results, success: true }
-    },
-    // https://docs.mistral.ai/capabilities/vision/
+    label: 'Mistral',
+    // Mistral rejects images above 20 MB.
+    maxImageBytes: 20 * 1024 * 1024,
     supportedMimeTypes: SUPPORTED_MIME_TYPES,
-  }
-}
+    timeoutMs,
+  })

--- a/alt-text/src/resolvers/openAI.ts
+++ b/alt-text/src/resolvers/openAI.ts
@@ -1,18 +1,11 @@
-import type { AutoParseableResponseFormat } from 'openai/lib/parser.mjs'
 import type { ChatCompletionContentPartText } from 'openai/resources/chat/completions.mjs'
-import type { ResponseFormatJSONSchema } from 'openai/resources/shared.mjs'
 
 import OpenAI from 'openai'
-import { makeParseableResponseFormat } from 'openai/lib/parser.mjs'
-import { z } from 'zod'
 
-import type {
-  AltTextBulkResolverArgs,
-  AltTextBulkResolverResponse,
-  AltTextResolver,
-  AltTextResolverArgs,
-  AltTextResolverResponse,
-} from './types.js'
+import type { VisionInstructions } from './createVisionResolver.js'
+import type { AltTextResolver } from './types.js'
+
+import { createVisionResolver } from './createVisionResolver.js'
 
 export type OpenAIResolverConfig = {
   /** OpenAI API key for authentication */
@@ -23,6 +16,13 @@ export type OpenAIResolverConfig = {
    * @default undefined — the OpenAI SDK defaults to 'https://api.openai.com/v1'
    */
   baseUrl?: string
+  /**
+   * Builds the instructions from the default ones, e.g. to append a house style
+   * rule. Sent as the system message, separately from the image.
+   *
+   * @default ({ defaultInstructions }) => defaultInstructions
+   */
+  instructions?: VisionInstructions
   /**
    * The OpenAI LLM model to use for alt text generation.
    * @default 'gpt-4.1-nano'
@@ -38,39 +38,27 @@ export type OpenAIResolverConfig = {
    * @default ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
    */
   supportedMimeTypes?: string[]
+  /**
+   * Abort after this many milliseconds, covering the completion call and any
+   * retry the SDK makes within it.
+   *
+   * Omitted by default, leaving the OpenAI client's own deadline (10 minutes)
+   * and its automatic retries in charge. Set it to put a shorter ceiling on a
+   * generate request.
+   */
+  timeoutMs?: number
 }
 
 /** @see https://platform.openai.com/docs/guides/images-vision */
 const OPENAI_SUPPORTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
 
 /**
- * Creates a chat completion `JSONSchema` response format object from
- * the given Zod schema.
- *
- * This is a temporary drop in replacement for the zodResponseFormat from openai/helpers/zod.ts
- * because of issue https://github.com/openai/openai-node/issues/1576
- */
-function zodResponseFormat<ZodInput extends z.ZodType>(
-  zodObject: ZodInput,
-  name: string,
-  props?: Omit<ResponseFormatJSONSchema.JSONSchema, 'name' | 'schema' | 'strict'>,
-): AutoParseableResponseFormat<z.infer<ZodInput>> {
-  return makeParseableResponseFormat(
-    {
-      type: 'json_schema',
-      json_schema: {
-        ...props,
-        name,
-        schema: z.toJSONSchema(zodObject, { target: 'draft-7' }),
-        strict: true,
-      },
-    },
-    (content) => zodObject.parse(JSON.parse(content)),
-  )
-}
-
-/**
  * Creates an OpenAI-based resolver for alt text generation.
+ *
+ * The thumbnail URL is handed to OpenAI, which fetches it itself — so the URL
+ * has to be reachable from the public internet. Behind a private bucket or in
+ * local development, reach for a resolver that inlines the bytes instead
+ * (`mistralResolver`, `anthropicResolver`).
  *
  * @example
  * ```typescript
@@ -90,162 +78,81 @@ function zodResponseFormat<ZodInput extends z.ZodType>(
  * })
  * ```
  */
-export const openAIResolver = (config: OpenAIResolverConfig): AltTextResolver => {
-  const { apiKey, baseUrl, model = 'gpt-4.1-nano' } = config
-
+export const openAIResolver = ({
+  apiKey,
+  baseUrl,
+  instructions,
+  model = 'gpt-4.1-nano',
+  supportedMimeTypes = OPENAI_SUPPORTED_MIME_TYPES,
+  timeoutMs,
+}: OpenAIResolverConfig): AltTextResolver => {
   // Build the client lazily (once, on first use): the `resolver` argument is
   // evaluated even when the plugin is disabled, so eager construction would
   // throw on a keyless `enabled: !!process.env.OPENAI_API_KEY` setup.
   let openai: OpenAI | undefined
   const getClient = (): OpenAI => (openai ??= new OpenAI({ apiKey, baseURL: baseUrl }))
 
-  return {
-    key: 'openai',
-    resolve: async ({
+  return createVisionResolver({
+    apiKey,
+    generate: async ({
       filename,
       imageThumbnailUrl,
-      locale,
-    }: AltTextResolverArgs): Promise<AltTextResolverResponse> => {
-      try {
-        const modelResponseSchema = z.object({
-          altText: z.string().describe('A concise, descriptive alt text for the image'),
-          keywords: z.array(z.string()).describe('Keywords that describe the content of the image'),
-        })
-
-        const response = await getClient().chat.completions.parse({
-          max_completion_tokens: 150,
+      instructions: resolvedInstructions,
+      maxTokens,
+      responseSchema,
+      signal,
+    }) => {
+      const response = await getClient().chat.completions.create(
+        {
+          max_completion_tokens: maxTokens,
           messages: [
-            {
-              content: `
-            You are an expert at analyzing images and creating descriptive image alt text.
-
-            Please analyze the given image and provide the following:
-            - A concise, descriptive alt text (1-2 sentences) as "altText". Focus on the subject, action, and setting. Avoid phrases like 'Image of', 'A picture of', or 'Photo showing'. Be specific and include relevant details like location or context if visible. Make no assumptions.
-            - A list of keywords that describe the content (e.g., ["Camel", "Palm trees", "Desert"]) as "keywords"
-
-            If a context is provided, use it to enhance the alt text.
-
-            Format your response as a JSON object. You must respond in the ${locale} language.
-          `,
-              role: 'system',
-            },
+            { content: resolvedInstructions, role: 'system' },
             {
               content: [
-                {
-                  type: 'image_url',
-                  image_url: { url: imageThumbnailUrl },
-                },
+                { type: 'image_url', image_url: { url: imageThumbnailUrl } },
                 ...(filename
-                  ? [
-                      {
-                        type: 'text',
-                        text: filename,
-                      } satisfies ChatCompletionContentPartText,
-                    ]
+                  ? [{ type: 'text', text: filename } as ChatCompletionContentPartText]
                   : []),
               ],
               role: 'user',
             },
           ],
           model,
-          response_format: zodResponseFormat(modelResponseSchema, 'data'),
-        })
+          response_format: {
+            type: 'json_schema',
+            json_schema: { name: 'data', schema: responseSchema, strict: true },
+          },
+        },
+        { signal },
+      )
 
-        const result = response.choices[0]?.message?.parsed
+      const choice = response.choices[0]
 
-        if (!result) {
-          return { error: 'No result from OpenAI', success: false }
-        }
-
-        return {
-          result,
-          success: true,
-        }
-      } catch (error) {
-        console.error('Error generating alt text:', error)
-        return {
-          error: error instanceof Error ? error.message : 'Unknown error',
-          success: false,
-        }
-      }
-    },
-    resolveBulk: async ({
-      filename,
-      imageThumbnailUrl,
-      locales,
-    }: AltTextBulkResolverArgs): Promise<AltTextBulkResolverResponse> => {
-      try {
-        const modelResponseSchema = z.object(
-          Object.fromEntries(
-            locales.map((locale) => [
-              locale,
-              z.object({
-                altText: z.string().describe('A concise, descriptive alt text for the image'),
-                keywords: z
-                  .array(z.string())
-                  .describe('Keywords that describe the content of the image'),
-              }),
-            ]),
-          ),
+      // A budget exhausted mid-JSON otherwise reaches JSON.parse and reads as
+      // "Unexpected end of JSON input" in the admin panel, which tells an editor
+      // nothing about what to change.
+      if (choice?.finish_reason === 'length') {
+        throw new Error(
+          `OpenAI ran out of tokens before finishing the alt text (max_completion_tokens: ${maxTokens})`,
         )
+      }
 
-        const response = await getClient().chat.completions.parse({
-          max_completion_tokens: 300,
-          messages: [
-            {
-              content: `
-      You are an expert at analyzing images and creating descriptive image alt text.
+      const content = choice?.message?.content
 
-      Please analyze the given image and provide the following in ${locales.join(', ')}:
-      - A concise, localized descriptive alt text (1-2 sentences) as "altText". Focus on the subject, action, and setting. Avoid phrases like 'Image of', 'A picture of', or 'Photo showing'. Be specific and include relevant details like location or context if visible. Make no assumptions.
-      - A localized list of keywords that describe the content (e.g., ["Camel", "Palm trees", "Desert"]) as "keywords"
+      if (typeof content !== 'string') {
+        throw new Error('No result from OpenAI')
+      }
 
-      If a context is provided, use it to enhance the alt text.
-
-      Format your response as a JSON object with ${locales.join(', ')} keys, each containing "altText" and "keywords".
-    `,
-              role: 'system',
-            },
-            {
-              content: [
-                {
-                  type: 'image_url',
-                  image_url: { url: imageThumbnailUrl },
-                },
-                ...(filename
-                  ? [
-                      {
-                        type: 'text',
-                        text: filename,
-                      } satisfies ChatCompletionContentPartText,
-                    ]
-                  : []),
-              ],
-              role: 'user',
-            },
-          ],
-          model,
-          response_format: zodResponseFormat(modelResponseSchema, 'data'),
-        })
-
-        const result = response.choices[0]?.message?.parsed
-
-        if (!result) {
-          return { error: 'No result from OpenAI', success: false }
-        }
-
-        return {
-          results: result,
-          success: true,
-        }
-      } catch (error) {
-        console.error('Error generating bulk alt text:', error)
-        return {
-          error: error instanceof Error ? error.message : 'Unknown error',
-          success: false,
-        }
+      try {
+        return JSON.parse(content)
+      } catch {
+        throw new Error('OpenAI returned a response that was not valid JSON')
       }
     },
-    supportedMimeTypes: config.supportedMimeTypes ?? OPENAI_SUPPORTED_MIME_TYPES,
-  }
+    instructions,
+    key: 'openai',
+    label: 'OpenAI',
+    supportedMimeTypes,
+    timeoutMs,
+  })
 }

--- a/alt-text/test/mistralResolver.test.ts
+++ b/alt-text/test/mistralResolver.test.ts
@@ -118,30 +118,6 @@ describe('mistral resolver', () => {
     assert.deepEqual(Object.keys(result.success ? result.results : {}), ['de', 'en', 'fr'])
   })
 
-  test('rejects a response that is missing one of the requested locales', async () => {
-    stubFetch({ completion: { de: threeLocales.de, en: threeLocales.en } })
-
-    const result = await mistralResolver({ apiKey: 'key' }).resolveBulk({
-      imageThumbnailUrl: IMAGE_URL,
-      locales: ['de', 'en', 'fr'],
-      req,
-    })
-
-    assert.equal(result.success, false)
-  })
-
-  test('rejects a blank alt text rather than writing it to the document', async () => {
-    stubFetch({ completion: { en: { altText: '   ', keywords: ['camel'] } } })
-
-    const result = await mistralResolver({ apiKey: 'key' }).resolve({
-      imageThumbnailUrl: IMAGE_URL,
-      locale: 'en',
-      req,
-    })
-
-    assert.equal(result.success, false)
-  })
-
   test('reports the format when the thumbnail is served as something Mistral cannot read', async () => {
     // An upload collection may hold SVG or AVIF, and `getImageThumbnail` falls
     // back to the original when no derivative exists. Naming the format beats a
@@ -157,22 +133,5 @@ describe('mistral resolver', () => {
     assert.equal(result.success, false)
     assert.match(result.success ? '' : (result.error ?? ''), /svg/)
     assert.equal(recorded.length, 0, 'the provider must not be called for an unreadable format')
-  })
-
-  test('reports a missing API key instead of throwing when the resolver is built', async () => {
-    // The README wires `enabled: !!process.env.MISTRAL_API_KEY` alongside
-    // `resolver: mistralResolver({ apiKey: process.env.MISTRAL_API_KEY! })`.
-    // The resolver argument is evaluated even when the plugin is disabled, so
-    // constructing it without a key must not break the Payload config.
-    const recorded = stubFetch({ completion: {} })
-
-    const result = await mistralResolver({ apiKey: '' }).resolve({
-      imageThumbnailUrl: IMAGE_URL,
-      locale: 'en',
-      req,
-    })
-
-    assert.equal(result.success, false)
-    assert.equal(recorded.length, 0)
   })
 })

--- a/alt-text/test/visionResolver.test.ts
+++ b/alt-text/test/visionResolver.test.ts
@@ -36,27 +36,53 @@ const enResult = { en: { altText: 'A camel in front of palm trees.', keywords: [
 
 type Recorded = { body: Record<string, unknown>; url: string }
 
+/** How often the stubbed thumbnail response had its body read, reset per stub. */
+const imageDownload = { bodyReads: 0 }
+
 /**
  * Serves the image download first and the completion second (Mistral inlines
  * the bytes), recording what was sent to the provider.
  */
 function stubMistral(
   completion: unknown,
-  image: { bytes?: Buffer; contentType?: null | string; status?: number } = {},
+  image: {
+    bytes?: Buffer
+    contentLength?: null | string
+    contentType?: null | string
+    status?: number
+  } = {},
   finishReason?: string,
 ): Recorded[] {
   const recorded: Recorded[] = []
-  const { bytes = PIXEL, contentType = 'image/jpeg', status: imageStatus = 200 } = image
+  const {
+    bytes = PIXEL,
+    // A host that names no length is the general case, so the byte-count guard
+    // stays under test unless a test opts into the header.
+    contentLength = null,
+    contentType = 'image/jpeg',
+    status: imageStatus = 200,
+  } = image
   let call = 0
+
+  imageDownload.bodyReads = 0
 
   globalThis.fetch = (async (url: string, init?: { body?: string }) => {
     call += 1
 
     if (call === 1) {
       return {
-        arrayBuffer: async () =>
-          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
-        headers: { get: (name: string) => (name === 'content-type' ? contentType : null) },
+        arrayBuffer: async () => {
+          imageDownload.bodyReads += 1
+          return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+        },
+        headers: {
+          get: (name: string) =>
+            name === 'content-type'
+              ? contentType
+              : name === 'content-length'
+                ? contentLength
+                : null,
+        },
         ok: imageStatus === 200,
         status: imageStatus,
       }
@@ -264,6 +290,44 @@ describe('response validation', () => {
     assert.equal(result.success, false)
     assert.match(result.success ? '' : (result.error ?? ''), /limit/)
     assert.equal(recorded.length, 0)
+  })
+
+  test('rejects a thumbnail the host declares as oversized without reading its body', async () => {
+    // getImageThumbnail may point at the original upload, which can be far
+    // above the provider's limit. Reading a rejected file into memory to
+    // measure it is work the content-length header already answers.
+    const recorded = stubMistral(enResult, {
+      contentLength: String(21 * 1024 * 1024),
+      bytes: PIXEL,
+    })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.match(result.success ? '' : (result.error ?? ''), /limit/)
+    assert.equal(imageDownload.bodyReads, 0, 'the body must not be read once the size is known')
+    assert.equal(recorded.length, 0)
+  })
+
+  test('names the type the host served when it does not identify an image format', async () => {
+    // "an unknown type" describes the wrong situation: the host did name a
+    // type, it just named a useless one, and `imageThumbnailMimeType` is the
+    // option that fixes it.
+    stubMistral(enResult, { contentType: 'application/octet-stream' })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.match(result.success ? '' : (result.error ?? ''), /application\/octet-stream/)
+    assert.match(result.success ? '' : (result.error ?? ''), /imageThumbnailMimeType/)
   })
 
   test('falls back to the declared thumbnail format when the host serves no content type', async () => {

--- a/alt-text/test/visionResolver.test.ts
+++ b/alt-text/test/visionResolver.test.ts
@@ -42,11 +42,11 @@ type Recorded = { body: Record<string, unknown>; url: string }
  */
 function stubMistral(
   completion: unknown,
-  image: { bytes?: Buffer; status?: number } = {},
+  image: { bytes?: Buffer; contentType?: null | string; status?: number } = {},
   finishReason?: string,
 ): Recorded[] {
   const recorded: Recorded[] = []
-  const { bytes = PIXEL, status: imageStatus = 200 } = image
+  const { bytes = PIXEL, contentType = 'image/jpeg', status: imageStatus = 200 } = image
   let call = 0
 
   globalThis.fetch = (async (url: string, init?: { body?: string }) => {
@@ -56,7 +56,7 @@ function stubMistral(
       return {
         arrayBuffer: async () =>
           bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
-        headers: { get: (name: string) => (name === 'content-type' ? 'image/jpeg' : null) },
+        headers: { get: (name: string) => (name === 'content-type' ? contentType : null) },
         ok: imageStatus === 200,
         status: imageStatus,
       }
@@ -264,6 +264,41 @@ describe('response validation', () => {
     assert.equal(result.success, false)
     assert.match(result.success ? '' : (result.error ?? ''), /limit/)
     assert.equal(recorded.length, 0)
+  })
+
+  test('falls back to the declared thumbnail format when the host serves no content type', async () => {
+    // `imageThumbnailMimeType` exists for exactly this: a provider that inlines
+    // the bytes needs a media type, and a private bucket or a signed URL may
+    // serve the file without naming one.
+    const recorded = stubMistral(enResult, { contentType: null })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailMimeType: 'image/webp',
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, true, result.success ? '' : (result.error ?? ''))
+    const content = (recorded[0]!.body.messages as { content: { image_url?: string }[] }[])[1]!
+      .content
+    assert.match(content[0]!.image_url ?? '', /^data:image\/webp;base64,/)
+  })
+
+  test('falls back to the declared thumbnail format when the host serves a generic binary type', async () => {
+    const recorded = stubMistral(enResult, { contentType: 'application/octet-stream' })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailMimeType: 'image/png',
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, true, result.success ? '' : (result.error ?? ''))
+    const content = (recorded[0]!.body.messages as { content: { image_url?: string }[] }[])[1]!
+      .content
+    assert.match(content[0]!.image_url ?? '', /^data:image\/png;base64,/)
   })
 
   test('reports a missing API key instead of calling the provider', async () => {

--- a/alt-text/test/visionResolver.test.ts
+++ b/alt-text/test/visionResolver.test.ts
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict'
+
+import { afterEach, describe, test } from 'vitest'
+
+import type { PayloadRequest } from 'payload'
+
+import { mistralResolver } from '../src/resolvers/mistral.ts'
+import { openAIResolver } from '../src/resolvers/openAI.ts'
+
+/**
+ * Both bundled resolvers are built on `createVisionResolver`, which owns the
+ * prompt, the required response shape and the reading of the answer. The
+ * behaviors pinned here are the ones the factory guarantees on every provider,
+ * asserted through the resolvers a user actually configures.
+ *
+ * They matter because of what may reach the document: the alt text field is
+ * required on the collection, so a blank or partial result would satisfy that
+ * requirement while telling a screen reader nothing — and nobody reads an alt
+ * text again once it is set.
+ */
+
+const IMAGE_URL = 'https://example.test/photo-600x400.jpg'
+const PIXEL = Buffer.from('89504e470d0a1a0a', 'hex')
+
+const req = {
+  payload: { logger: { error() {}, info() {}, warn() {} } },
+} as unknown as PayloadRequest
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const enResult = { en: { altText: 'A camel in front of palm trees.', keywords: ['camel'] } }
+
+type Recorded = { body: Record<string, unknown>; url: string }
+
+/**
+ * Serves the image download first and the completion second (Mistral inlines
+ * the bytes), recording what was sent to the provider.
+ */
+function stubMistral(
+  completion: unknown,
+  image: { bytes?: Buffer; status?: number } = {},
+  finishReason?: string,
+): Recorded[] {
+  const recorded: Recorded[] = []
+  const { bytes = PIXEL, status: imageStatus = 200 } = image
+  let call = 0
+
+  globalThis.fetch = (async (url: string, init?: { body?: string }) => {
+    call += 1
+
+    if (call === 1) {
+      return {
+        arrayBuffer: async () =>
+          bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+        headers: { get: (name: string) => (name === 'content-type' ? 'image/jpeg' : null) },
+        ok: imageStatus === 200,
+        status: imageStatus,
+      }
+    }
+
+    recorded.push({ body: JSON.parse(init?.body ?? '{}'), url })
+
+    return {
+      json: async () => ({
+        choices: [
+          { finish_reason: finishReason, message: { content: JSON.stringify(completion) } },
+        ],
+      }),
+      ok: true,
+      status: 200,
+      text: async () => '',
+    }
+  }) as unknown as typeof fetch
+
+  return recorded
+}
+
+/**
+ * The OpenAI SDK sends its request through global fetch, so stubbing the
+ * network keeps the resolver's own SDK usage under test.
+ */
+function stubOpenAI(completion: unknown): Recorded[] {
+  const recorded: Recorded[] = []
+
+  globalThis.fetch = (async (url: string, init?: { body?: string }) => {
+    recorded.push({ body: JSON.parse(init?.body ?? '{}'), url: String(url) })
+
+    return new Response(
+      JSON.stringify({ choices: [{ message: { content: JSON.stringify(completion) } }] }),
+      { headers: { 'content-type': 'application/json' }, status: 200 },
+    )
+  }) as unknown as typeof fetch
+
+  return recorded
+}
+
+describe('instructions customization', () => {
+  test('appends a house style rule to the default instructions without dropping them', async () => {
+    const recorded = stubMistral(enResult)
+
+    await mistralResolver({
+      apiKey: 'key',
+      instructions: ({ defaultInstructions }) =>
+        `${defaultInstructions}\n\nAlways mention the brand name "Acme" when its logo is visible.`,
+    }).resolve({ imageThumbnailUrl: IMAGE_URL, locale: 'en', req })
+
+    const system = (recorded[0]!.body.messages as { content: string }[])[0]!.content
+
+    assert.match(system, /Always mention the brand name "Acme"/)
+    assert.match(system, /expert at analyzing images/)
+  })
+
+  test('sends the customized instructions separately from the image', async () => {
+    // Replacing the instructions entirely must not be able to drop the image or
+    // the required response shape - those are the resolver's contract with its
+    // provider, not a rule about the content.
+    const recorded = stubOpenAI(enResult)
+
+    await openAIResolver({
+      apiKey: 'key',
+      instructions: ({ locales }) => `Describe the image in ${locales.join(', ')}.`,
+    }).resolve({ imageThumbnailUrl: IMAGE_URL, locale: 'en', req })
+
+    const messages = recorded[0]!.body.messages as {
+      content: { image_url?: { url: string }; type: string }[] | string
+      role: string
+    }[]
+
+    assert.equal(messages[0]!.content, 'Describe the image in en.')
+    assert.equal(
+      (messages[1]!.content as { image_url?: { url: string } }[])[0]!.image_url!.url,
+      IMAGE_URL,
+    )
+    assert.deepEqual(
+      (
+        recorded[0]!.body.response_format as {
+          json_schema: { schema: { required: string[] } }
+        }
+      ).json_schema.schema.required,
+      ['en'],
+    )
+  })
+
+  test('receives the locales the response must cover', async () => {
+    const recorded = stubMistral({
+      de: { altText: 'Ein Kamel vor Palmen.', keywords: ['Kamel'] },
+      ...enResult,
+    })
+    const seen: string[][] = []
+
+    await mistralResolver({
+      apiKey: 'key',
+      instructions: ({ defaultInstructions, locales }) => {
+        seen.push(locales)
+        return defaultInstructions
+      },
+    }).resolveBulk({ imageThumbnailUrl: IMAGE_URL, locales: ['de', 'en'], req })
+
+    assert.deepEqual(seen, [['de', 'en']])
+    assert.equal(recorded.length, 1, 'every locale belongs in a single request')
+  })
+})
+
+describe('response validation', () => {
+  test('rejects a blank alt text rather than writing it to the document', async () => {
+    stubOpenAI({ en: { altText: '   ', keywords: ['camel'] } })
+
+    const result = await openAIResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+  })
+
+  test('rejects a response that is missing one of the requested locales', async () => {
+    stubOpenAI(enResult)
+
+    const result = await openAIResolver({ apiKey: 'key' }).resolveBulk({
+      imageThumbnailUrl: IMAGE_URL,
+      locales: ['de', 'en'],
+      req,
+    })
+
+    assert.equal(result.success, false)
+  })
+
+  test('grants the same token budget for one locale as for several', async () => {
+    // Before the factory, OpenAI's bulk path used a flat 300 and only the
+    // single-image path used 150. Scaling purely by locale count silently
+    // halved the budget for a single-locale project, and a budget spent
+    // mid-JSON surfaces as an unreadable parse error.
+    const recorded = stubMistral(enResult)
+
+    await mistralResolver({ apiKey: 'key' }).resolveBulk({
+      imageThumbnailUrl: IMAGE_URL,
+      locales: ['en'],
+      req,
+    })
+
+    assert.ok(
+      (recorded[0]!.body.max_tokens as number) >= 300,
+      `one locale must not get less than the pre-factory bulk budget, got ${recorded[0]!.body.max_tokens}`,
+    )
+  })
+
+  test('names a truncated answer instead of letting it reach JSON.parse', async () => {
+    // A budget spent mid-JSON otherwise surfaces as "Unexpected end of JSON
+    // input" in the admin panel, which tells an editor nothing to act on.
+    stubMistral(enResult, {}, 'length')
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.match(result.success ? '' : (result.error ?? ''), /ran out of tokens/)
+  })
+
+  test('reports a thumbnail URL that could not be downloaded', async () => {
+    const recorded = stubMistral(enResult, { status: 404 })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.match(result.success ? '' : (result.error ?? ''), /404/)
+    assert.equal(recorded.length, 0, 'the provider must not be called without an image')
+  })
+
+  test('reports an empty thumbnail instead of sending zero bytes to the provider', async () => {
+    const recorded = stubMistral(enResult, { bytes: Buffer.alloc(0) })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.match(result.success ? '' : (result.error ?? ''), /empty/)
+    assert.equal(recorded.length, 0)
+  })
+
+  test('reports an oversized thumbnail before paying to upload it', async () => {
+    const recorded = stubMistral(enResult, { bytes: Buffer.alloc(21 * 1024 * 1024) })
+
+    const result = await mistralResolver({ apiKey: 'key' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.match(result.success ? '' : (result.error ?? ''), /limit/)
+    assert.equal(recorded.length, 0)
+  })
+
+  test('reports a missing API key instead of calling the provider', async () => {
+    // The README wires `enabled: !!process.env.OPENAI_API_KEY` alongside
+    // `resolver: openAIResolver({ apiKey: process.env.OPENAI_API_KEY! })`. The
+    // resolver argument is evaluated even when the plugin is disabled, so a
+    // keyless build must fail with a readable message - and must not spend a
+    // request or an image download finding that out.
+    const recorded = stubOpenAI(enResult)
+
+    const result = await openAIResolver({ apiKey: '' }).resolve({
+      imageThumbnailUrl: IMAGE_URL,
+      locale: 'en',
+      req,
+    })
+
+    assert.equal(result.success, false)
+    assert.match(result.success ? '' : (result.error ?? ''), /OpenAI API key/)
+    assert.equal(recorded.length, 0)
+  })
+})


### PR DESCRIPTION
**Stack 1/2 (alt-text)** — base for #207. The content-translator PRs (#208, #209) are independent and target `main` directly.

## Why

`openAI.ts` and `mistral.ts` each re-implemented the prompt text, the per-locale zod schema, the response parsing and the `resolve`/`resolveBulk` split. The two prompts had already drifted apart (the OpenAI single-locale path said *"You must respond in the `${locale}` language"*, the bulk path said something else again). A third provider would have meant a third copy.

## What

`createVisionResolver` owns everything that is not the provider call:

- the default instructions, plus an `instructions?: (args) => string` hook ported from the content-translator plugin
- the per-locale schema and its draft-7 JSON Schema projection
- the optional image download (`inlineImage`) with `timeoutMs` / `AbortSignal`, for providers that send bytes rather than a URL
- the strict reading of the response, including the blank-`altText` rejection
- collapsing `resolve`/`resolveBulk` into one `run({ locales })`
- the `{ success, error }` shaping

A provider now supplies only `generate()`, its model defaults and its `supportedMimeTypes`. It is exported, so a project can build its own resolver the same way.

`openAIResolver` keeps the SDK, but drops the `zodResponseFormat` / `makeParseableResponseFormat` workaround for [openai-node#1576](https://github.com/openai/openai-node/issues/1576) — the factory does the zod parsing now, so the plain `chat.completions.create` with a `json_schema` response format is enough. This is safe on the wire: `main` already built the schema with `z.toJSONSchema(..., { target: 'draft-7' })` and used the workaround only to attach a client-side parser, so the JSON sent is byte-identical.

## Behavior changes

Not a pure refactor. The user-visible ones are in the CHANGELOG:

- **A blank `altText`, or a response missing one of the requested locales, is now rejected** on `openAIResolver` instead of being written to the document. The field is required on the collection, so a blank value satisfies that requirement while telling a screen reader nothing.
- **A missing API key is reported before a request is spent**, rather than surfacing as the SDK's credentials error.
- **A truncated answer is named.** Losing `chat.completions.parse` also lost its `LengthFinishReasonError`, so `finish_reason: 'length'` is now checked explicitly — otherwise a budget spent mid-JSON reaches `JSON.parse` and reads as `Unexpected end of JSON input` in the admin panel.
- **The token budget no longer halves for a single locale.** The pre-factory bulk path used a flat 300; scaling purely by locale count gave a single-locale project 150. `maxTokensPerLocale` now defaults to 300, so no locale count gets less than before. It is a ceiling, not a reservation, so the headroom is free.
- **`openAIResolver` keeps its previous deadline.** The factory's `timeoutMs` has no default, so the OpenAI client's own 10-minute timeout and automatic retries stay in charge; a new `timeoutMs` option sets a shorter ceiling for anyone who wants one. (An earlier revision of this PR imposed a 30 s deadline on the OpenAI path that `main` did not have, and shared the spent deadline across SDK retries.)
- **Single-locale generations ask for a locale-keyed response** (`{ "en": { … } }`) where OpenAI previously asked for a flat object with the locale named in the prompt. Generated wording may differ slightly from previous versions.
- **Resolver errors are logged through `req.payload.logger`** rather than `console.error`.
- **The declared `imageThumbnailMimeType` stands in when the host names no type.** The factory trusts the served `content-type`, but a private bucket or signed URL may send none, or a generic `application/octet-stream`; both used to be rejected as unreadable even with the declaration in place — the very case the option was added for in 0.10.0. Now the declaration fills that gap; a concrete served type still wins.
- **`imageThumbnailMimeType` reaches `generate`.** `AltTextResolverArgs` carries it and the README tells resolver authors they need it, but the first revision of the factory dropped it before `generate` saw it.
- **A thumbnail the host cannot identify names what it served.** When neither the `content-type` nor a declared `imageThumbnailMimeType` yields an image format, the error used to read *"was served as \"an unknown type\""* — which describes the wrong situation when the host did name a type, just a useless one. It now names `application/octet-stream` (or reports that no header arrived) and points at the option that fixes it.
- **An oversized thumbnail is rejected from its `content-length`**, before its body is read. `getImageThumbnail` may point at the original upload, which can sit far above the provider's limit; measuring it by reading it into memory is work the header already answered. The byte-count check stays for hosts that send no length.

## Tests

`test/visionResolver.test.ts` covers the factory through the two resolvers a user actually configures, stubbing the network (`globalThis.fetch`) rather than the SDK: instructions appended / replaced, locales reaching the hook, every locale in one request, blank alt text, missing locale, missing key, the single-locale token budget, truncation, and the image-download failure branches (non-ok status, empty body, oversize by body and by declared `content-length`, and an unidentifiable format). Three tests that duplicated factory-owned coverage were dropped from `mistralResolver.test.ts`, which now pins only what is Mistral-specific.

## Dev app demonstration

`alt-text/dev/src/payload.config.ts` wires `instructions` on whichever resolver runs, appending *"Always name the dominant colour of the main subject."* — generate an alt text for the seeded sample image and the result names a colour, which the default instructions alone would not produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017u7VExnspdeUhL1oDXfono

